### PR TITLE
Make counts datatype int. Used as index.

### DIFF
--- a/caffe2/python/operator_test/segment_ops_test.py
+++ b/caffe2/python/operator_test/segment_ops_test.py
@@ -110,7 +110,7 @@ class SegmentsTester(TesterBase):
                 dtype=data.dtype
             ) for seg_id in range(0, K)
         ]
-        counts = np.zeros(K)
+        counts = np.zeros(K, dtype=int)
         for i, seg_id in enumerate(segment_ids):
             data_idx = i if indices is None else indices[i]
             outputs[seg_id][counts[seg_id]] = data[data_idx]
@@ -123,7 +123,7 @@ class SegmentsTester(TesterBase):
         if len(segment_ids) == 0:
             return output
         K = max(segment_ids) + 1
-        counts = np.zeros(K)
+        counts = np.zeros(K, dtype=int)
         for i, seg_id in enumerate(segment_ids):
             output[i] = inputs[seg_id][counts[seg_id]]
             counts[seg_id] += 1


### PR DESCRIPTION
To avoid Numpy warning: using a non-integer number instead of an integer will result in an error in the future