### PR TITLE
[build] Fix for Windows build

### DIFF
--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -117,7 +117,7 @@ class OperatorBase {
 #define USE_SIMPLE_BASE_CTOR_DTOR(name)                                        \
   name(const OperatorDef& operator_def, Workspace* ws)                         \
       : OperatorBase(operator_def, ws) {}                                      \
-  virtual ~name() {}
+  virtual ~name() noexcept {}
 
 // OP_SINGLE_ARG provides a shorter initialization choice for initialization of
 // member variables for the class constructors.
@@ -153,7 +153,7 @@ class Operator : public OperatorBase {
     // constructors will run on that device.
     context_.SwitchToDevice(0);
   }
-  virtual ~Operator() {}
+  virtual ~Operator() noexcept {}
 
   inline const Tensor<Context>& Input(int idx) {
     return OperatorBase::template Input<Tensor<Context> >(idx); }
@@ -220,7 +220,7 @@ class Operator : public OperatorBase {
 #define USE_SIMPLE_CTOR_DTOR(name)                                             \
   name(const OperatorDef& operator_def, Workspace* ws)                         \
       : Operator<Context>(operator_def, ws) {}                                 \
-  virtual ~name() {}
+  virtual ~name() noexcept {}
 
 // Helpers to implement runtime op polymorphism. Often it's convenient to make
 // an op work on different input types (e.g. i32 vs i64 indices) or special-case

--- a/caffe2/operators/top_k.h
+++ b/caffe2/operators/top_k.h
@@ -1,7 +1,7 @@
 #ifndef CAFFE2_OPERATORS_TOP_K_H_
 #define CAFFE2_OPERATORS_TOP_K_H_
 
-#include "caffe2/caffe2/core/logging.h"
+#include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
 

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -54,5 +54,13 @@ endif()
 
 # ---[ If we are using msvc, set no warning flags
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
-  message(STATUS "Adding no warning argument to the compiler")
+  add_compile_options(
+      /wd4018 # (3): Signed/unsigned mismatch
+      /wd4065 # (3): switch with default but no case. Protobuf related.
+      /wd4244 # (2/3/4): Possible loss of precision
+      /wd4267 # (3): Conversion of size_t to smaller type. Possible loss of data.
+      /wd4506 # (1): no definition for inline function. Protobuf related.
+      /wd4800 # (3): Forcing non-boolean value to true or false.
+      /wd4996 # (3): Use of a deprecated member
+  )
 endif()


### PR DESCRIPTION
suppressed warning, added noexcept to destructors, and fixed an inclusion bug introduced today in the top_k diff.