### PR TITLE
Strip prefix of strip_prefix in blob names before save and load.

### DIFF
--- a/caffe2/operators/load_save_op.cc
+++ b/caffe2/operators/load_save_op.cc
@@ -32,6 +32,12 @@ DBReader to load from, and we ignore the db and db_type arguments.
         "absolute_path",
         "(int, default 0) if set, use the db path directly and do not prepend "
         "the current root folder of the workspace.")
+     .Arg(
+         "strip_prefix",
+         "(string, default=\"\") characters in the provided blob "
+         " names that match strip_prefix will be removed prior to saving."
+         " Also, characters that precede strip_prefix will be removed. Useful "
+         " for removing device scope from blob names.")
     .Arg("db", "(string) the path to the db to load.")
     .Arg("db_type", "(string) the type of the db.")
     .Arg(
@@ -56,11 +62,12 @@ db specified by the arguments.
         "absolute_path",
         "(int, default 0) if set, use the db path directly and do not prepend "
         "the current root folder of the workspace.")
-    .Arg(
-        "strip_regex",
-        "(string, default=\"\") if set, characters in the provided blob "
-        " names that match the regex will be removed prior to saving. Useful "
-        " for removing device scope from blob names.")
+     .Arg(
+         "strip_prefix",
+         "(string, default=\"\") characters in the provided blob "
+         " names that match strip_prefix will be removed prior to saving."
+         " Also, characters that precede strip_prefix will be removed. Useful "
+         " for removing device scope from blob names.")
     .Arg(
         "blob_name_overrides",
         "(list of strings) if set, used instead of original "

--- a/caffe2/python/load_save_test.py
+++ b/caffe2/python/load_save_test.py
@@ -165,7 +165,7 @@ class TestLoadSave(TestLoadSaveBase):
                     core.CreateOperator(
                         "Save", original_names, [],
                         absolute_path=1,
-                        strip_regex='.temp',
+                        strip_prefix='.temp',
                         blob_name_overrides=new_names,
                         db=os.path.join(tmp_folder, "db"),
                         db_type=self._db_type


### PR DESCRIPTION
- Replaces strip_regex implementation in SaveOp. It deletes the prefix of blob names upto a given substring.
- Adds the same functionality to LoadOp. Needed for loading checkpoints that are stored using the strip_prefix feature.
