### PR TITLE
Prevent concurrent memory and NCCL ops

### DIFF
--- a/caffe2/core/context_gpu.cu
+++ b/caffe2/core/context_gpu.cu
@@ -63,12 +63,6 @@ CudaMemoryPoolType GetCudaMemoryPoolType() {
   return g_cuda_memory_pool_type;
 }
 
-// shared mutex to lock out alloc / free during NCCL launches
-static std::mutex& gCUDAContextMutex() {
-  static std::mutex m;
-  return m;
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 // A wrapper to allow us to lazily initialize all cuda environments that Caffe
 // uses. This gets done the first time a caffe2::CUDAContext::New() gets called
@@ -274,8 +268,10 @@ CUDAContext::CUDAContext(const DeviceOption& option)
   DCHECK_EQ(option.device_type(), CUDA);
 }
 
+// shared mutex to lock out alloc / free during NCCL launches
 std::mutex& CUDAContext::mutex() {
-  return gCUDAContextMutex();
+  static std::mutex m;
+  return m;
 }
 
 void* CUDAContext::New(size_t nbytes) {

--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -2,6 +2,7 @@
 #define CAFFE2_CORE_CONTEXT_GPU_H_
 
 #include <ctime>
+#include <mutex>
 
 #include "caffe2/core/common_gpu.h"
 #include "caffe2/core/context.h"
@@ -176,6 +177,10 @@ class CUDAContext final {
   static void* New(size_t nbytes);
 
   static void Delete(void* data);
+
+
+  // Get the read-write mutex
+  static std::mutex& mutex();
 
   template <class SrcContext, class DstContext>
   inline void CopyBytes(size_t nbytes, const void* src, void* dst) {

--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -179,7 +179,9 @@ class CUDAContext final {
   static void Delete(void* data);
 
 
-  // Get the read-write mutex
+  // Get a mutex to lock out cudaMalloc / cudaFree calls when
+  // NCCL kernels are being launched. Should remove threat of
+  // deadlocks
   static std::mutex& mutex();
 
   template <class SrcContext, class DstContext>


### PR DESCRIPTION
Use a mutex to prevent simultaneous memory alloc / free and NCCL ops