### PR TITLE
update PYTHONPATH in ipython launcher

### DIFF
--- a/caffe2/python/tutorial/start_ipython_notebook.sh
+++ b/caffe2/python/tutorial/start_ipython_notebook.sh
@@ -3,7 +3,7 @@
 # to access it.
 
 # Use the following command for very verbose prints.
-# GLOG_logtostderr=1 GLOG_v=1 PYTHONPATH=../../../gen:$PYTHONPATH ipython notebook --ip='*'
+# GLOG_logtostderr=1 GLOG_v=1 PYTHONPATH=../../../build:$PYTHONPATH ipython notebook --ip='*'
 
 # Use the following command for a normal run.
-PYTHONPATH=../../../gen:$PYTHONPATH ipython notebook --ip='*'
+PYTHONPATH=../../../build:$PYTHONPATH ipython notebook --ip='*'


### PR DESCRIPTION
I followed installation [instructions](https://github.com/caffe2/caffe2/blob/master/README.md#os-x) for OS-X. Works perfect. After installation instructions, ipython notebook works with the updated PYTHONPATH.