### PR TITLE
windows build: getting there

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,9 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "binaries")
 
 # ---[ Build flags
-if (WIN32)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
+  message(STATUS "Adding no warning argument to the compiler")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /w")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "binaries")
 
 # ---[ Build flags
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
+  message(WARNING "Develop note: when all errors are addressed, turn on warning.")
   message(STATUS "Adding no warning argument to the compiler")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /w")
 else()

--- a/caffe2/core/common.h
+++ b/caffe2/core/common.h
@@ -15,6 +15,10 @@
 #include <TargetConditionals.h>
 #endif
 
+#if defined(_MSC_VER)
+#include <io.h>
+#endif
+
 namespace caffe2 {
 
 // Data type for caffe2 Index/Size. We use size_t to be safe here as well as for

--- a/caffe2/core/common.h
+++ b/caffe2/core/common.h
@@ -17,6 +17,8 @@
 
 #if defined(_MSC_VER)
 #include <io.h>
+#else
+#include <unistd.h>
 #endif
 
 namespace caffe2 {

--- a/caffe2/core/common_omp.h
+++ b/caffe2/core/common_omp.h
@@ -6,7 +6,9 @@
 #endif // _OPENMP
 
 // Macro to abstract out basic omp parallel loops
-#ifdef _OPENMP
+// Note(jiayq): it seems that VS2015 does not support _Pragma yet, so we
+// disable it here.
+#if defined(_OPENMP) && !defined(_MSC_VER)
 #define CAFFE2_OMP_PARALLEL_FOR() _Pragma("omp parallel for")
 // _Pragma( STRINGIFY( CONCATENATE( omp parallel for ) ) )
 #else

--- a/caffe2/core/common_omp.h
+++ b/caffe2/core/common_omp.h
@@ -8,9 +8,12 @@
 // Macro to abstract out basic omp parallel loops
 // Note(jiayq): it seems that VS2015 does not support _Pragma yet, so we
 // disable it here.
-#if defined(_OPENMP) && !defined(_MSC_VER)
+#ifdef _OPENMP
+#if defined(_MSC_VER)
+#define CAFFE2_OMP_PARALLEL_FOR() __pragma("omp parallel for")
+#else
 #define CAFFE2_OMP_PARALLEL_FOR() _Pragma("omp parallel for")
-// _Pragma( STRINGIFY( CONCATENATE( omp parallel for ) ) )
+#endif // _MSC_VER
 #else
 // empty macro, do nothing
 #define CAFFE2_OMP_PARALLEL_FOR()

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -35,15 +35,15 @@ class OperatorBase {
   // argument name to a specific type of argument that we are trying to access.
   template <typename T>
   inline T GetSingleArgument(const string& name, const T& default_value) const {
-    return arg_helper_.GetSingleArgument<T>(name, default_value);
+    return arg_helper_.template GetSingleArgument<T>(name, default_value);
   }
   template <typename T>
   inline bool HasSingleArgumentOfType(const string& name) const {
-    return arg_helper_.HasSingleArgumentOfType<T>(name);
+    return arg_helper_.template HasSingleArgumentOfType<T>(name);
   }
   template <typename T>
   inline vector<T> GetRepeatedArgument(const string& name) const {
-    return arg_helper_.GetRepeatedArgument<T>(name);
+    return arg_helper_.template GetRepeatedArgument<T>(name);
   }
 
   // Get the inputs and outputs as specific types.

--- a/caffe2/operators/exp_op.cc
+++ b/caffe2/operators/exp_op.cc
@@ -1,6 +1,5 @@
-#include <cmath>
-
 #include "caffe2/operators/elementwise_op.h"
+#include "caffe2/utils/math.h"
 
 namespace caffe2 {
 
@@ -8,7 +7,7 @@ struct ExpCPUFunctor {
   template <typename T>
   inline void
   operator()(const int n, const T* x, T* y, CPUContext* device_context) {
-    std::transform(x, x + n, y, exp);
+    math::Exp<T, CPUContext>(n, x, y, device_context);
   }
 };
 

--- a/caffe2/operators/extend_tensor_op.cc
+++ b/caffe2/operators/extend_tensor_op.cc
@@ -35,7 +35,7 @@ class ExtendTensorOp final : public Operator<Context> {
 
     auto extendSize = (TIndex)maxElem - oldSize;
     if (extendSize > 0) {
-      new_tensor->template Extend(extendSize, growthPct_, &context_);
+      new_tensor->Extend(extendSize, growthPct_, &context_);
       if (!new_tensor->meta().ctor()) {
         auto oldSizeBytes = oldSize * new_tensor->meta().itemsize();
         auto* dst = (char*)new_tensor->raw_mutable_data() + oldSizeBytes;

--- a/caffe2/operators/log_op.cc
+++ b/caffe2/operators/log_op.cc
@@ -1,6 +1,6 @@
-#include <cmath>
-
 #include "caffe2/operators/elementwise_op.h"
+#include "caffe2/utils/math.h"
+
 
 namespace caffe2 {
 
@@ -8,7 +8,7 @@ struct LogCPUFunctor {
   template <typename T>
   inline void
   operator()(const int n, const T* x, T* y, CPUContext* device_context) {
-    std::transform(x, x + n, y, log);
+    math::Log<T, CPUContext>(n, x, y, device_context);
   }
 };
 

--- a/caffe2/operators/text_file_reader.cc
+++ b/caffe2/operators/text_file_reader.cc
@@ -102,7 +102,10 @@ class TextFileReaderReadOp : public Operator<CPUContext> {
             to_string(instance->fieldTypes.size()) + " got " +
             to_string(numFields));
 
-    char* datas[numFields];
+    // char* datas[numFields];
+    // MSVC does not allow using const int, so we will need to dynamically allocate
+    // it.
+    std::vector<char*> datas(numFields);
     for (int i = 0; i < numFields; ++i) {
       Output(i)->Resize(batchSize_);
       datas[i] = (char*)Output(i)->raw_mutable_data(instance->fieldMetas[i]);

--- a/caffe2/operators/text_file_reader_utils.cc
+++ b/caffe2/operators/text_file_reader_utils.cc
@@ -1,7 +1,6 @@
 #include "caffe2/operators/text_file_reader_utils.h"
 
 #include <fcntl.h>
-#include <unistd.h>
 #include <cstring>
 #include <sstream>
 

--- a/caffe2/operators/text_file_reader_utils.h
+++ b/caffe2/operators/text_file_reader_utils.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include "caffe2/core/common.h"
+
 namespace caffe2 {
 
 struct Token {

--- a/caffe2/utils/math_cpu.cc
+++ b/caffe2/utils/math_cpu.cc
@@ -11,7 +11,6 @@
 //     platforms, it allows one to quickly port Caffe2 to different platforms
 //     where BLAS may not be present.
 
-#include <unistd.h>
 #include <atomic>
 #include <chrono>
 #include <random>
@@ -25,6 +24,10 @@
 #include "caffe2/core/context.h"
 #include "Eigen/Core"
 #include "Eigen/Dense"
+
+#if defined(_MSC_VER)
+#include <process.h>
+#endif
 
 namespace caffe2 {
 namespace math {

--- a/caffe2/utils/proto_utils.cc
+++ b/caffe2/utils/proto_utils.cc
@@ -1,7 +1,6 @@
 #include "caffe2/utils/proto_utils.h"
 
 #include <fcntl.h>
-#include <unistd.h>
 #include <cerrno>
 #include <fstream>
 

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -35,3 +35,9 @@ else()
   message(STATUS "This compiler does not have builtin_cpu_supports feature.")
   add_definitions(-DCAFFE2_NO_BUILTIN_CPU_SUPPORTS)
 endif()
+
+# ---[ If we are using msvc, set no warning flags
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
+  message(STATUS "Adding no warning argument to the compiler")
+  
+endif()


### PR DESCRIPTION
This clears up a bunch of windows build errors, but there are still 12 errors mostly relating to
- template keywords
- initializer list
- pthreadpool

that are not readily available on windows. Also, cuda build is being disabled right now.

Current error can be found here: https://ci.appveyor.com/project/Yangqing/caffe2-w2ucm