### PR TITLE
Fix test_random_seed_behavior for multi-GPU

### DIFF
--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -239,12 +239,16 @@ class TestOperators(hu.HypothesisTestCase):
                 do.random_seed = 1000
 
         def run(do):
+            # Reset each time because 'Y' may already exist in the workspace
+            #   on a different device
+            workspace.ResetWorkspace()
+            ws = workspace.C.Workspace()
             op = core.CreateOperator(
                 "XavierFill", [], ["Y"],
                 device_option=do,
                 shape=[2])
-            self.ws.run(op)
-            return self.ws.blobs["Y"].fetch()
+            ws.run(op)
+            return ws.blobs["Y"].fetch()
 
         ys = [run(do) for do in device_options]
         for y in ys[1:]:


### PR DESCRIPTION
```
E0327 17:33:12.775998 15629 context_gpu.h:126] Encountered CUDA error: an illegal memory access was encountered
F0327 17:33:12.776208 15629 operator.h:176] Computation on device returned error in operator
output: "Y" name: "" type: "XavierFill" arg { name: "shape" ints: 2 } device_option { device_type: 1 cuda_gpu_id: 0 }
```