### PR TITLE
Fix gflags build

### DIFF
--- a/caffe2/core/flags.h
+++ b/caffe2/core/flags.h
@@ -58,6 +58,12 @@ bool CommandLineFlagsHasBeenParsed();
 
 #include <gflags/gflags.h>
 
+// gflags before 2.0 uses namespace google and after 2.1 uses namespace gflags.
+// Using GFLAGS_GFLAGS_H_ to capture this change.
+#ifndef GFLAGS_GFLAGS_H_
+namespace gflags = google;
+#endif  // GFLAGS_GFLAGS_H_
+
 #define CAFFE2_GFLAGS_DEF_WRAPPER(type, name, default_value, help_str)         \
   DEFINE_##type(name, default_value, help_str);                                \
   namespace caffe2 {                                                           \


### PR DESCRIPTION
Our internal update of gflags in https://github.com/caffe2/caffe2/commit/b0e325ce69aeb49c28124b189be68aea83a656ef called for this change.