### PR TITLE
Cudnn v6

### DIFF
--- a/caffe2/core/common_cudnn.h
+++ b/caffe2/core/common_cudnn.h
@@ -18,6 +18,9 @@ static_assert(
     CUDNN_VERSION >= 5000,
     "Caffe2 requires cudnn version 5.0 or above.");
 
+#define CUDNN_VERSION_MIN(major, minor, patch) \
+  (CUDNN_VERSION >= ((major) * 1000 + (minor) * 100 + (patch)))
+
 namespace caffe2 {
 
 namespace internal {

--- a/caffe2/core/common_cudnn.h
+++ b/caffe2/core/common_cudnn.h
@@ -73,6 +73,43 @@ inline const char* cudnnGetErrorString(cudnnStatus_t status) {
         ::caffe2::internal::cudnnGetErrorString(status)); \
   } while (0)
 
+// report the version of cuDNN Caffe2 was compiled with
+inline size_t cudnnCompiledVersion() {
+  return CUDNN_VERSION;
+}
+// report the runtime version of cuDNN
+inline size_t cudnnRuntimeVersion() {
+  return cudnnGetVersion();
+}
+
+// Extract cuDNN versions
+inline size_t cudnnExtractMajorVersion(size_t v) {
+  return v / 1000;
+}
+inline size_t cudnnExtractMinorVersion(size_t v) {
+  return (v % 1000) / 100;
+}
+inline size_t cudnnExtractPatchVersion(size_t v) {
+  return v % 100;
+}
+
+// Check compatibility of compiled and runtime cuDNN versions
+inline void CheckCuDNNVersions() {
+  // Version format is major*1000 + minor*100 + patch
+  // Major and minor versions must match
+  auto compiled_version = cudnnCompiledVersion();
+  auto runtime_version = cudnnRuntimeVersion();
+  auto compiled_major = cudnnExtractMajorVersion(compiled_version);
+  auto compiled_minor = cudnnExtractMinorVersion(compiled_version);
+  auto runtime_major = cudnnExtractMajorVersion(runtime_version);
+  auto runtime_minor = cudnnExtractMinorVersion(runtime_version);
+
+  bool version_match = (compiled_major == runtime_major) && (compiled_minor == runtime_minor);
+  CAFFE_ENFORCE(version_match,
+                "cuDNN compiled (", cudnnCompiledVersion(), ") and"
+                "runtime (", cudnnRuntimeVersion(), ") versions mismatch");
+}
+
 /**
  * cudnnTypeWrapper is a wrapper class that allows us to refer to the cudnn type
  * in a template function. The class is specialized explicitly for different

--- a/caffe2/core/common_cudnn.h
+++ b/caffe2/core/common_cudnn.h
@@ -82,29 +82,11 @@ inline size_t cudnnRuntimeVersion() {
   return cudnnGetVersion();
 }
 
-// Extract cuDNN versions
-inline size_t cudnnExtractMajorVersion(size_t v) {
-  return v / 1000;
-}
-inline size_t cudnnExtractMinorVersion(size_t v) {
-  return (v % 1000) / 100;
-}
-inline size_t cudnnExtractPatchVersion(size_t v) {
-  return v % 100;
-}
-
 // Check compatibility of compiled and runtime cuDNN versions
 inline void CheckCuDNNVersions() {
   // Version format is major*1000 + minor*100 + patch
-  // Major and minor versions must match
-  auto compiled_version = cudnnCompiledVersion();
-  auto runtime_version = cudnnRuntimeVersion();
-  auto compiled_major = cudnnExtractMajorVersion(compiled_version);
-  auto compiled_minor = cudnnExtractMinorVersion(compiled_version);
-  auto runtime_major = cudnnExtractMajorVersion(runtime_version);
-  auto runtime_minor = cudnnExtractMinorVersion(runtime_version);
-
-  bool version_match = (compiled_major == runtime_major) && (compiled_minor == runtime_minor);
+  // Major, minor and patch versions must all match
+  bool version_match = cudnnCompiledVersion() == cudnnRuntimeVersion();
   CAFFE_ENFORCE(version_match,
                 "cuDNN compiled (", cudnnCompiledVersion(), ") and"
                 "runtime (", cudnnRuntimeVersion(), ") versions mismatch");

--- a/caffe2/core/context_gpu.cu
+++ b/caffe2/core/context_gpu.cu
@@ -10,6 +10,7 @@
 #endif // CAFFE2_USE_CNMEM
 
 #include "caffe2/core/asan.h"
+#include "caffe2/core/common_cudnn.h"
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/core/init.h"
 #include "caffe2/core/logging.h"
@@ -139,6 +140,9 @@ static void Caffe2InitializeCuda() {
     TypeMeta::Id<Tensor<CUDAContext>>(),
     GetTensorShape<CUDAContext>
   );
+
+  // Check the versions of cuDNN that were compiled and linked with are compatible
+  CheckCuDNNVersions();
 }
 
 #ifdef CAFFE2_USE_CNMEM

--- a/caffe2/operators/conv_op_cudnn.cc
+++ b/caffe2/operators/conv_op_cudnn.cc
@@ -56,9 +56,12 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
         pad_l_ == pad_r_,
         "The current padding scheme leads to unequal padding on the left "
         "and right, which is not supported by cudnn.");
+    // dilated convolution supported by some algorithms in cuDNN v6
+#if !(CUDNN_VERSION_MIN(6,0,0))
     OPERATOR_NEEDS_FEATURE(
         dilation_h_ == 1 && dilation_w_ == 1,
         "The cudnn convolution does not support dilation yet.");
+#endif
 
     CUDNN_CHECK(cudnnCreateTensorDescriptor(&bottom_desc_));
     CUDNN_CHECK(cudnnCreateFilterDescriptor(&filter_desc_));
@@ -272,7 +275,7 @@ bool CudnnConvOp<T>::RunOnDevice() {
     // Set the convolution descriptor
 #if CUDNN_VERSION_MIN(6,0,0)
     CUDNN_CHECK(cudnnSetConvolution2dDescriptor(
-          conv_desc_, pad_t_, pad_l_, stride_h_, stride_w_, 1, 1,
+          conv_desc_, pad_t_, pad_l_, stride_h_, stride_w_, dilation_h_, dilation_w_,
           CUDNN_CROSS_CORRELATION, cudnnTypeWrapper<T>::type));
 #else
     CUDNN_CHECK(cudnnSetConvolution2dDescriptor(
@@ -458,7 +461,7 @@ bool CudnnConvGradientOp<T>::RunOnDevice() {
     // Set the convolution descriptor
 #if CUDNN_VERSION_MIN(6,0,0)
     CUDNN_CHECK(cudnnSetConvolution2dDescriptor(
-          conv_desc_, pad_t_, pad_l_, stride_h_, stride_w_, 1, 1,
+          conv_desc_, pad_t_, pad_l_, stride_h_, stride_w_, dilation_h_, dilation_w_,
           CUDNN_CROSS_CORRELATION, cudnnTypeWrapper<T>::type));
 #else
     CUDNN_CHECK(cudnnSetConvolution2dDescriptor(

--- a/caffe2/operators/conv_op_cudnn.cc
+++ b/caffe2/operators/conv_op_cudnn.cc
@@ -270,9 +270,15 @@ bool CudnnConvOp<T>::RunOnDevice() {
         H_out,
         W_out));
     // Set the convolution descriptor
+#if CUDNN_VERSION_MIN(6,0,0)
+    CUDNN_CHECK(cudnnSetConvolution2dDescriptor(
+          conv_desc_, pad_t_, pad_l_, stride_h_, stride_w_, 1, 1,
+          CUDNN_CROSS_CORRELATION, cudnnTypeWrapper<T>::type));
+#else
     CUDNN_CHECK(cudnnSetConvolution2dDescriptor(
           conv_desc_, pad_t_, pad_l_, stride_h_, stride_w_, 1, 1,
           CUDNN_CROSS_CORRELATION));
+#endif
     if (deterministic_) {
       algo_ = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM;
     } else if (exhaustive_search_) {
@@ -450,9 +456,15 @@ bool CudnnConvGradientOp<T>::RunOnDevice() {
         H_out,
         W_out));
     // Set the convolution descriptor
+#if CUDNN_VERSION_MIN(6,0,0)
+    CUDNN_CHECK(cudnnSetConvolution2dDescriptor(
+          conv_desc_, pad_t_, pad_l_, stride_h_, stride_w_, 1, 1,
+          CUDNN_CROSS_CORRELATION, cudnnTypeWrapper<T>::type));
+#else
     CUDNN_CHECK(cudnnSetConvolution2dDescriptor(
           conv_desc_, pad_t_, pad_l_, stride_h_, stride_w_, 1, 1,
           CUDNN_CROSS_CORRELATION));
+#endif
     // Set the workspace
 
     size_t bwd_filter_ws_size, bwd_data_ws_size;

--- a/caffe2/operators/conv_transpose_op_cudnn.cc
+++ b/caffe2/operators/conv_transpose_op_cudnn.cc
@@ -228,6 +228,18 @@ bool CudnnConvTransposeOp<T>::RunOnDevice() {
         pad_r_,
         "The current padding scheme leads to unequal padding on the left "
         "and right, which is not supported by cudnn.");
+#if CUDNN_VERSION_MIN(6,0,0)
+    CUDNN_CHECK(cudnnSetConvolution2dDescriptor(
+        conv_desc_,
+        pad_t_,
+        pad_l_,
+        stride_h_,
+        stride_w_,
+        1,
+        1,
+        CUDNN_CROSS_CORRELATION,
+        cudnnTypeWrapper<T>::type));
+#else
     CUDNN_CHECK(cudnnSetConvolution2dDescriptor(
         conv_desc_,
         pad_t_,
@@ -237,6 +249,7 @@ bool CudnnConvTransposeOp<T>::RunOnDevice() {
         1,
         1,
         CUDNN_CROSS_CORRELATION));
+#endif
     if (deterministic_) {
       bwd_data_algo_ = CUDNN_CONVOLUTION_BWD_DATA_ALGO_1;
     } else if (exhaustive_search_) {
@@ -434,6 +447,18 @@ bool CudnnConvTransposeGradientOp<T>::RunOnDevice() {
         pad_r_,
         "The current padding scheme leads to unequal padding on the left "
         "and right, which is not supported by cudnn.");
+#if CUDNN_VERSION_MIN(6,0,0)
+    CUDNN_CHECK(cudnnSetConvolution2dDescriptor(
+        conv_desc_,
+        pad_t_,
+        pad_l_,
+        stride_h_,
+        stride_w_,
+        1,
+        1,
+        CUDNN_CROSS_CORRELATION,
+        cudnnTypeWrapper<T>::type));
+#else
     CUDNN_CHECK(cudnnSetConvolution2dDescriptor(
         conv_desc_,
         pad_t_,
@@ -443,6 +468,7 @@ bool CudnnConvTransposeGradientOp<T>::RunOnDevice() {
         1,
         1,
         CUDNN_CROSS_CORRELATION));
+#endif
     // Set the workspace
 
     size_t bwd_filter_ws_size, fwd_ws_size;

--- a/caffe2/operators/recurrent_op_cudnn.h
+++ b/caffe2/operators/recurrent_op_cudnn.h
@@ -119,7 +119,8 @@ class RecurrentGradientOp : public RecurrentBaseOp<T> {
       GRAD_HIDDEN_INPUT,
       GRAD_CELL_INPUT,
       GRAD_WEIGHT,
-      DROPOUT_STATES);
+      DROPOUT_STATES,
+      RNN_SCRATCH_OUT);
 };
 
 template <typename T>

--- a/caffe2/python/pybind_state_gpu.cc
+++ b/caffe2/python/pybind_state_gpu.cc
@@ -10,6 +10,7 @@
 #include <pybind11/stl.h>
 
 #include "caffe2/core/context_gpu.h"
+#include "caffe2/core/common_cudnn.h"
 #include "caffe2/operators/operator_fallback_gpu.h"
 
 namespace caffe2 {
@@ -27,6 +28,7 @@ void addCUDAGlobalMethods(py::module& m) {
   m.def("num_cuda_devices", &NumCudaDevices);
   m.def("set_default_gpu_id", &SetDefaultGPUID);
   m.def("get_default_gpu_id", &GetDefaultGPUID);
+  m.def("get_cudnn_version", &cudnnCompiledVersion);
   m.def("get_cuda_peer_access_pattern", []() {
     std::vector<std::vector<bool>> pattern;
     CAFFE_ENFORCE(caffe2::GetCudaPeerAccessPattern(&pattern));

--- a/caffe2/python/workspace.py
+++ b/caffe2/python/workspace.py
@@ -34,6 +34,7 @@ if has_gpu_support:
     NumCudaDevices = C.num_cuda_devices
     SetDefaultGPUID = C.set_default_gpu_id
     GetDefaultGPUID = C.get_default_gpu_id
+    GetCuDNNVersion = C.get_cudnn_version
 
     def GetCudaPeerAccessPattern():
         return np.asarray(C.get_cuda_peer_access_pattern())


### PR DESCRIPTION
Add cudnn v6 support, including testing support for dilated convolution.
Add a check to ensure that the versions of cuDNN used to compile Caffe2 and run it are compatible 