### PR TITLE
No exception for float64 in FeedBlob. Warning instead.

### DIFF
--- a/caffe2/python/workspace.py
+++ b/caffe2/python/workspace.py
@@ -5,12 +5,16 @@ import os
 import shutil
 import socket
 import tempfile
+import logging
 
 import numpy as np
 from caffe2.proto import caffe2_pb2
 from caffe2.python import scope, utils
 
 import caffe2.python._import_c_extension as C
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
 
 Blobs = C.blobs
 CreateBlob = C.create_blob
@@ -205,7 +209,7 @@ def FeedBlob(name, arr, device_option=None):
 
     if device_option and device_option.device_type == caffe2_pb2.CUDA:
         if arr.dtype == np.dtype('float64'):
-            raise Exception(
+            logger.warning(
                 "CUDA operators do not support 64-bit doubles, " +
                 "please use arr.astype(np.float32) or np.int32 for ints." +
                 " Blob: {}".format(name) +


### PR DESCRIPTION
The exception in FeedBlob causes many tests to fail.
Instead of exception, we log a warning message and move on.
Feeding a float64 blob should not cause any issue.