### PR TITLE
Fix a data_workers test

### DIFF
--- a/caffe2/python/data_workers_test.py
+++ b/caffe2/python/data_workers_test.py
@@ -28,6 +28,7 @@ class DataWorkersTest(unittest.TestCase):
 
     def testNonParallelModel(self):
         model = cnn.CNNModelHelper(name="test")
+        old_seq_id = data_workers.global_coordinator._fetcher_id_seq
         coordinator = data_workers.init_data_input_workers(
             model,
             ["data", "label"],
@@ -35,7 +36,9 @@ class DataWorkersTest(unittest.TestCase):
             32,
             2,
         )
-        self.assertEqual(coordinator._fetcher_id_seq, 2)
+        new_seq_id = data_workers.global_coordinator._fetcher_id_seq
+        self.assertEqual(new_seq_id, old_seq_id + 2)
+
         coordinator.start()
 
         workspace.RunNetOnce(model.param_init_net)
@@ -60,6 +63,7 @@ class DataWorkersTest(unittest.TestCase):
 
     def testGracefulShutdown(self):
         model = cnn.CNNModelHelper(name="test")
+        old_seq_id = data_workers.global_coordinator._fetcher_id_seq
         coordinator = data_workers.init_data_input_workers(
             model,
             ["data", "label"],
@@ -67,7 +71,9 @@ class DataWorkersTest(unittest.TestCase):
             32,
             2,
         )
-        self.assertEqual(coordinator._fetcher_id_seq, 2)
+        new_seq_id = data_workers.global_coordinator._fetcher_id_seq
+        self.assertEqual(new_seq_id, old_seq_id + 2)
+
         coordinator.start()
 
         workspace.RunNetOnce(model.param_init_net)


### PR DESCRIPTION
This is a global variable which can be incremented by other tests.

Before:
```
$ pytest -v caffe2/python/data_workers_test.py
...
caffe2/python/data_workers_test.py::DataWorkersTest::testGracefulShutdown PASSED
caffe2/python/data_workers_test.py::DataWorkersTest::testNonParallelModel FAILED

============================================= FAILURES ==============================================
_______________________________ DataWorkersTest.testNonParallelModel ________________________________

self = <data_workers_test.DataWorkersTest testMethod=testNonParallelModel>

    def testNonParallelModel(self):
        model = cnn.CNNModelHelper(name="test")
        coordinator = data_workers.init_data_input_workers(
            model,
            ["data", "label"],
            dummy_fetcher,
            32,
            2,
        )
>       self.assertEqual(coordinator._fetcher_id_seq, 2)
E       AssertionError: 4 != 2

caffe2/python/data_workers_test.py:38: AssertionError
--------------------------------------- Captured stdout call ----------------------------------------
Created queue: data_c2queue_train
Created queue: label_c2queue_train
================================ 1 failed, 1 passed in 0.76 seconds =================================
```
After:
```
$ pytest -v caffe2/python/data_workers_test.py 
...
caffe2/python/data_workers_test.py::DataWorkersTest::testGracefulShutdown PASSED
caffe2/python/data_workers_test.py::DataWorkersTest::testNonParallelModel PASSED

===================================== 2 passed in 1.64 seconds =====================================
```