### PR TITLE
[tests] Skip test if libfb not present

### DIFF
--- a/caffe2/contrib/torch/torch_ops_test.py
+++ b/caffe2/contrib/torch/torch_ops_test.py
@@ -10,7 +10,14 @@ from hypothesis import given
 import hypothesis.strategies as st
 import numpy as np
 import os
-from libfb import parutil
+import unittest
+
+try:
+    from libfb import parutil
+except ImportError as e:
+    # If libfb not found, skip all tests in this file
+    raise unittest.SkipTest(str(e))
+
 core.GlobalInit(["python", "--caffe2_log_level=0"])
 
 dyndep.InitOpsLibrary('@/caffe2/caffe2/contrib/torch:torch_ops')


### PR DESCRIPTION
Allows `nose` or `pytest` to collect all tests.
```sh
$ cd build
$ nosetests --collect-only
..............................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 222 tests in 0.430s

OK
```