### PR TITLE
Use version-specific CUDA packages 16.04

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -79,24 +79,31 @@ else
   # Install CUDA #
   ################
 
-  CUDA_REPO_PKG="cuda-repo-ubuntu1404_8.0.44-1_amd64.deb"
+  source /etc/lsb-release
+
+  REPO="ubuntu1404"
+  if [ "${DISTRIB_RELEASE}" == "16.04" ]; then
+      REPO="ubuntu1604"
+  fi
+
+  CUDA_REPO_PKG="cuda-repo-${REPO}_8.0.44-1_amd64.deb"
   CUDA_PKG_VERSION="8-0"
   CUDA_VERSION="8.0"
 
-  wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1404/x86_64/$CUDA_REPO_PKG
-  sudo dpkg -i $CUDA_REPO_PKG
-  rm $CUDA_REPO_PKG
+  wget "http://developer.download.nvidia.com/compute/cuda/repos/${REPO}/x86_64/${CUDA_REPO_PKG}"
+  sudo dpkg -i "${CUDA_REPO_PKG}"
+  rm -f "${CUDA_REPO_PKG}"
   sudo apt-get update
   sudo apt-get install -y --no-install-recommends \
-      cuda-core-$CUDA_PKG_VERSION \
-      cuda-cublas-dev-$CUDA_PKG_VERSION \
-      cuda-cudart-dev-$CUDA_PKG_VERSION \
-      cuda-curand-dev-$CUDA_PKG_VERSION \
-      cuda-driver-dev-$CUDA_PKG_VERSION \
-      cuda-nvrtc-dev-$CUDA_PKG_VERSION
+      "cuda-core-${CUDA_PKG_VERSION}" \
+      "cuda-cublas-dev-${CUDA_PKG_VERSION}" \
+      "cuda-cudart-dev-${CUDA_PKG_VERSION}" \
+      "cuda-curand-dev-${CUDA_PKG_VERSION}" \
+      "cuda-driver-dev-${CUDA_PKG_VERSION}" \
+      "cuda-nvrtc-dev-${CUDA_PKG_VERSION}"
 
   # manually create CUDA symlink
-  sudo ln -s /usr/local/cuda-$CUDA_VERSION /usr/local/cuda
+  sudo ln -sf /usr/local/cuda-$CUDA_VERSION /usr/local/cuda
 
   #################
   # Install cudnn #


### PR DESCRIPTION
So you can just run `BUILD_CUDA=ON .travis/install.sh` on a 16.04 machine and have it install the right packages.