### PR TITLE
Imagenet training scripts

### DIFF
--- a/caffe2/python/examples/imagenet/BREW
+++ b/caffe2/python/examples/imagenet/BREW
@@ -1,0 +1,4 @@
+filegroup(
+  name="imagenet_example_files",
+  srcs=Glob(["*.py"]),
+)

--- a/caffe2/python/examples/imagenet/Inception_v3.py
+++ b/caffe2/python/examples/imagenet/Inception_v3.py
@@ -1,0 +1,542 @@
+from caffe2.python import cnn, core, workspace, dyndep, net_drawer
+from caffe2.proto import caffe2_pb2
+
+# Rethinking the Inception Architecture for Computer Vision
+# Port of MXNet definition (https://github.com/dmlc/mxnet/blob/master/example/image-classification/symbol_inception-v3.py)
+
+def ConvBNRelu(model, input_blob, output_name, num_input, num_output, filter_size, stride=1, pad=0, is_test=False):
+    conv = model.Conv(
+        input_blob,
+        output_name + "_conv",
+        num_input,
+        num_output,
+        filter_size,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        stride=stride,
+        pad=pad
+    )
+    keywords = {'is_test' : 1} if is_test else {'is_test' : 0}
+    bn = model.SpatialBN(
+        conv,
+        output_name + "_bn",
+        num_output,
+        **keywords)
+    relu = model.Relu(
+        output_name + "_bn",
+        output_name + "_bn"
+    )
+    return relu
+
+def Inception7A(model,
+                data,
+                input_filters,
+                num_1x1,
+                num_3x3_red, num_3x3_1, num_3x3_2,
+                num_5x5_red, num_5x5,
+                proj,
+                prefix, is_test=False):
+
+    # 1x1 tower
+    tower_1x1 = ConvBNRelu(model,
+                           data,
+                           prefix+"_conv",
+                           num_input=input_filters,
+                           num_output=num_1x1,
+                           filter_size=1,
+                           is_test=is_test)
+    # 5x5 tower
+    tower_5x5 = ConvBNRelu(model,
+                           data,
+                           prefix+"_tower_conv",
+                           num_input=input_filters,
+                           num_output=num_5x5_red,
+                           filter_size=5,
+                           pad=2,
+                           is_test=is_test)
+    tower_5x5 = ConvBNRelu(model,
+                           tower_5x5,
+                           prefix+"_tower_conv_1",
+                           num_input=num_5x5_red,
+                           num_output=num_5x5,
+                           filter_size=5,
+                           pad=2,
+                           is_test=is_test)
+
+    # 3x3 tower
+    tower_3x3 = ConvBNRelu(model,
+                           data,
+                           prefix+"_tower_1_conv",
+                           num_input=input_filters,
+                           num_output=num_3x3_red,
+                           filter_size=3,
+                           pad=1,
+                           is_test=is_test)
+    tower_3x3 = ConvBNRelu(model,
+                           tower_3x3,
+                           prefix+"_tower_1_conv_1",
+                           num_input=num_3x3_red,
+                           num_output=num_3x3_1,
+                           filter_size=3,
+                           pad=1,
+                           is_test=is_test)
+    tower_3x3 = ConvBNRelu(model,
+                           tower_3x3,
+                           prefix+"_tower_1_conv_2",
+                           num_input=num_3x3_1,
+                           num_output=num_3x3_2,
+                           filter_size=3,
+                           pad=1,
+                           is_test=is_test)
+
+    # pooling tower
+    pooling = model.AveragePool(data, prefix+"_pool", kernel=3, stride=1, pad=1)
+    cproj = ConvBNRelu(model,
+                       pooling,
+                       prefix+"_tower_2_conv",
+                       num_input=input_filters,
+                       num_output=proj,
+                       filter_size=1,
+                       stride=1,
+                       is_test=is_test)
+
+    concat = model.Concat([tower_1x1, tower_3x3, tower_5x5, cproj], prefix+"_concat")
+
+    # model, output_filters
+    return concat, (num_1x1 + num_5x5 + num_3x3_2 + proj)
+
+# First Downsample
+def Inception7B(model,
+                data,
+                input_filters,
+                num_3x3,
+                num_d3x3_red, num_d3x3_1, num_d3x3_2,
+                prefix,
+                is_test=False):
+    tower_3x3 = ConvBNRelu(model,
+                           data,
+                           prefix+"_conv",
+                           num_input=input_filters,
+                           num_output=num_3x3,
+                           filter_size=3,
+                           stride=2,
+                           pad=0,
+                           is_test=is_test)
+
+    tower_d3x3 = ConvBNRelu(model,
+                            data,
+                            prefix+"_tower_conv",
+                            num_input=input_filters,
+                            num_output=num_d3x3_red,
+                            filter_size=1,
+                            pad=0,
+                            is_test=is_test)
+    tower_d3x3 = ConvBNRelu(model,
+                            tower_d3x3,
+                            prefix+"_tower_conv_1",
+                            num_input=num_d3x3_red,
+                            num_output=num_d3x3_1,
+                            filter_size=3,
+                            pad=1,
+                            is_test=is_test)
+    tower_d3x3 = ConvBNRelu(model,
+                            tower_d3x3,
+                            prefix+"_tower_conv_2",
+                            num_input=num_d3x3_1,
+                            num_output=num_d3x3_2,
+                            filter_size=3,
+                            pad=0,
+                            stride=2,
+                            is_test=is_test)
+
+    pooling = model.MaxPool(data, prefix+"_pool", kernel=3, stride=2, pad=0)
+
+    concat = model.Concat([tower_3x3, tower_d3x3, pooling], prefix+"_concat")
+
+    return concat, (num_3x3+num_d3x3_2+input_filters)
+
+def Inception7C(model,
+                data,
+                input_filters,
+                num_1x1,
+                num_d7_red, num_d7_1, num_d7_2, # d7_{1,2} correspond to factorized [7,1] [1,7]
+                num_q7_red, num_q7_1, num_q7_2, num_q7_3, num_q7_4, # q7_{{1,2},{3,4}} are factorized pairs
+                proj,
+                prefix, is_test=False):
+    # 1x1 tower
+    tower_1x1 = ConvBNRelu(model,
+                           data,
+                           prefix+"_conv",
+                           num_input=input_filters,
+                           num_output=num_1x1,
+                           filter_size=1,
+                           is_test=is_test)
+                       
+    # 7x7 tower (1)
+    tower_d7 = ConvBNRelu(model,
+                          data,
+                          prefix+"_tower_conv",
+                          num_input=input_filters,
+                          num_output=num_d7_red,
+                          filter_size=1,
+                          pad=0,
+                          is_test=is_test)
+    # [7x1] [1x7] -> [7x7]
+    tower_d7 = ConvBNRelu(model,
+                          tower_d7,
+                          prefix+"_tower_conv_1",
+                          num_input=num_d7_red,
+                          num_output=num_d7_2,
+                          filter_size=7,
+                          pad=3,
+                          is_test=is_test)
+    # Pair of [7x1][1x7] conv
+    tower_q7 = ConvBNRelu(model,
+                          data,
+                          prefix+"_tower_1_conv",
+                          num_input=input_filters,
+                          num_output=num_q7_red,
+                          filter_size=1,
+                          pad=0,
+                          is_test=is_test)
+    tower_q7 = ConvBNRelu(model,
+                          tower_q7,
+                          prefix+"_tower_1_conv_1",
+                          num_input=num_q7_red,
+                          num_output=num_q7_2,
+                          filter_size=7,
+                          pad=3,
+                          is_test=is_test)
+    tower_q7 = ConvBNRelu(model,
+                          tower_q7,
+                          prefix+"_tower_1_conv_3",
+                          num_input=num_q7_2,
+                          num_output=num_q7_4,
+                          filter_size=7,
+                          pad=3,
+                          is_test=is_test)
+
+    # pooling
+    pooling = model.AveragePool(data, prefix+"_pool", kernel=3, stride=1, pad=1)
+    # projection
+    cproj = ConvBNRelu(model,
+                      pooling,
+                      prefix+"_tower_2_conv",
+                      num_input=input_filters,
+                      num_output=proj,
+                      filter_size=1,
+                      is_test=is_test)
+
+    concat = model.Concat([tower_1x1, tower_d7, tower_q7, cproj], prefix+"_concat")
+
+    return concat, (num_1x1+num_d7_2+num_q7_4+proj)
+
+def Inception7D(model,
+                data,
+                input_filters,
+                num_3x3_red, num_3x3,
+                num_d7_3x3_red, num_d7_1, num_d7_2, num_d7_3,
+                prefix, is_test=False):
+    # tower 3x3
+    tower_3x3 = ConvBNRelu(model,
+                           data,
+                           prefix+"_conv",
+                           num_input=input_filters,
+                           num_output=num_3x3_red,
+                           filter_size=1,
+                           is_test=is_test)
+    tower_3x3 = ConvBNRelu(model,
+                           tower_3x3,
+                           prefix+"_conv_1",
+                           num_input=num_3x3_red,
+                           num_output=num_3x3,
+                           filter_size=3,
+                           pad=0,
+                           stride=2,
+                           is_test=is_test)
+
+    # tower d7
+    tower_d7_3x3 = ConvBNRelu(model,
+                              data,
+                              prefix+"_tower_1_conv",
+                              num_input=input_filters,
+                              num_output=num_d7_3x3_red,
+                              filter_size=1,
+                              is_test=is_test)
+    tower_d7_3x3 = ConvBNRelu(model,
+                              tower_d7_3x3,
+                              prefix+"_tower_1_conv_1",
+                              num_input=num_d7_3x3_red,
+                              num_output=num_d7_2,
+                              filter_size=7,
+                              pad=3,
+                              is_test=is_test)
+    tower_d7_3x3 = ConvBNRelu(model,
+                              tower_d7_3x3,
+                              prefix+"_tower_1_conv_3",
+                              num_input=num_d7_2,
+                              num_output=num_d7_3,
+                              filter_size=3,
+                              pad=0,
+                              stride=2,
+                              is_test=is_test)
+
+    pooling = model.MaxPool(data, prefix+"_pool", kernel=3, stride=2)
+
+    concat = model.Concat([tower_3x3, tower_d7_3x3, pooling], prefix+"_concat")
+
+    return concat, (num_3x3+num_d7_3+input_filters)
+
+def Inception7E(model,
+                data,
+                input_filters,
+                num_1x1,
+                num_d3_red, num_d3_1, num_d3_2,
+                num_3x3_d3_red, num_3x3, num_3x3_d3_1, num_3x3_d3_2,
+                pool, proj,
+                prefix, is_test = False):
+    # 1x1 tower
+    tower_1x1 = ConvBNRelu(model,
+                           data,
+                           prefix+"_conv",
+                           num_input=input_filters,
+                           num_output=num_1x1,
+                           filter_size=1,
+                           is_test=is_test)
+    # d3 tower
+    tower_d3 = ConvBNRelu(model,
+                          data,
+                          prefix+"_tower_conv",
+                          num_input=input_filters,
+                          num_output=num_d3_red,
+                          filter_size=1,
+                          is_test=is_test)
+
+    tower_d3_ab = ConvBNRelu(model,
+                             tower_d3,
+                             prefix+"_tower_mixed_conv",
+                             num_input=num_d3_red,
+                             num_output=num_d3_2,
+                             filter_size=3,
+                             pad=1,
+                             is_test=is_test)
+
+    tower_3x3_d3 = ConvBNRelu(model,
+                               data,
+                               prefix+"_tower_1_conv",
+                               num_input=input_filters,
+                               num_output=num_3x3_d3_red,
+                               filter_size=1,
+                               is_test=is_test)
+    tower_3x3_d3 = ConvBNRelu(model,
+                               tower_3x3_d3,
+                               prefix+"_tower_1_conv_1",
+                               num_input=num_3x3_d3_red,
+                               num_output=num_3x3,
+                               filter_size=3,
+                               pad=1,
+                               is_test=is_test)
+    tower_3x3_d3_ab = ConvBNRelu(model,
+                                  tower_3x3_d3,
+                                  prefix+"_tower_1_mixed_conv_12",
+                                  num_input=num_3x3,
+                                  num_output=num_3x3_d3_2,
+                                  filter_size=3,
+                                  pad=1,
+                                  is_test=is_test)
+
+    pool_fn = model.MaxPool if (pool=="MAX") else model.AveragePool
+
+    pooling = pool_fn(data, prefix+"_pool", kernel=3, pad=1, stride=1)
+    cproj = ConvBNRelu(model,
+                      pooling,
+                      prefix+"_tower_2_conv",
+                      num_input=input_filters,
+                      num_output=proj,
+                      filter_size=1,
+                      is_test=is_test)
+
+    concat = model.Concat([tower_1x1, tower_d3_ab, tower_3x3_d3_ab, cproj], prefix+"_concat")
+
+    return concat, (num_1x1+num_d3_2+num_3x3_d3_2+proj)
+
+class Inception_v3():
+    @staticmethod
+    def CropSize():
+        return 299
+
+    @staticmethod
+    def Net(model, data, test_phase=False):
+
+        # stage1
+        conv = ConvBNRelu(model,
+                          data,
+                          "conv",
+                          num_input=3,
+                          num_output=32,
+                          filter_size=3,
+                          stride=2,
+                          is_test=test_phase)
+        conv_1 = ConvBNRelu(model,
+                            conv,
+                            "conv_1",
+                            num_input=32,
+                            num_output=32,
+                            filter_size=3,
+                            stride=1,
+                            is_test=test_phase)
+        conv_2 = ConvBNRelu(model,
+                            conv_1,
+                            "conv_2",
+                            num_input=32,
+                            num_output=64,
+                            filter_size=3,
+                            stride=1,
+                            pad=1,
+                            is_test=test_phase)
+        pool = model.MaxPool(conv_2,
+                                "pool",
+                                kernel=3,
+                                stride=2)
+
+        # stage 2
+        conv_3 = ConvBNRelu(model,
+                            pool,
+                            "conv_3",
+                            num_input=64,
+                            num_output=80,
+                            filter_size=1,
+                            stride=1,
+                            is_test=test_phase)
+        conv_4 = ConvBNRelu(model,
+                            conv_3,
+                            "conv_4",
+                            num_input=80,
+                            num_output=192,
+                            filter_size=3,
+                            stride=1,
+                            pad=1,
+                            is_test=test_phase)
+        pool1 = model.MaxPool(conv_4,
+                              "pool1",
+                              kernel=3,
+                              stride=2)
+
+        # stage 3
+        in3a, outputs = Inception7A(model,
+                           pool1,
+                           192,
+                           64,
+                           64, 96, 96,
+                           48, 64,
+                           32,
+                           prefix="mixed",
+                           is_test=test_phase)
+
+        in3b, outputs = Inception7A(model,
+                           in3a,
+                           outputs,
+                           64,
+                           64, 96, 96,
+                           48, 64,
+                           64,
+                           prefix="mixed_1",
+                           is_test=test_phase)
+
+        in3c, outputs = Inception7A(model,
+                           in3b,
+                           outputs,
+                           64,
+                           64, 96, 96,
+                           48, 64,
+                           64,
+                           prefix="mixed_2",
+                           is_test=test_phase)
+
+        in3d, outputs = Inception7B(model,
+                           in3c,
+                           outputs,
+                           384,
+                           64, 96, 96,
+                           prefix="mixed_3",
+                           is_test=test_phase)
+
+        # stage 4
+        in4a, outputs = Inception7C(model,
+                           in3d,
+                           outputs,
+                           192,
+                           128, 128, 192,
+                           128, 128, 128, 128, 192,
+                           192,
+                           prefix="mixed_4",
+                           is_test=test_phase)
+
+        in4b, outputs = Inception7C(model,
+                           in4a,
+                           outputs,
+                           192,
+                           160, 160, 192,
+                           160, 160, 160, 160, 192,
+                           192,
+                           prefix="mixed_5",
+                           is_test=test_phase)
+
+        in4c, outputs = Inception7C(model,
+                           in4b,
+                           outputs,
+                           192,
+                           160, 160, 192,
+                           160, 160, 160, 160, 192,
+                           192,
+                           prefix="mixed_6",
+                           is_test=test_phase)
+
+        in4d, outputs = Inception7C(model,
+                           in4c,
+                           outputs,
+                           192,
+                           192, 192, 192,
+                           192, 192, 192, 192, 192,
+                           192,
+                           prefix="mixed_7",
+                           is_test=test_phase)
+
+        in4e, outputs = Inception7D(model,
+                           in4d,
+                           outputs,
+                           192, 320,
+                           192, 192, 192, 192,
+                           prefix="mixed_8",
+                           is_test=test_phase)
+
+        # Stage 5
+        in5a, outputs = Inception7E(model,
+                           in4e,
+                           outputs,
+                           320,
+                           384, 384, 384,
+                           448, 384, 384, 384,
+                           "AVG",
+                           192,
+                           prefix="mixed_9",
+                           is_test=test_phase)
+
+        in5b, outputs = Inception7E(model,
+                           in5a,
+                           outputs,
+                           320,
+                           384, 384, 384,
+                           448, 384, 384, 384,
+                           "MAX",
+                           192,
+                           prefix="mixed_10",
+                           is_test=test_phase)
+
+        pool = model.AveragePool(in5b, "global_pool", kernel=8, stride=1)
+
+        fc = model.FC(pool, "fc", outputs, 1000)
+
+        pred = model.Softmax(fc, "pred")
+
+        return pred

--- a/caffe2/python/examples/imagenet/Networks.py
+++ b/caffe2/python/examples/imagenet/Networks.py
@@ -1,0 +1,439 @@
+from caffe2.python import cnn, core, workspace, dyndep, net_drawer
+from caffe2.proto import caffe2_pb2
+
+class VGGA(object):
+    @staticmethod
+    def CropSize():
+        return 231
+    @staticmethod
+    def Net(model, data, test_phase=False):
+        conv1 = model.Conv(
+            data,
+            "conv1",
+            3,
+            64,
+            3,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            pad=1
+        )
+        relu1 = model.Relu(conv1, "conv1")
+        pool1 = model.MaxPool(relu1, "pool1", kernel=2, stride=2)
+        conv2 = model.Conv(
+            pool1,
+            "conv2",
+            64,
+            128,
+            3,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            pad=1
+        )
+        relu2 = model.Relu(conv2, "conv2")
+        pool2 = model.MaxPool(relu2, "pool2", kernel=2, stride=2)
+        conv3 = model.Conv(
+            pool2,
+            "conv3",
+            128,
+            256,
+            3,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            pad=1
+        )
+        relu3 = model.Relu(conv3, "conv3")
+        conv4 = model.Conv(
+            relu3,
+            "conv4",
+            256,
+            256,
+            3,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            pad=1
+        )
+        relu4 = model.Relu(conv4, "conv4")
+        pool4 = model.MaxPool(relu4, "pool4", kernel=2, stride=2)
+        conv5 = model.Conv(
+            pool4,
+            "conv5",
+            256,
+            512,
+            3,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            pad=1
+        )
+        relu5 = model.Relu(conv5, "conv5")
+        conv6 = model.Conv(
+            relu5,
+            "conv6",
+            512,
+            512,
+            3,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            pad=1
+        )
+        relu6 = model.Relu(conv6, "conv6")
+        pool6 = model.MaxPool(relu6, "pool6", kernel=2, stride=2)
+        conv7 = model.Conv(
+            pool6,
+            "conv7",
+            512,
+            512,
+            3,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            pad=1
+        )
+        relu7 = model.Relu(conv7, "conv7")
+        conv8 = model.Conv(
+            relu7,
+            "conv8",
+            512,
+            512,
+            3,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            pad=1
+        )
+        relu8 = model.Relu(conv8, "conv8")
+        pool8 = model.MaxPool(relu8, "pool8", kernel=2, stride=2)
+
+        fcix = model.FC(
+            pool8, "fcix", 512 * 7 * 7, 4096, ('XavierFill', {}),
+            ('ConstantFill', {})
+        )
+        reluix = model.Relu(fcix, "fcix")
+        fcx = model.FC(
+            reluix, "fcx", 4096, 4096, ('XavierFill', {}), ('ConstantFill', {})
+        )
+        relux = model.Relu(fcx, "fcx")
+        fcxi = model.FC(
+            relux, "fcxi", 4096, 1000, ('XavierFill', {}), ('ConstantFill', {})
+        )
+        pred = model.Softmax(fcxi, "pred")
+
+        return pred
+
+class AlexNet(object):
+    @staticmethod
+    def CropSize():
+        return 227
+
+    @staticmethod
+    def Net(model, data, test_phase=False):
+        conv1 = model.Conv(
+            data, "conv1", 3, 64, 11,
+            ('XavierFill', {}), ('ConstantFill', {}),
+            stride=4, pad=2)
+        relu1 = model.Relu(conv1, conv1)
+        pool1 = model.MaxPool(relu1, "pool1", kernel=3, stride=2)
+        conv2 = model.Conv(
+            pool1, "conv2", 64, 192, 5,
+            ('XavierFill', {}), ('ConstantFill', {}), pad=2)
+        relu2 = model.Relu(conv2, conv2)
+        pool2 = model.MaxPool(relu2, "pool2", kernel=3, stride=2)
+        conv3 = model.Conv(
+            pool2, "conv3",
+            192, 384, 3,
+            ('XavierFill', {}), ('ConstantFill', {}),
+            pad=1)
+        relu3 = model.Relu(conv3, conv3)
+        conv4 = model.Conv(
+            relu3, "conv4", 384, 256, 3,
+            ('XavierFill', {}), ('ConstantFill', {}),
+            pad=1)
+        relu4 = model.Relu(conv4, conv4)
+        conv5 = model.Conv(
+            relu4, "conv5", 256, 256, 3,
+            ('XavierFill', {}), ('ConstantFill', {}),
+            pad=1)
+        relu5 = model.Relu(conv5, conv5)
+        pool5 = model.MaxPool(relu5, "pool5", kernel=3, stride=2)
+        fc6 = model.FC(
+            pool5, "fc6", 256 * 6 * 6, 4096, ('XavierFill', {}),
+            ('ConstantFill', {}))
+        relu6 = model.Relu(fc6, fc6)
+        fc7 = model.FC(
+            relu6, "fc7", 4096, 4096, ('XavierFill', {}),
+            ('ConstantFill', {}))
+        relu7 = model.Relu(fc7, fc7)
+        fc8 = model.FC(
+            relu7, "fc8", 4096, 1000,
+            ('XavierFill', {}), ('ConstantFill', {})
+        )
+        pred = model.Softmax(fc8, "pred")
+
+        return pred
+ 
+class AlexNetBN(object):
+    @staticmethod
+    def CropSize():
+        return 227
+
+    @staticmethod
+    def Net(model, data, test_phase=False):
+        keywords = {'is_test' : 1} if test_phase else {'is_test' : 0}
+        conv1 = model.Conv(
+            data, "conv1", 3, 64, 11,
+            ('XavierFill', {}), ('ConstantFill', {}),
+            stride=4, pad=2)
+        bn1 = model.SpatialBN(conv1, "bn1", 64, **keywords)
+        relu1 = model.Relu(bn1, bn1)
+        pool1 = model.MaxPool(relu1, "pool1", kernel=3, stride=2)
+        conv2 = model.Conv(
+            pool1, "conv2", 64, 192, 5,
+            ('XavierFill', {}), ('ConstantFill', {}), pad=2)
+        bn2 = model.SpatialBN(conv2, "bn2", 192, **keywords)
+        relu2 = model.Relu(bn2, bn2)
+        pool2 = model.MaxPool(relu2, "pool2", kernel=3, stride=2)
+        conv3 = model.Conv(
+            pool2, "conv3",
+            192, 384, 3,
+            ('XavierFill', {}), ('ConstantFill', {}),
+            pad=1)
+        bn3 = model.SpatialBN(conv3, "bn3", 384, **keywords)
+        relu3 = model.Relu(bn3, bn3)
+        conv4 = model.Conv(
+            relu3, "conv4", 384, 256, 3,
+            ('XavierFill', {}), ('ConstantFill', {}),
+            pad=1)
+        bn4 = model.SpatialBN(conv4, "bn4", 256, **keywords)
+        relu4 = model.Relu(bn4, bn4)
+        conv5 = model.Conv(
+            relu4, "conv5", 256, 256, 3,
+            ('XavierFill', {}), ('ConstantFill', {}),
+            pad=1)
+        bn5 = model.SpatialBN(conv5, "bn5", 256, **keywords)
+        relu5 = model.Relu(bn5, bn5)
+        pool5 = model.MaxPool(relu5, "pool5", kernel=3, stride=2)
+        fc6 = model.FC(
+            pool5, "fc6", 256 * 6 * 6, 4096, ('XavierFill', {}),
+            ('ConstantFill', {}))
+        relu6 = model.Relu(fc6, fc6)
+        fc7 = model.FC(
+            relu6, "fc7", 4096, 4096, ('XavierFill', {}),
+            ('ConstantFill', {}))
+        relu7 = model.Relu(fc7, fc7)
+        fc8 = model.FC(
+            relu7, "fc8", 4096, 1000,
+            ('XavierFill', {}), ('ConstantFill', {})
+        )
+        pred = model.Softmax(fc8, "pred")
+
+        return pred
+ 
+class OverFeat(object):
+    @staticmethod
+    def CropSize():
+        return 231
+
+    @staticmethod
+    def Net(model, data, test_phase=False):
+        conv1 = model.Conv(
+            data,
+            "conv1",
+            3,
+            96,
+            11,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            stride=4
+        )
+        relu1 = model.Relu(conv1, "conv1")
+        pool1 = model.MaxPool(relu1, "pool1", kernel=2, stride=2)
+        conv2 = model.Conv(
+            pool1, "conv2", 96, 256, 5, ('XavierFill', {}), ('ConstantFill', {})
+        )
+        relu2 = model.Relu(conv2, "conv2")
+        pool2 = model.MaxPool(relu2, "pool2", kernel=2, stride=2)
+        conv3 = model.Conv(
+            pool2,
+            "conv3",
+            256,
+            512,
+            3,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            pad=1
+        )
+        relu3 = model.Relu(conv3, "conv3")
+        conv4 = model.Conv(
+            relu3,
+            "conv4",
+            512,
+            1024,
+            3,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            pad=1
+        )
+        relu4 = model.Relu(conv4, "conv4")
+        conv5 = model.Conv(
+            relu4,
+            "conv5",
+            1024,
+            1024,
+            3,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            pad=1
+        )
+        relu5 = model.Relu(conv5, "conv5")
+        pool5 = model.MaxPool(relu5, "pool5", kernel=2, stride=2)
+        fc6 = model.FC(
+            pool5, "fc6", 1024 * 6 * 6, 3072, ('XavierFill', {}),
+            ('ConstantFill', {})
+        )
+        relu6 = model.Relu(fc6, "fc6")
+        fc7 = model.FC(
+            relu6, "fc7", 3072, 4096, ('XavierFill', {}), ('ConstantFill', {})
+        )
+        relu7 = model.Relu(fc7, "fc7")
+        fc8 = model.FC(
+            relu7, "fc8", 4096, 1000, ('XavierFill', {}), ('ConstantFill', {})
+        )
+        pred = model.Softmax(fc8, "pred")
+
+        return pred
+
+class Inception(object):
+    @staticmethod
+    def CropSize():
+        return 224
+
+    @staticmethod
+    def _InceptionModule(
+        model, input_blob, input_depth, output_name, conv1_depth, conv3_depths,
+        conv5_depths, pool_depth
+    ):
+        # path 1: 1x1 conv
+        conv1 = model.Conv(
+            input_blob, output_name + ":conv1", input_depth, conv1_depth, 1,
+            ('XavierFill', {}), ('ConstantFill', {})
+        )
+        conv1 = model.Relu(conv1, conv1)
+        # path 2: 1x1 conv + 3x3 conv
+        conv3_reduce = model.Conv(
+            input_blob, output_name + ":conv3_reduce", input_depth, conv3_depths[0],
+            1, ('XavierFill', {}), ('ConstantFill', {})
+        )
+        conv3_reduce = model.Relu(conv3_reduce, conv3_reduce)
+        conv3 = model.Conv(
+            conv3_reduce,
+            output_name + ":conv3",
+            conv3_depths[0],
+            conv3_depths[1],
+            3,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            pad=1
+        )
+        conv3 = model.Relu(conv3, conv3)
+        # path 3: 1x1 conv + 5x5 conv
+        conv5_reduce = model.Conv(
+            input_blob, output_name + ":conv5_reduce", input_depth, conv5_depths[0],
+            1, ('XavierFill', {}), ('ConstantFill', {})
+        )
+        conv5_reduce = model.Relu(conv5_reduce, conv5_reduce)
+        conv5 = model.Conv(
+            conv5_reduce,
+            output_name + ":conv5",
+            conv5_depths[0],
+            conv5_depths[1],
+            5,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            pad=2
+        )
+        conv5 = model.Relu(conv5, conv5)
+        # path 4: pool + 1x1 conv
+        pool = model.MaxPool(
+            input_blob,
+            output_name + ":pool",
+            kernel=3,
+            stride=1,
+            pad=1
+        )
+        pool_proj = model.Conv(
+            pool, output_name + ":pool_proj", input_depth, pool_depth, 1,
+            ('XavierFill', {}), ('ConstantFill', {})
+        )
+        pool_proj = model.Relu(pool_proj, pool_proj)
+        output = model.Concat([conv1, conv3, conv5, pool_proj], output_name)
+        return output
+
+
+    @staticmethod
+    def Net(model, data, test_phase=False):
+        conv1 = model.Conv(
+            data,
+            "conv1",
+            3,
+            64,
+            7,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            stride=2,
+            pad=3
+        )
+        relu1 = model.Relu(conv1, "conv1")
+        pool1 = model.MaxPool(relu1, "pool1", kernel=3, stride=2, pad=1)
+        conv2a = model.Conv(
+            pool1, "conv2a", 64, 64, 1, ('XavierFill', {}), ('ConstantFill', {})
+        )
+        conv2a = model.Relu(conv2a, conv2a)
+        conv2 = model.Conv(
+            conv2a,
+            "conv2",
+            64,
+            192,
+            3,
+            ('XavierFill', {}),
+            ('ConstantFill', {}),
+            pad=1
+        )
+        relu2 = model.Relu(conv2, "conv2")
+        pool2 = model.MaxPool(relu2, "pool2", kernel=3, stride=2, pad=1)
+        # Inception modules
+        inc3 = Inception._InceptionModule(
+            model, pool2, 192, "inc3", 64, [96, 128], [16, 32], 32
+        )
+        inc4 = Inception._InceptionModule(
+            model, inc3, 256, "inc4", 128, [128, 192], [32, 96], 64
+        )
+        pool5 = model.MaxPool(inc4, "pool5", kernel=3, stride=2, pad=1)
+        inc5 = Inception._InceptionModule(
+            model, pool5, 480, "inc5", 192, [96, 208], [16, 48], 64
+        )
+        inc6 = Inception._InceptionModule(
+            model, inc5, 512, "inc6", 160, [112, 224], [24, 64], 64
+        )
+        inc7 = Inception._InceptionModule(
+            model, inc6, 512, "inc7", 128, [128, 256], [24, 64], 64
+        )
+        inc8 = Inception._InceptionModule(
+            model, inc7, 512, "inc8", 112, [144, 288], [32, 64], 64
+        )
+        inc9 = Inception._InceptionModule(
+            model, inc8, 528, "inc9", 256, [160, 320], [32, 128], 128
+        )
+        pool9 = model.MaxPool(inc9, "pool9", kernel=3, stride=2, pad=1)
+        inc10 = Inception._InceptionModule(
+            model, pool9, 832, "inc10", 256, [160, 320], [32, 128], 128
+        )
+        inc11 = Inception._InceptionModule(
+            model, inc10, 832, "inc11", 384, [192, 384], [48, 128], 128
+        )
+        pool11 = model.AveragePool(inc11, "pool11", kernel=7, stride=1)
+        fc = model.FC(
+            pool11, "fc", 1024, 1000, ('XavierFill', {}), ('ConstantFill', {})
+        )
+        # It seems that Soumith's benchmark does not have softmax on top
+        # for Inception. We will add it anyway so we can have a proper
+        # backward pass.
+        pred = model.Softmax(fc, "pred")
+
+        return pred

--- a/caffe2/python/examples/imagenet/ResNet.py
+++ b/caffe2/python/examples/imagenet/ResNet.py
@@ -1,0 +1,376 @@
+from caffe2.python import cnn, core, workspace, dyndep, net_drawer
+from caffe2.proto import caffe2_pb2
+
+# basic building block
+# Convolution + BatchNorm
+def ConvBN(model, input_blob, output_name, num_input, num_output, filter_size, stride, pad, is_test=False):
+    conv = model.Conv(
+        input_blob,
+        output_name + "_conv",
+        num_input,
+        num_output,
+        filter_size,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        stride=stride,
+        pad=pad
+    )
+    keywords = {'is_test' : 1} if is_test else {'is_test' : 0}
+    bn = model.SpatialBN(
+        conv,
+        output_name + "_bn",
+        num_output,
+        **keywords)
+    return bn
+
+def ConvBNRelu(model, input_blob, output_name, num_input, num_output, filter_size, stride, pad, is_test=False):
+    bn = ConvBN(model, input_blob, output_name, num_input, num_output, filter_size, stride, pad, is_test)
+
+    bn = model.Relu(bn, bn)
+
+    return bn
+
+def ResNetStem(model, data, is_test=False):
+    conv1 = ConvBNRelu(
+        model,
+        data,
+        "conv1",
+        num_input=3,
+        num_output=64,
+        filter_size=7,
+        stride=2,
+        pad=3,
+        is_test=is_test
+    )
+    pool1 = model.MaxPool(
+        conv1,
+        "pool1",
+        kernel=3,
+        stride=2,
+        pad=1
+    )
+    return pool1
+
+
+# Block for ResNet_{18,34}
+def BasicBlock(model, block, num, input_blob, input_filters, intermediate_filters, output_filters, prefix, is_test=False):
+
+    # Use convolution-shortcut (option C) for now
+    stride = 2 if (num == 1) and (block != 2) else 1
+    conv_shortcut = model.Conv(
+        input_blob,
+        prefix + "_{}_shortcut".format(num),
+        input_filters,
+        output_filters,
+        1,
+        ('XavierFill', {}),
+        ('ConstantFill',{}),
+        pad=0,
+        stride=stride
+    )
+
+    conv1 = ConvBNRelu(
+        model,
+        input_blob,
+        prefix + "_{}_1".format(num),
+        num_input=input_filters,
+        num_output=intermediate_filters,
+        filter_size=3,
+        stride=stride,
+        pad=1,
+        is_test=is_test
+    )
+    conv2 = ConvBN(
+        model,
+        conv1,
+        prefix + "_{}_2".format(num),
+        num_input=intermediate_filters,
+        num_output=output_filters,
+        filter_size=3,
+        stride=1,
+        pad=1,
+        is_test=is_test
+    )
+    # Bring in shortcut layer
+    # Add shortcut (identity) and conv3 
+    add = model.Add([conv2, conv_shortcut], prefix+"_{}_sum".format(num))
+    add = model.Relu(add, add)
+
+    return add
+
+# Block for ResNet_{50,101,152}
+def Bottleneck(model, block, num, input_blob, input_filters, intermediate_filters, output_filters, prefix, is_test=False):
+
+    stride = 2 if (num == 1) and (block != 2) else 1
+    # Use convolution-shortcut (option C) for now
+    conv_shortcut = model.Conv(
+        input_blob,
+        prefix + "_{}_shortcut".format(num),
+        input_filters,
+        output_filters,
+        1,
+        ('XavierFill', {}),
+        ('ConstantFill',{}),
+        stride=stride,
+        pad=0
+    )
+
+    conv1 = ConvBNRelu(
+        model,
+        input_blob,
+        prefix + "_{}_1".format(num),
+        num_input=input_filters,
+        num_output=intermediate_filters,
+        filter_size=1,
+        stride=stride,
+        pad=0,
+        is_test=is_test
+    )
+    conv2 = ConvBNRelu(
+        model,
+        conv1,
+        prefix + "_{}_2".format(num),
+        num_input=intermediate_filters,
+        num_output=intermediate_filters,
+        filter_size=3,
+        stride=1,
+        pad=1,
+        is_test=is_test
+    )
+    conv3 = ConvBN(
+        model,
+        conv2,
+        prefix + "_{}_3".format(num),
+        num_input=intermediate_filters,
+        num_output=output_filters,
+        filter_size=1,
+        stride=1,
+        pad=0,
+        is_test=is_test
+    )
+    # Bring in shortcut layer
+    # Add shortcut (identity) and conv3 
+    add = model.Add([conv3, conv_shortcut], prefix+"_{}_sum".format(num))
+    add = model.Relu(add, add)
+
+    return add
+
+# Resnet 18 + 34
+class ResNetSmall():
+    @staticmethod
+    def CropSize():
+        return 224
+
+# def BasicBlock(model, num, input_blob, input_filters, intermediate_filters, output_filters, prefix):
+    # default to 34-layer resnet
+    @staticmethod
+    def Net(model, data, is_test=False, layer_numbers=[3,4,6,3]):
+        stem = ResNetStem(model, data, is_test)
+
+        current_input = stem
+        current_input_filters = 64
+
+        # ConvBNRelu + ConvBNRelu + ConvBN + EltWise + Relu
+        for l in xrange(1, layer_numbers[0]+1):
+            conv2 = BasicBlock(
+                model,
+                2,
+                l,
+                current_input,
+                input_filters=current_input_filters,
+                intermediate_filters=64,
+                output_filters=64,
+                prefix="conv2",
+                is_test=is_test
+            )
+            current_input_filters = 64
+            current_input = conv2
+            
+        # Next set: 512 filters in/out, 128 intermediate
+        for l in xrange(1, layer_numbers[1]+1):
+            conv3 = BasicBlock(
+                model,
+                3,
+                l,
+                current_input,
+                input_filters=current_input_filters,
+                intermediate_filters=128,
+                output_filters=128,
+                prefix="conv3",
+                is_test=is_test
+            )
+            current_input_filters=128
+            current_input=conv3
+
+        # 256 intermediate, 1024 in/out
+        for l in xrange(1, layer_numbers[2]+1):
+            conv4 = BasicBlock(
+                model,
+                4,
+                l,
+                current_input,
+                input_filters=current_input_filters,
+                intermediate_filters=256,
+                output_filters=256,
+                prefix="conv4",
+                is_test=is_test
+            )
+            current_input_filters=256
+            current_input=conv4
+
+        # 512 intermediate, 2048 in/out
+        for l in xrange(1,layer_numbers[3]+1):
+            conv5 = BasicBlock(
+                model,
+                5,
+                l,
+                current_input,
+                input_filters=current_input_filters,
+                intermediate_filters=512,
+                output_filters=512,
+                prefix="conv5",
+                is_test=is_test
+            )
+            current_input_filters=512
+            current_input=conv5
+
+        # average pool
+        pool2 = model.AveragePool(
+            current_input,
+            "pool2",
+            kernel=7,
+            stride=1,
+            pad=0
+        )
+        fc = model.FC(
+            pool2,
+            "fc",
+            512,
+            1000,
+            ('XavierFill', {}),
+            ('ConstantFill', {})
+        )
+        pred = model.Softmax(fc, "pred")
+
+        return pred
+
+
+class ResNet():
+    @staticmethod
+    def CropSize():
+        return 224
+
+    # default to 50-layer resnet
+    @staticmethod
+    def Net(model, data, is_test=False, layer_numbers=[3,4,6,3]):
+        stem = ResNetStem(model, data, is_test)
+
+        current_input = stem
+        current_input_filters = 64
+        # ConvBNRelu + ConvBNRelu + ConvBN + EltWise + Relu
+        for l in xrange(1, layer_numbers[0]+1):
+            conv2 = Bottleneck(
+                model,
+                2,
+                l,
+                current_input,
+                input_filters=current_input_filters,
+                intermediate_filters=64,
+                output_filters=256,
+                prefix="conv2",
+                is_test=is_test
+            )
+            current_input_filters = 256
+            current_input = conv2
+            
+        # Next set: 512 filters in/out, 128 intermediate
+
+        for l in xrange(1, layer_numbers[1]+1):
+            conv3 = Bottleneck(
+                model,
+                3,
+                l,
+                current_input,
+                input_filters=current_input_filters,
+                intermediate_filters=128,
+                output_filters=512,
+                prefix="conv3",
+                is_test=is_test
+            )
+            current_input_filters=512
+            current_input=conv3
+
+        # 256 intermediate, 1024 in/out
+        for l in xrange(1, layer_numbers[2]+1):
+            conv4 = Bottleneck(
+                model,
+                4,
+                l,
+                current_input,
+                input_filters=current_input_filters,
+                intermediate_filters=256,
+                output_filters=1024,
+                prefix="conv4",
+                is_test=is_test
+            )
+            current_input_filters=1024
+            current_input=conv4
+
+        # 512 intermediate, 2048 in/out
+        for l in xrange(1,layer_numbers[3]+1):
+            conv5 = Bottleneck(
+                model,
+                5,
+                l,
+                current_input,
+                input_filters=current_input_filters,
+                intermediate_filters=512,
+                output_filters=2048,
+                prefix="conv5",
+                is_test=is_test
+            )
+            current_input_filters=2048
+            current_input=conv5
+
+        # average pool
+        pool2 = model.AveragePool(
+            current_input,
+            "pool2",
+            kernel=7,
+            stride=1,
+            pad=0
+        )
+        fc = model.FC(
+            pool2,
+            "fc",
+            2048,
+            1000,
+            ('XavierFill', {}),
+            ('ConstantFill', {})
+        )
+        pred = model.Softmax(fc, "pred")
+
+        return pred
+
+class ResNetHelper():
+    def __init__(self, depth):
+        self.depth = depth
+
+    def CropSize(self):
+        return 224
+
+    def Net(self, model, data, test_phase=False):
+        if self.depth == 18:
+            return ResNetSmall.Net(model, data, test_phase, [2,2,2,2])
+        elif self.depth == 34:
+            return ResNetSmall.Net(model, data, test_phase, [3,4,6,3])
+        elif self.depth == 50:
+            return ResNet.Net(model, data, test_phase, [3,4,6,3])
+        elif self.depth == 101:
+            return ResNet.Net(model, data, test_phase, [3,4,23,3])
+        elif self.depth == 152:
+            return ResNet.Net(model, data, test_phase, [3,8,36,3])
+        else:
+            print('Error - invalid resnet depth specified')
+
+

--- a/caffe2/python/examples/imagenet/train_imagenet.py
+++ b/caffe2/python/examples/imagenet/train_imagenet.py
@@ -1,0 +1,294 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from caffe2.python import cnn, core, workspace, dyndep, net_drawer
+from caffe2.proto import caffe2_pb2
+
+from Networks import *
+from ResNet import *
+from Inception_v3 import *
+
+import numpy as np
+ 
+import argparse
+import time
+from timeit import default_timer as timer 
+ 
+##
+ #
+ # Copyright (c) 2016, NVIDIA CORPORATION, All rights reserved
+ #
+ # Redistribution and use in source and binary forms, with or without
+ # modification, are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice, this
+ #    list of conditions and the following disclaimer.
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ # DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ # ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ # (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ # LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ # ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+##
+
+dyndep.InitOpsLibrary('@/caffe2/caffe2/contrib/nccl:nccl_ops')
+ 
+def getNet(net_type):
+    nets = {
+        'AlexNet' : AlexNet,
+        'AlexNetBN' : AlexNetBN,
+        'OverFeat' : OverFeat,
+        'VGGA' : VGGA,
+        'Inception' : Inception,
+        'ResNet' : ResNet,
+        'ResNet18' : ResNetHelper(18),
+        'ResNet34' : ResNetHelper(34),
+        'ResNet50' : ResNetHelper(50),
+        'ResNet101' : ResNetHelper(101),
+        'ResNet1523' : ResNetHelper(152),
+        'InceptionV3' : Inception_v3
+    }
+
+    return nets[net_type]
+
+def addData(model, reader, batch_size, crop_size, mirror=True):
+    data, label = model.ImageInput(
+        [reader], ["data", "label"],
+        use_gpu_transform=True,
+        batch_size=batch_size, use_caffe_datum=True,
+        mean=128., std=128., scale=256, crop=crop_size, mirror=1,
+    )
+    return data, label
+
+def addAccuracy(model, softmax, label):
+    accuracy = model.Accuracy([softmax, label], "accuracy")
+
+    return accuracy
+
+def generateTestModel(args, num_gpus, crop_size, mirror=False):
+    # Don't init params, will reference from GPU0 training net
+    test_model = cnn.CNNModelHelper(
+        "NCHW", "imagenet_test", use_cudnn=True, cudnn_exhaustive_search=False,
+        ws_nbytes_limit=8192, init_params=False)
+
+    reader = test_model.CreateDB(
+        "reader",
+        db=args.test_db,
+        db_type=args.test_db_type)
+
+    # always weak scale testing
+    batch_size = args.test_batch_size
+
+    for i in range(num_gpus):
+        with core.NameScope("gpu_{}".format(i)):
+            with core.DeviceScope(core.DeviceOption(caffe2_pb2.CUDA, i)):
+
+                # Base net
+                net = getNet(args.net)
+                data, label = addData(test_model, reader, batch_size=batch_size, crop_size=net.CropSize(), mirror=mirror)
+                pred = net.Net(test_model, data, test_phase=True)
+                xent = test_model.LabelCrossEntropy([pred, label], "xent")
+                test_loss = test_model.AveragedLoss(xent, "test_loss")
+                
+                # Test-specific
+                accuracy = addAccuracy(test_model, softmax=pred, label=label)
+
+    return test_model
+
+def generateTrainModel(args, num_gpus, crop_size, mirror):
+    train_model = cnn.CNNModelHelper(
+        "NCHW", "imagenet_train", use_cudnn=True, cudnn_exhaustive_search=True,
+        ws_nbytes_limit=64*1024*1024)
+    reader = train_model.CreateDB(
+        "reader",
+        db=args.db,
+        db_type=args.db_type)
+    all_loss_gradients = {}
+
+    # handle strong / weak scaling
+    batch_size = args.batch_size if args.scaling == 'weak' else args.batch_size / num_gpus
+
+    for i in range(num_gpus):
+        with core.NameScope("gpu_{}".format(i)):
+            with core.DeviceScope(core.DeviceOption(caffe2_pb2.CUDA, i)):
+
+                # initialize the net on this GPU
+                net = getNet(args.net)
+                data, label = addData(train_model, reader, batch_size=batch_size, crop_size=net.CropSize(), mirror=True)
+                pred = net.Net(train_model, data)
+
+                # Training-specific ops
+                xent = train_model.LabelCrossEntropy([pred, label], "xent")
+                loss = train_model.AveragedLoss(xent, "loss")
+                # Since we are doing multiple GPU, we will need to explicitly
+                # create the loss gradients on each GPU.
+                one = train_model.ConstantFill(loss, ["loss_grad"], value=1.0)
+                all_loss_gradients[str(loss)] = str(one)
+ 
+    train_model.AddGradientOperators(all_loss_gradients)
+ 
+    # After the gradients, we will add an NCCLAllreduce for all the parameters.
+    # Also add NCCLBroadcast for initial parameters
+    all_params = train_model.params
+    assert len(all_params) % num_gpus == 0, "This should not happen."
+    params_per_gpu = len(all_params) // num_gpus
+    with core.DeviceScope(core.DeviceOption(caffe2_pb2.CUDA, 0)):
+        if num_gpus > 1:
+            for i in reversed(range(params_per_gpu)):
+                gradients = [
+                    train_model.param_to_grad[p] for p in all_params[i::params_per_gpu]
+                ]
+                train_model.NCCLAllreduce(gradients, gradients)
+
+            # broadcast parameters
+            for i in range(params_per_gpu):
+                params = all_params[i::params_per_gpu]
+
+                train_model.param_init_net.NCCLBroadcast(params, params)
+ 
+    # add basic training iter
+    for i in range(num_gpus):
+        with core.NameScope("gpu_{}".format(i)):
+            with core.DeviceScope(core.DeviceOption(caffe2_pb2.CUDA, i)):
+                ITER = train_model.Iter("iter")
+                LR = train_model.LearningRate(ITER, "LR", base_lr=-0.01, policy="step", stepsize=1, gamma=0.999)
+                ONE = train_model.param_init_net.ConstantFill([], "ONE", shape=[1], value=1.0)
+
+                # all parameters on this GPU
+                for param in all_params[i*params_per_gpu:(i+1)*params_per_gpu]:
+                    # print(param)
+                    # relevant gradient
+                    param_grad = train_model.param_to_grad[param]
+                    param_mom = train_model.param_init_net.ConstantFill([param], param_grad+"_mom", value=0.)
+                    train_model.MomentumSGD([param_grad, param_mom, LR], [param_grad, param_mom], momentum=0.9, nesterov=False)
+                    train_model.WeightedSum([param, ONE, param_grad, ONE], param)
+
+    train_model.net.Proto().type = 'dag'
+    train_model.net.Proto().num_workers = num_gpus * 3
+ 
+    # print(train_model.net.Proto())
+
+    return train_model
+
+def parseArgs():
+    parser = argparse.ArgumentParser(
+        description="image throughput benchmark.")
+    parser.add_argument(
+        "--db", type=str,
+        default="/data/imagenet-compressed/256px/ilsvrc12_train_lmdb",
+        help="The input db path.")
+    parser.add_argument(
+        "--db_type", type=str, default="lmdb",
+        help="The input db type.")
+    parser.add_argument(
+        "--test_db", type=str,
+        default="/data/imagenet-compressed/256px/ilsvrc12_val_lmdb",
+        help="The input db path.")
+    parser.add_argument(
+        "--test_db_type", type=str, default="lmdb",
+        help="The input db type.")
+    parser.add_argument(
+        "--batch_size", type=int, default=128,
+        help="The batch size.")
+    parser.add_argument(
+        "--test_batch_size", type=int, default=50,
+        help="The batch size.")
+    parser.add_argument(
+        "--caffe2_log_level", type=int, default=0,
+        help="The log level of caffe2.")
+    parser.add_argument(
+        "--gpus", type=int, default=-1,
+        help="Number of GPUs to use")
+    parser.add_argument(
+        "--save_graph", action="store_true",
+        help="Save pdf of graph to disk")
+    parser.add_argument(
+        "--net", type=str, default="AlexNet",
+        help="Network type to train")
+    parser.add_argument(
+        "--scaling", choices=['strong', 'weak'], type=str,
+        default='weak',
+        help="Type of scaling used")
+    args = parser.parse_args()
+
+    return args
+
+def main():
+    args = parseArgs()
+    workspace.GlobalInit(
+        ["caffe2", "-caffe2_log_level={}".format(args.caffe2_log_level)])
+ 
+    num_gpus = workspace.NumCudaDevices() if (args.gpus <= 0) else args.gpus
+
+    # generate the training model on all GPUs
+    train_model = generateTrainModel(args, num_gpus=num_gpus, crop_size=227, mirror=True)
+ 
+    #generate the test model on GPU 0
+    test_model = generateTestModel(args, num_gpus=num_gpus, crop_size=227, mirror=False)
+
+    # draw the model.
+    with open("imagenet_multi_gpu.pbtxt", "w") as fid:
+        fid.write(str(train_model.net.Proto()))
+
+    if args.save_graph:
+        graph = net_drawer.GetPydotGraphMinimal(train_model.net.Proto().op, "imagenet")
+        graph.write_pdf("imagenet_multi_gpu.pdf")
+ 
+    workspace.RunNetOnce(train_model.param_init_net)
+    workspace.CreateNet(train_model.net)
+
+    workspace.RunNetOnce(test_model.param_init_net)
+    workspace.CreateNet(test_model.net)
+
+    num_iter = 2500
+    test_interval = 500
+    print_interval = 100
+
+    aggregate_batch_size = args.batch_size*num_gpus if args.scaling == 'weak' else args.batch_size
+    batch_size_per_gpu = args.batch_size if args.scaling == 'weak' else args.batch_size / num_gpus
+
+    print('\nTotal batchsize: {}, {} per GPU'.format(aggregate_batch_size, batch_size_per_gpu))
+    print('\n==== Starting Optimization Loop ({0} iterations) ====\n'.format(num_iter))
+    accumulated_time = 0.
+    for i in range(num_iter+1):
+        start = timer()
+        workspace.RunNet(train_model.net.Proto().name)
+        end = timer()
+        accumulated_time += end-start
+
+        # run test net, track Accuracy
+        acc_str = ""
+        if (i % test_interval == 0 and i != 0):
+            workspace.RunNet(test_model.net.Proto().name)
+            loss_sum = 0.
+            acc_sum = 0.
+            for g in range(num_gpus):
+                acc_sum += workspace.FetchBlob("gpu_{}/accuracy".format(g))
+                loss_sum += workspace.FetchBlob("gpu_{}/test_loss".format(g))
+            acc_str = ", test loss: {0:4f}, test accuracy: {1:.3f}".format(float(loss_sum / num_gpus), float(acc_sum))
+            # print("iter: {0:8d} test loss: {1:4f}, test accuracy: {2:4f}".format(i, float(loss_sum / num_gpus), float(acc_sum)))
+
+        # track Loss
+        if (i % print_interval == 0):
+            loss = workspace.FetchBlob("gpu_0/loss")
+            time_per_iter = accumulated_time / print_interval
+            accumulated_time = 0.
+            samples_per_second = aggregate_batch_size / time_per_iter
+            output_str = "[{timestamp}] iter: {0:8d}, loss: {1:4f}, {2:.0f} images/second".format(i, float(loss), float(samples_per_second), timestamp=time.strftime('%H:%M:%S'))
+
+            output_str += acc_str
+            print(output_str)
+
+    workspace.ResetWorkspace()
+ 
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Very initial version of training scripts for imagenet. Initial version based on a script from @Yangqing, and many thanks to @Yangqing for the time he spent talking to me in the process of writing these!

Not necessarily intended to be merged as-is, I'd like to build from this PR into something more fully-featured.

Requires the following PRs for full functionality (read: multi-GPU and BN-based networks)
#45, #46, #47, #48

Current features:
- Multi-GPU execution via the `--gpus` command-line flag (i.e. `--gpus=2` runs on 2 GPUs, if left unspecified, Caffe2 will run on all available devices)
- Networks supported:
  - AlexNet
  - AlexNet + BatchNorm
  - VGG
  - Googlenet
  - ResNet{18,34,50,101,152}
  - Inception_v3 (based on the MXNet definition, without factorized convolutions)
  - I have an untested SqueezeNet v1.1 network around as well if there's interest.
- Optimization with SGD
- Train and test networks
