### PR TITLE
Explicitly pass CXX to NCCL Makefile

### DIFF
--- a/cmake/External/nccl.cmake
+++ b/cmake/External/nccl.cmake
@@ -22,7 +22,7 @@ if (NOT __NCCL_INCLUDED)
       SOURCE_DIR ${nccl_PREFIX}
       BUILD_IN_SOURCE 1
       CONFIGURE_COMMAND ""
-      BUILD_COMMAND make
+      BUILD_COMMAND make "CXX=${CMAKE_CXX_COMPILER}"
       INSTALL_COMMAND ""
       )
 
@@ -36,4 +36,3 @@ if (NOT __NCCL_INCLUDED)
   endif()
 
 endif()
-


### PR DESCRIPTION
Necessary if CXX isn't set when cmake is called. The CXX variable will then be
empty which prevents make from using its own default.