### PR TITLE
Add _aligned_free if defined _MSC_VER in context.h

### DIFF
--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -55,7 +55,11 @@ struct DefaultCPUAllocator final : CPUAllocator {
     memset(data, 0, nbytes);
     return data;
   }
+#ifdef _MSC_VER
+  void Delete(void* data) override { _aligned_free(data); }
+#else
   void Delete(void* data) override { free(data); }
+#endif
 };
 
 // Get the CPU Alloctor.


### PR DESCRIPTION
In windows, it is necessary to use `_aligned_free` instead of `free` when using `_aligned_malloc` before.