### PR TITLE
Add Conv register to MKL operator

### DIFF
--- a/caffe2/mkl/operators/conv_op_mkldnn.cc
+++ b/caffe2/mkl/operators/conv_op_mkldnn.cc
@@ -120,6 +120,8 @@ class ConvMKLDNNOp final : public ConvPoolOpBase<CPUContext> {
 
 REGISTER_CPU_OPERATOR_WITH_ENGINE(Conv, MKLDNN, mkl::ConvMKLDNNOp<float>);
 
+REGISTER_MKL_OPERATOR(Conv, mkl::ConvMKLDNNOp<float>);
+
 }  // namespace caffe2
 
 #endif // CAFFE2_HAS_MKL_DNN


### PR DESCRIPTION
If we want to use Conv op of MKLDNN with current Caffe2, we must add `engine: "MKLDNN"`  in every conv op message. After this register, we can use Conv op of MKLDNN just by adding one `device_option { device_type: 2 }` message in NetDef.