### PR TITLE
Fix git URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Caffe2 is released under the [BSD 2-Clause license](https://github.com/Yangqing/
 
 [![Build Status](https://travis-ci.org/caffe2/caffe2.svg?branch=master)](https://travis-ci.org/caffe2/caffe2)
 
-    git clone --recursive https://github.com/bwasti/caffe2.git
+    git clone --recursive https://github.com/caffe2/caffe2.git
     cd caffe2
     
 #### OS X


### PR DESCRIPTION
URL was changed in https://github.com/caffe2/caffe2/commit/f5169438411737b49265b2e319c2ef588428c46b