### PR TITLE
Convnet benchmark cudnn_ws

### DIFF
--- a/caffe2/python/convnet_benchmarks.py
+++ b/caffe2/python/convnet_benchmarks.py
@@ -591,7 +591,6 @@ def GetArgumentParser():
     parser.add_argument(
         "--cudnn_ws",
         type=int,
-        default=-1,
         help="The cudnn workspace size."
     )
     parser.add_argument(
@@ -641,8 +640,7 @@ def GetArgumentParser():
 if __name__ == '__main__':
     args = GetArgumentParser().parse_args()
     if (
-        not args.batch_size or not args.model or not args.order or
-        not args.cudnn_ws
+        not args.batch_size or not args.model or not args.order
     ):
         GetArgumentParser().print_help()
 

--- a/caffe2/python/convnet_benchmarks.py
+++ b/caffe2/python/convnet_benchmarks.py
@@ -62,7 +62,7 @@ from caffe2.python import cnn, workspace
 
 
 def MLP(order, cudnn_ws):
-    model = cnn.CNNModelHelper(ws_nbytes_limit=cudnn_ws)
+    model = cnn.CNNModelHelper()
     d = 256
     depth = 20
     width = 3

--- a/caffe2/python/convnet_benchmarks.py
+++ b/caffe2/python/convnet_benchmarks.py
@@ -643,18 +643,18 @@ if __name__ == '__main__':
         not args.batch_size or not args.model or not args.order
     ):
         GetArgumentParser().print_help()
+    else:
+        workspace.GlobalInit(
+            ['caffe2', '--caffe2_log_level=0'] +
+            (['--caffe2_use_nvtx'] if args.use_nvtx else []) +
+            (['--caffe2_htrace_span_log_path=' + args.htrace_span_log_path]
+                if args.htrace_span_log_path else []))
 
-    workspace.GlobalInit(
-        ['caffe2', '--caffe2_log_level=0'] +
-        (['--caffe2_use_nvtx'] if args.use_nvtx else []) +
-        (['--caffe2_htrace_span_log_path=' + args.htrace_span_log_path]
-            if args.htrace_span_log_path else []))
-
-    model_map = {
-        'AlexNet': AlexNet,
-        'OverFeat': OverFeat,
-        'VGGA': VGGA,
-        'Inception': Inception,
-        'MLP': MLP,
-    }
-    Benchmark(model_map[args.model], args)
+        model_map = {
+            'AlexNet': AlexNet,
+            'OverFeat': OverFeat,
+            'VGGA': VGGA,
+            'Inception': Inception,
+            'MLP': MLP,
+        }
+        Benchmark(model_map[args.model], args)


### PR DESCRIPTION
- Do not set default for cudnn_ws. Will use the default set by cuDNN ops.
- Do not use cudnn_ws for MLP.
- Do not run the benchmark if the required args are not set. Previously tried to run and errors out.