### PR TITLE
Allow test discovery in caffe2/python/

### DIFF
--- a/caffe2/python/caffe_translator_test.py
+++ b/caffe2/python/caffe_translator_test.py
@@ -16,8 +16,6 @@ import unittest
 @unittest.skipIf(not os.path.exists('data/testdata/caffe_translator'),
                  'No testdata existing for the caffe translator test. Exiting.')
 def setUpModule():
-    raise RuntimeError
-
     # We will do all the computation stuff in the global space.
     caffenet = caffe_pb2.NetParameter()
     caffenet_pretrained = caffe_pb2.NetParameter()

--- a/caffe2/python/caffe_translator_test.py
+++ b/caffe2/python/caffe_translator_test.py
@@ -13,6 +13,39 @@ import sys
 import unittest
 
 
+@unittest.skipIf(not os.path.exists('data/testdata/caffe_translator'),
+                 'No testdata existing for the caffe translator test. Exiting.')
+def setUpModule():
+    raise RuntimeError
+
+    # We will do all the computation stuff in the global space.
+    caffenet = caffe_pb2.NetParameter()
+    caffenet_pretrained = caffe_pb2.NetParameter()
+    text_format.Merge(
+        open('data/testdata/caffe_translator/deploy.prototxt').read(), caffenet
+    )
+    caffenet_pretrained.ParseFromString(
+        open(
+            'data/testdata/caffe_translator/bvlc_reference_caffenet.caffemodel')
+        .read()
+    )
+    net, pretrained_params = caffe_translator.TranslateModel(
+        caffenet, caffenet_pretrained, is_test=True
+    )
+    with open('data/testdata/caffe_translator/'
+              'bvlc_reference_caffenet.translatedmodel',
+              'w') as fid:
+        fid.write(str(net))
+    for param in pretrained_params.protos:
+        workspace.FeedBlob(param.name, utils.Caffe2TensorToNumpyArray(param))
+    # Let's also feed in the data from the Caffe test code.
+    data = np.load('data/testdata/caffe_translator/data_dump.npy').astype(
+        np.float32)
+    workspace.FeedBlob('data', data)
+    # Actually running the test.
+    workspace.RunNetOnce(net.SerializeToString())
+
+
 class TestNumericalEquivalence(test_util.TestCase):
     def testBlobs(self):
         names = [
@@ -41,33 +74,4 @@ if __name__ == '__main__':
             'Pass in any argument to have the test run for you.'
         )
         sys.exit(0)
-    if not os.path.exists('data/testdata/caffe_translator'):
-        print('No testdata existing for the caffe translator test. Exiting.')
-        sys.exit(0)
-    # We will do all the computation stuff in the global space.
-    caffenet = caffe_pb2.NetParameter()
-    caffenet_pretrained = caffe_pb2.NetParameter()
-    text_format.Merge(
-        open('data/testdata/caffe_translator/deploy.prototxt').read(), caffenet
-    )
-    caffenet_pretrained.ParseFromString(
-        open(
-            'data/testdata/caffe_translator/bvlc_reference_caffenet.caffemodel')
-        .read()
-    )
-    net, pretrained_params = caffe_translator.TranslateModel(
-        caffenet, caffenet_pretrained, is_test=True
-    )
-    with open('data/testdata/caffe_translator/'
-              'bvlc_reference_caffenet.translatedmodel',
-              'w') as fid:
-        fid.write(str(net))
-    for param in pretrained_params.protos:
-        workspace.FeedBlob(param.name, utils.Caffe2TensorToNumpyArray(param))
-    # Let's also feed in the data from the Caffe test code.
-    data = np.load('data/testdata/caffe_translator/data_dump.npy').astype(
-        np.float32)
-    workspace.FeedBlob('data', data)
-    # Actually running the test.
-    workspace.RunNetOnce(net.SerializeToString())
     unittest.main()

--- a/caffe2/python/net_builder_test.py
+++ b/caffe2/python/net_builder_test.py
@@ -11,7 +11,7 @@ from caffe2.python.session import LocalSession
 import unittest
 
 
-def test_loop():
+def _test_loop():
     x = ops.Const(5)
     y = ops.Const(0)
     with ops.loop():
@@ -21,20 +21,20 @@ def test_loop():
     return y
 
 
-def test_inner_stop(x):
+def _test_inner_stop(x):
     ops.stop_if(ops.LT([x, ops.Const(5)]))
 
 
-def test_outer():
+def _test_outer():
     x = ops.Const(10)
     # test stop_if(False)
     with ops.stop_guard() as g1:
-        test_inner_stop(x)
+        _test_inner_stop(x)
 
     # test stop_if(True)
     y = ops.Const(3)
     with ops.stop_guard() as g2:
-        test_inner_stop(y)
+        _test_inner_stop(y)
 
     # test no stop
     with ops.stop_guard() as g4:
@@ -48,7 +48,7 @@ def test_outer():
         g1.has_stopped(), g2.has_stopped(), g3.has_stopped(), g4.has_stopped())
 
 
-def test_if(x):
+def _test_if(x):
     y = ops.Const(1)
     with ops.If(ops.GT([x, ops.Const(50)])):
         ops.Const(2, blob_out=y)
@@ -62,10 +62,10 @@ def test_if(x):
 class TestNetBuilder(unittest.TestCase):
     def test_ops(self):
         with NetBuilder() as nb:
-            y = test_loop()
-            z, w, a, b = test_outer()
-            p = test_if(ops.Const(75))
-            q = test_if(ops.Const(25))
+            y = _test_loop()
+            z, w, a, b = _test_outer()
+            p = _test_if(ops.Const(75))
+            q = _test_if(ops.Const(25))
         plan = Plan('name')
         plan.AddStep(to_execution_step(nb))
         ws = workspace.C.Workspace()

--- a/caffe2/python/operator_test/reshape_ops_test.py
+++ b/caffe2/python/operator_test/reshape_ops_test.py
@@ -27,36 +27,36 @@ class TestLengthsToShapeOps(TestCase):
                  workspace.FetchBlob('res')).all())
 
     def test_basic_reshape(self):
-        test_reshape(old_shape=(4, 2, 1), new_shape=(2, 4))
-        test_reshape(old_shape=(4, 2, 1), new_shape=(2, 4), arg_shape=False)
+        _test_reshape(old_shape=(4, 2, 1), new_shape=(2, 4))
+        _test_reshape(old_shape=(4, 2, 1), new_shape=(2, 4), arg_shape=False)
 
     def test_missing_dim(self):
-        test_reshape(old_shape=(4, 2, 1), new_shape=(-1, 8))
-        test_reshape(old_shape=(4, 2, 1), new_shape=(-1, 8), arg_shape=False)
+        _test_reshape(old_shape=(4, 2, 1), new_shape=(-1, 8))
+        _test_reshape(old_shape=(4, 2, 1), new_shape=(-1, 8), arg_shape=False)
 
     def test_in_place(self):
-        test_reshape(old_shape=(4, 2, 1), new_shape=(-1, 8), in_place=True)
-        test_reshape(old_shape=(4, 2, 1), new_shape=(-1, 8),
+        _test_reshape(old_shape=(4, 2, 1), new_shape=(-1, 8), in_place=True)
+        _test_reshape(old_shape=(4, 2, 1), new_shape=(-1, 8),
                      in_place=True, arg_shape=False)
 
     def test_zero_dim(self):
-        test_reshape(old_shape=(4, 2, 1), new_shape=(0, 0, 0),
+        _test_reshape(old_shape=(4, 2, 1), new_shape=(0, 0, 0),
                      expected_shape=(4, 2, 1))
-        test_reshape(old_shape=(4, 2, 1), new_shape=(0, 0, 0),
+        _test_reshape(old_shape=(4, 2, 1), new_shape=(0, 0, 0),
                      expected_shape=(4, 2, 1), arg_shape=False)
-        test_reshape(old_shape=(4, 2, 1), new_shape=(0, 2, 1),
+        _test_reshape(old_shape=(4, 2, 1), new_shape=(0, 2, 1),
                      expected_shape=(4, 2, 1))
-        test_reshape(old_shape=(4, 2, 1), new_shape=(0, 2, 1),
+        _test_reshape(old_shape=(4, 2, 1), new_shape=(0, 2, 1),
                      expected_shape=(4, 2, 1), arg_shape=False)
 
     def test_zero_dim_and_missing_dim(self):
-        test_reshape(old_shape=(4, 2, 1), new_shape=(0, -1, 0),
+        _test_reshape(old_shape=(4, 2, 1), new_shape=(0, -1, 0),
                      expected_shape=(4, 2, 1))
-        test_reshape(old_shape=(4, 2, 1), new_shape=(0, -1, 0),
+        _test_reshape(old_shape=(4, 2, 1), new_shape=(0, -1, 0),
                      expected_shape=(4, 2, 1), arg_shape=False)
-        test_reshape(old_shape=(4, 3, 2), new_shape=(-1, 0),
+        _test_reshape(old_shape=(4, 3, 2), new_shape=(-1, 0),
                      expected_shape=(8, 3))
-        test_reshape(old_shape=(4, 3, 2), new_shape=(-1, 0),
+        _test_reshape(old_shape=(4, 3, 2), new_shape=(-1, 0),
                      expected_shape=(8, 3), arg_shape=False)
 
     def test_backprop(self):
@@ -105,7 +105,7 @@ class TestLengthsToShapeOps(TestCase):
         workspace.RunNet(net)
 
 
-def test_reshape(old_shape, new_shape, expected_shape=None, arg_shape=True,
+def _test_reshape(old_shape, new_shape, expected_shape=None, arg_shape=True,
                  in_place=False):
     devices = [core.DeviceOption(caffe2_pb2.CPU, 0)]
     if workspace.NumCudaDevices() > 0:

--- a/caffe2/python/operator_test/segment_ops_test.py
+++ b/caffe2/python/operator_test/segment_ops_test.py
@@ -37,7 +37,7 @@ class TesterBase:
         ]
         return self.unsplit(data.shape[1:], segment_grads, segment_ids)
 
-    def test(self, prefix, input_strategy, refs, **kwargs):
+    def _test(self, prefix, input_strategy, refs, **kwargs):
         tester = self
         operator_args = kwargs.pop('operator_args', {})
         threshold = kwargs.pop('threshold', 1e-4)
@@ -247,7 +247,7 @@ REFERENCES_SORTED = [
 
 class TestSegmentOps(hu.HypothesisTestCase):
     def test_sorted_segment_ops(self):
-        SegmentsTester().test(
+        SegmentsTester()._test(
             'SortedSegment',
             hu.segmented_tensor(
                 dtype=np.float32,
@@ -258,7 +258,7 @@ class TestSegmentOps(hu.HypothesisTestCase):
         )(self)
 
     def test_unsorted_segment_ops(self):
-        SegmentsTester().test(
+        SegmentsTester()._test(
             'UnsortedSegment',
             hu.segmented_tensor(
                 dtype=np.float32,
@@ -269,7 +269,7 @@ class TestSegmentOps(hu.HypothesisTestCase):
         )(self)
 
     def test_sparse_sorted_segment_ops(self):
-        SegmentsTester().test(
+        SegmentsTester()._test(
             'SparseSortedSegment',
             hu.sparse_segmented_tensor(
                 dtype=np.float32,
@@ -280,7 +280,7 @@ class TestSegmentOps(hu.HypothesisTestCase):
         )(self)
 
     def test_sparse_unsorted_segment_ops(self):
-        SegmentsTester().test(
+        SegmentsTester()._test(
             'SparseUnsortedSegment',
             hu.sparse_segmented_tensor(
                 dtype=np.float32,
@@ -291,7 +291,7 @@ class TestSegmentOps(hu.HypothesisTestCase):
         )(self)
 
     def test_lengths_ops(self):
-        LengthsTester().test(
+        LengthsTester()._test(
             'Lengths',
             hu.lengths_tensor(
                 dtype=np.float32,
@@ -303,7 +303,7 @@ class TestSegmentOps(hu.HypothesisTestCase):
         )(self)
 
     def test_sparse_lengths_ops(self):
-        LengthsTester().test(
+        LengthsTester()._test(
             'SparseLengths',
             hu.sparse_lengths_tensor(
                 dtype=np.float32,

--- a/caffe2/python/optimizer_test.py
+++ b/caffe2/python/optimizer_test.py
@@ -2,26 +2,26 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from caffe2.python.optimizer import build_sgd, build_ftrl, build_adagrad, build_adam
-from caffe2.python.optimizer_test_util import TestBase
+from caffe2.python.optimizer_test_util import OptimizerTestBase
 from caffe2.python.test_util import TestCase
 
 
-class TestSgd(TestBase, TestCase):
+class TestSgd(OptimizerTestBase, TestCase):
     def build_optimizer(self, model):
         build_sgd(model, base_learning_rate=0.1)
 
 
-class TestFtrl(TestBase, TestCase):
+class TestFtrl(OptimizerTestBase, TestCase):
     def build_optimizer(self, model):
         build_ftrl(
             model, engine=None, alpha=1.0, beta=0.1, lambda1=0.0, lambda2=0.0)
 
 
-class TestAdagrad(TestBase, TestCase):
+class TestAdagrad(OptimizerTestBase, TestCase):
     def build_optimizer(self, model):
         build_adagrad(model, base_learning_rate=1.0)
 
 
-class TestAdam(TestBase, TestCase):
+class TestAdam(OptimizerTestBase, TestCase):
     def build_optimizer(self, model):
         build_adam(model, base_learning_rate=0.1)

--- a/caffe2/python/optimizer_test_util.py
+++ b/caffe2/python/optimizer_test_util.py
@@ -6,7 +6,13 @@ import numpy as np
 from caffe2.python import core, workspace, cnn
 
 
-class TestBase(object):
+class OptimizerTestBase(object):
+    """
+    This is an abstract base class.
+    Don't inherit from unittest.TestCase, and don't name it 'Test*'.
+    Do, however, do these things in classes which inherit from this.
+    """
+
     def testDense(self):
         perfect_model = np.array([2, 6, 5, 0, 1]).astype(np.float32)
         np.random.seed(123)  # make test deterministic


### PR DESCRIPTION
These are all essentially no-op changes which allow for nose-style (or pytest-style) test discovery.

With this patch, you can use any of these methods to discover and run tests under `caffe2/python`:
```
python -m unittest discover caffe2/python/ '*test*.py'
python -m nose caffe2/python/
python -m pytest caffe2/python/
```

Future work:

* Get all of the tests to pass
  * Some seem to be testing operations which don't have GPU implementations
  * I get a segfault unless I set `CUDA_VISIBLE_DEVICES=0`
  * Some tests are flaky
* Allow test discovery throughout the whole project (e.g. the `experiments/` dir)