### PR TITLE
Use MDB_NOLOCK.

### DIFF
--- a/caffe2/db/lmdb.cc
+++ b/caffe2/db/lmdb.cc
@@ -143,7 +143,7 @@ LMDB::LMDB(const string& source, Mode mode) : DB(source, mode) {
   }
   int flags = 0;
   if (mode == READ) {
-    flags = MDB_RDONLY | MDB_NOTLS;
+    flags = MDB_RDONLY | MDB_NOTLS | MDB_NOLOCK;
   }
   MDB_CHECK(mdb_env_open(mdb_env_, source.c_str(), flags, 0664));
   VLOG(1) << "Opened lmdb " << source;


### PR DESCRIPTION
- Do not lock LMDB.
- This avoids failure when multiple readers try to read the same LMDB.
- This also can cause a race if a process tries to write into the LMDB that is being read by another process. Because this commit removes the locking mechanism. 
- Note that we already use MDB_RDONLY when reading LMDB.
- It seems that LMDB does not provide any method of locking the database to avoid writes while allowing reads.