### PR TITLE
Reset workspace after each test in copy_ops_test

### DIFF
--- a/caffe2/python/operator_test/copy_ops_test.py
+++ b/caffe2/python/operator_test/copy_ops_test.py
@@ -12,6 +12,12 @@ from caffe2.python import workspace, core, cnn
 
 class CopyOpsTest(unittest.TestCase):
 
+    def tearDown(self):
+        # Reset workspace after each test
+        # Otherwise, the multi-GPU test will use previously created tensors,
+        #   which may have been placed on the wrong device
+        workspace.ResetWorkspace()
+
     def run_test_copy_gradient(self, device_opt):
         model = cnn.CNNModelHelper(name="copy_test")
         with core.DeviceScope(device_opt):
@@ -56,8 +62,6 @@ class CopyOpsTest(unittest.TestCase):
         workspace.FeedBlob("x_cpu", np.random.rand(32).astype(np.float32))
         workspace.RunNetOnce(model.param_init_net)
         workspace.RunNetOnce(model.net)
-
-        print(model.net.Proto())
 
         self.assertTrue(np.array_equal(
             workspace.FetchBlob("x_gpu_1"),


### PR DESCRIPTION
This was a nasty one to track down. This was the error message:
```
E0323 14:47:46.138900  2870 context_gpu.h:126] Encountered CUDA error: an illegal memory access was encountered
F0323 14:47:46.139143  2870 operator.h:176] Computation on device returned error in operator
input: "x_gpu_2" output: "loss" name: "" type: "AveragedLoss" device_option { device_type: 1 cuda_gpu_id: 1 }
```