### PR TITLE
Add fp16 dispatch to main cuDNN operators

### DIFF
--- a/caffe2/core/common_cudnn.h
+++ b/caffe2/core/common_cudnn.h
@@ -111,6 +111,7 @@ class cudnnTypeWrapper<float> {
  public:
   static const cudnnDataType_t type = CUDNN_DATA_FLOAT;
   typedef const float ScalingParamType;
+  typedef float BNParamType;
   static ScalingParamType* kOne() {
     static ScalingParamType v = 1.0;
     return &v;
@@ -126,6 +127,7 @@ class cudnnTypeWrapper<double> {
  public:
   static const cudnnDataType_t type = CUDNN_DATA_DOUBLE;
   typedef const double ScalingParamType;
+  typedef double BNParamType;
   static ScalingParamType* kOne() {
     static ScalingParamType v = 1.0;
     return &v;
@@ -141,6 +143,7 @@ class cudnnTypeWrapper<float16> {
  public:
   static const cudnnDataType_t type = CUDNN_DATA_HALF;
   typedef const float ScalingParamType;
+  typedef float BNParamType;
   static ScalingParamType* kOne() {
     static ScalingParamType v = 1.0;
     return &v;

--- a/caffe2/operators/conv_op_cudnn.cc
+++ b/caffe2/operators/conv_op_cudnn.cc
@@ -420,8 +420,9 @@ bool CudnnConvOp::RunOnDevice() {
                          // float16,      // Math
                          float16>();   // Y
   } else {
-    CAFFE_THROW("Unsupported inputs");
+    LOG(FATAL) << "Unsupported type inputs";
   }
+  return true;
 }
 
 template <typename T_X, typename T_DY, typename T_W, typename T_B,
@@ -753,8 +754,9 @@ bool CudnnConvGradientOp::RunOnDevice() {
                          float16,    // dW
                          float16>(); // db
   } else {
-    CAFFE_THROW("Unsupported inputs");
+    LOG(FATAL) << "Unsupported input types";
   }
+  return true;
 }
 
 REGISTER_CUDNN_OPERATOR(Conv, CudnnConvOp);

--- a/caffe2/operators/conv_op_cudnn.cc
+++ b/caffe2/operators/conv_op_cudnn.cc
@@ -417,7 +417,6 @@ bool CudnnConvOp::RunOnDevice() {
                          float16,      // W
                          float16,      // B
                          float,      // Math
-                         // float16,      // Math
                          float16>();   // Y
   } else {
     LOG(FATAL) << "Unsupported type inputs";
@@ -749,7 +748,6 @@ bool CudnnConvGradientOp::RunOnDevice() {
                          float16,    //  W
                          float16,    //  b
                          float,    // Math
-                         // float16,    // Math
                          float16,    // dX
                          float16,    // dW
                          float16>(); // db

--- a/caffe2/operators/conv_op_cudnn.cc
+++ b/caffe2/operators/conv_op_cudnn.cc
@@ -140,13 +140,16 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
   size_t cudnn_state_;
 };
 
-template <typename T>
+
 class CudnnConvOp final : public CudnnConvOpBase {
  public:
   CudnnConvOp(const OperatorDef& operator_def, Workspace* ws)
       : CudnnConvOpBase(operator_def, ws)  {}
 
   ~CudnnConvOp() {}
+
+  template <typename T_X, typename T_W, typename T_B, typename MATH, typename T_Y>
+  bool DoRunWithType();
 
   bool RunOnDevice() override;
 
@@ -158,7 +161,6 @@ class CudnnConvOp final : public CudnnConvOpBase {
   INPUT_TAGS(INPUT, FILTER, BIAS);
 };
 
-template <typename T>
 class CudnnConvGradientOp final : public CudnnConvOpBase {
  public:
   CudnnConvGradientOp(const OperatorDef& operator_def, Workspace* ws)
@@ -170,6 +172,11 @@ class CudnnConvGradientOp final : public CudnnConvOpBase {
   }
 
   ~CudnnConvGradientOp() {}
+
+  template <typename T_X, typename T_DY, typename T_W, typename T_B,
+            typename MATH,
+            typename T_DX, typename T_DW, typename T_DB>
+  bool DoRunWithType();
 
   bool RunOnDevice() override;
 
@@ -189,8 +196,8 @@ class CudnnConvGradientOp final : public CudnnConvOpBase {
 // Implementations
 ////////////////////////////////////////////////////////////////////////////////
 
-template <typename T>
-bool CudnnConvOp<T>::RunOnDevice() {
+template <typename T_X, typename T_W, typename T_B, typename MATH, typename T_Y>
+bool CudnnConvOp::DoRunWithType() {
   auto& X = Input(INPUT);
   auto& filter = Input(FILTER);
   auto* Y = Output(0);
@@ -243,13 +250,13 @@ bool CudnnConvOp<T>::RunOnDevice() {
     VLOG(1) << "Changing the cudnn descriptor configurations.";
     if (input_changed) {
       cudnn_input_dims_ = X.dims();
-      SetTensor4dDescriptorWithGroup<T>(bottom_desc_, N, C, H, W);
+      SetTensor4dDescriptorWithGroup<T_X>(bottom_desc_, N, C, H, W);
     }
     if (filter_changed) {
       cudnn_filter_dims_ = filter.dims();
       CUDNN_ENFORCE(cudnnSetFilter4dDescriptor(
           filter_desc_,
-          cudnnTypeWrapper<T>::type,
+          cudnnTypeWrapper<T_W>::type,
           GetCudnnTensorFormat(order_),
           M / group_,
           C / group_,
@@ -259,7 +266,7 @@ bool CudnnConvOp<T>::RunOnDevice() {
         CUDNN_ENFORCE(cudnnSetTensor4dDescriptor(
             bias_desc_,
             GetCudnnTensorFormat(order_),
-            cudnnTypeWrapper<T>::type,
+            cudnnTypeWrapper<T_B>::type,
             1,
             M,
             1,
@@ -267,12 +274,12 @@ bool CudnnConvOp<T>::RunOnDevice() {
       }
     }
     // Set the output
-    SetTensor4dDescriptorWithGroup<T>(top_desc_, N, M, H_out, W_out);
+    SetTensor4dDescriptorWithGroup<T_Y>(top_desc_, N, M, H_out, W_out);
     // Set the output with descriptor useful for bias addition in one run
     CUDNN_ENFORCE(cudnnSetTensor4dDescriptor(
         top_desc_for_bias_,
         GetCudnnTensorFormat(order_),
-        cudnnTypeWrapper<T>::type,
+        cudnnTypeWrapper<T_B>::type,
         N,
         M,
         H_out,
@@ -288,7 +295,7 @@ bool CudnnConvOp<T>::RunOnDevice() {
         dilation_h(),
         dilation_w(),
         CUDNN_CROSS_CORRELATION,
-        cudnnTypeWrapper<T>::type));
+        cudnnTypeWrapper<MATH>::type));
 #else
     CUDNN_ENFORCE(cudnnSetConvolution2dDescriptor(
         conv_desc_,
@@ -318,12 +325,12 @@ bool CudnnConvOp<T>::RunOnDevice() {
           CUDNN_ENFORCE(cudnnFindConvolutionForwardAlgorithmEx(
               state->cudnn_handle(),
               bottom_desc_,
-              X.template data<T>(),
+              X.template data<T_X>(),
               filter_desc_,
-              filter.template data<T>(),
+              filter.template data<T_W>(),
               conv_desc_,
               top_desc_,
-              Y->template mutable_data<T>(),
+              Y->template mutable_data<T_Y>(),
               kNUM_CUDNN_FWD_ALGS,
               &returned_algo_count,
               perf_stat.data(),
@@ -363,18 +370,18 @@ bool CudnnConvOp<T>::RunOnDevice() {
     cudnn_wrapper_.with_cudnn_state(cudnn_state_, [&](CuDNNState* state) {
       CUDNN_ENFORCE(cudnnConvolutionForward(
           state->cudnn_handle(),
-          cudnnTypeWrapper<T>::kOne(),
+          cudnnTypeWrapper<T_X>::kOne(),
           bottom_desc_,
-          X.template data<T>() + i * group_offset_X,
+          X.template data<T_X>() + i * group_offset_X,
           filter_desc_,
-          filter.template data<T>() + i * group_offset_filter,
+          filter.template data<T_W>() + i * group_offset_filter,
           conv_desc_,
           algo_,
           state->workspace().get(cudnn_ws_nbytes_),
           cudnn_ws_nbytes_,
-          cudnnTypeWrapper<T>::kZero(),
+          cudnnTypeWrapper<T_Y>::kZero(),
           top_desc_,
-          Y->template mutable_data<T>() + i * group_offset_Y));
+          Y->template mutable_data<T_Y>() + i * group_offset_Y));
     });
   }
   // Bias
@@ -386,21 +393,41 @@ bool CudnnConvOp<T>::RunOnDevice() {
 
     CUDNN_ENFORCE(cudnnAddTensor(
         cudnn_wrapper_.inline_cudnn_handle(),
-        cudnnTypeWrapper<T>::kOne(),
+        cudnnTypeWrapper<T_B>::kOne(),
         bias_desc_,
-        bias.template data<T>(),
-        cudnnTypeWrapper<T>::kOne(),
+        bias.template data<T_B>(),
+        cudnnTypeWrapper<T_Y>::kOne(),
         top_desc_for_bias_,
-        Y->template mutable_data<T>()));
+        Y->template mutable_data<T_Y>()));
   }
   // Done.
   return true;
 }
 
-// TODO(Yangqing): a lot of the function contents are very similar. Consider
-// consolidating them.
-template <typename T>
-bool CudnnConvGradientOp<T>::RunOnDevice() {
+bool CudnnConvOp::RunOnDevice() {
+
+  if (Input(0).IsType<float>()) {
+    return DoRunWithType<float,      // X
+                         float,      // W
+                         float,      // B
+                         float,      // Math
+                         float>();   // Y
+  } else if (Input(0).IsType<float16>()) {
+    return DoRunWithType<float16,      // X
+                         float16,      // W
+                         float16,      // B
+                         float,      // Math
+                         // float16,      // Math
+                         float16>();   // Y
+  } else {
+    CAFFE_THROW("Unsupported inputs");
+  }
+}
+
+template <typename T_X, typename T_DY, typename T_W, typename T_B,
+          typename MATH,
+          typename T_DX, typename T_DW, typename T_DB>
+bool CudnnConvGradientOp::DoRunWithType() {
   auto& X = Input(INPUT);
   auto& filter = Input(FILTER);
   auto& dY = Input(OUTPUT_GRAD);
@@ -454,13 +481,13 @@ bool CudnnConvGradientOp<T>::RunOnDevice() {
     VLOG(1) << "Changing the cudnn descriptor configurations.";
     if (input_changed) {
       cudnn_input_dims_ = X.dims();
-      SetTensor4dDescriptorWithGroup<T>(bottom_desc_, N, C, H, W);
+      SetTensor4dDescriptorWithGroup<T_X>(bottom_desc_, N, C, H, W);
     }
     if (filter_changed) {
       cudnn_filter_dims_ = filter.dims();
       CUDNN_ENFORCE(cudnnSetFilter4dDescriptor(
           filter_desc_,
-          cudnnTypeWrapper<T>::type,
+          cudnnTypeWrapper<T_W>::type,
           GetCudnnTensorFormat(order_),
           M / group_,
           C / group_,
@@ -470,7 +497,7 @@ bool CudnnConvGradientOp<T>::RunOnDevice() {
         CUDNN_ENFORCE(cudnnSetTensor4dDescriptor(
             bias_desc_,
             GetCudnnTensorFormat(order_),
-            cudnnTypeWrapper<T>::type,
+            cudnnTypeWrapper<T_B>::type,
             1,
             M,
             1,
@@ -478,12 +505,12 @@ bool CudnnConvGradientOp<T>::RunOnDevice() {
       }
     }
     // Set the output
-    SetTensor4dDescriptorWithGroup<T>(top_desc_, N, M, H_out, W_out);
+    SetTensor4dDescriptorWithGroup<T_DX>(top_desc_, N, M, H_out, W_out);
     // Set the output with descriptor useful for bias addition in one run
     CUDNN_ENFORCE(cudnnSetTensor4dDescriptor(
         top_desc_for_bias_,
         GetCudnnTensorFormat(order_),
-        cudnnTypeWrapper<T>::type,
+        cudnnTypeWrapper<T_DB>::type,
         N,
         M,
         H_out,
@@ -499,7 +526,7 @@ bool CudnnConvGradientOp<T>::RunOnDevice() {
         dilation_h(),
         dilation_w(),
         CUDNN_CROSS_CORRELATION,
-        cudnnTypeWrapper<T>::type));
+        cudnnTypeWrapper<MATH>::type));
 #else
     CUDNN_ENFORCE(cudnnSetConvolution2dDescriptor(
         conv_desc_,
@@ -541,12 +568,12 @@ bool CudnnConvGradientOp<T>::RunOnDevice() {
                   CUDNN_ENFORCE(cudnnFindConvolutionBackwardFilterAlgorithmEx(
                       state->cudnn_handle(),
                       bottom_desc_,
-                      X.template data<T>(),
+                      X.template data<T_X>(),
                       top_desc_,
-                      dY.template data<T>(),
+                      dY.template data<T_DY>(),
                       conv_desc_,
                       filter_desc_,
-                      dfilter->template mutable_data<T>(),
+                      dfilter->template mutable_data<T_DW>(),
                       kNUM_CUDNN_BWD_FILTER_ALGS,
                       &returned_algo_count,
                       filter_perf_stat.data(),
@@ -572,9 +599,9 @@ bool CudnnConvGradientOp<T>::RunOnDevice() {
                     auto* dX =
                         Output(no_bias_ ? BIAS_OR_INPUT_GRAD : INPUT_GRAD);
                     dX->ResizeLike(X);
-                    const T* filter_data = filter.template data<T>();
-                    const T* dYdata = dY.template data<T>();
-                    T* dXdata = dX->template mutable_data<T>();
+                    const T_W* filter_data = filter.template data<T_W>();
+                    const T_DY* dYdata = dY.template data<T_DY>();
+                    T_DX* dXdata = dX->template mutable_data<T_DX>();
                     CUDNN_ENFORCE(cudnnFindConvolutionBackwardDataAlgorithmEx(
                         state->cudnn_handle(),
                         filter_desc_,
@@ -607,15 +634,17 @@ bool CudnnConvGradientOp<T>::RunOnDevice() {
           cudnn_ws_nbytes_limit_,
           &bwd_filter_algo_));
       // choose backward algo for data
-      CUDNN_ENFORCE(cudnnGetConvolutionBackwardDataAlgorithm(
-          cudnn_wrapper_.inline_cudnn_handle(),
-          filter_desc_,
-          top_desc_,
-          conv_desc_,
-          bottom_desc_,
-          CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
-          cudnn_ws_nbytes_limit_,
-          &bwd_data_algo_));
+      if (OutputSize() == 3 || (no_bias_ && (OutputSize() == 2))) {
+        CUDNN_ENFORCE(cudnnGetConvolutionBackwardDataAlgorithm(
+            cudnn_wrapper_.inline_cudnn_handle(),
+            filter_desc_,
+            top_desc_,
+            conv_desc_,
+            bottom_desc_,
+            CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
+            cudnn_ws_nbytes_limit_,
+            &bwd_data_algo_));
+      }
     }
     // get workspace for backwards filter algorithm
     CUDNN_ENFORCE(cudnnGetConvolutionBackwardFilterWorkspaceSize(
@@ -626,15 +655,19 @@ bool CudnnConvGradientOp<T>::RunOnDevice() {
         filter_desc_,
         bwd_filter_algo_,
         &bwd_filter_ws_size));
-    // get workspace for backwards data algorithm
-    CUDNN_ENFORCE(cudnnGetConvolutionBackwardDataWorkspaceSize(
-        cudnn_wrapper_.inline_cudnn_handle(),
-        filter_desc_,
-        top_desc_,
-        conv_desc_,
-        bottom_desc_,
-        bwd_data_algo_,
-        &bwd_data_ws_size));
+    if (OutputSize() == 3 || (no_bias_ && (OutputSize() == 2))) {
+      // get workspace for backwards data algorithm
+      CUDNN_ENFORCE(cudnnGetConvolutionBackwardDataWorkspaceSize(
+          cudnn_wrapper_.inline_cudnn_handle(),
+          filter_desc_,
+          top_desc_,
+          conv_desc_,
+          bottom_desc_,
+          bwd_data_algo_,
+          &bwd_data_ws_size));
+    } else {
+      bwd_data_ws_size = 0;
+    }
     cudnn_ws_nbytes_ = std::max(bwd_filter_ws_size, bwd_data_ws_size);
 
     VLOG(1) << "CuDNN bwd algorithm: " << bwd_filter_algo_ << ", "
@@ -648,80 +681,83 @@ bool CudnnConvGradientOp<T>::RunOnDevice() {
     dbias->Resize(M);
     CUDNN_ENFORCE(cudnnConvolutionBackwardBias(
         cudnn_wrapper_.inline_cudnn_handle(),
-        cudnnTypeWrapper<T>::kOne(),
+        cudnnTypeWrapper<T_DY>::kOne(),
         top_desc_for_bias_,
-        dY.template data<T>(),
-        cudnnTypeWrapper<T>::kZero(),
+        dY.template data<T_DY>(),
+        cudnnTypeWrapper<T_DB>::kZero(),
         bias_desc_,
-        dbias->template mutable_data<T>()));
+        dbias->template mutable_data<T_DB>()));
   }
 
   for (int i = 0; i < group_; ++i) {
     cudnn_wrapper_.with_cudnn_state(cudnn_state_, [&](CuDNNState* state) {
       CUDNN_ENFORCE(cudnnConvolutionBackwardFilter(
           state->cudnn_handle(),
-          cudnnTypeWrapper<T>::kOne(),
+          cudnnTypeWrapper<T_X>::kOne(),
           bottom_desc_,
-          X.template data<T>() + i * group_offset_X,
+          X.template data<T_X>() + i * group_offset_X,
           top_desc_,
-          dY.template data<T>() + i * group_offset_Y,
+          dY.template data<T_DY>() + i * group_offset_Y,
           conv_desc_,
           bwd_filter_algo_,
           state->workspace().get(cudnn_ws_nbytes_),
           cudnn_ws_nbytes_,
-          cudnnTypeWrapper<T>::kZero(),
+          cudnnTypeWrapper<T_DW>::kZero(),
           filter_desc_,
-          dfilter->template mutable_data<T>() + i * group_offset_filter));
+          dfilter->template mutable_data<T_DW>() + i * group_offset_filter));
       if (OutputSize() == 3 || (no_bias_ && (OutputSize() == 2))) {
         // Compute the gradient w.r.t. the input.
         auto* dX = Output(no_bias_ ? BIAS_OR_INPUT_GRAD : INPUT_GRAD);
         dX->ResizeLike(X);
         CUDNN_ENFORCE(cudnnConvolutionBackwardData(
             state->cudnn_handle(),
-            cudnnTypeWrapper<T>::kOne(),
+            cudnnTypeWrapper<T_W>::kOne(),
             filter_desc_,
-            filter.template data<T>() + i * group_offset_filter,
+            filter.template data<T_W>() + i * group_offset_filter,
             top_desc_,
-            dY.template data<T>() + i * group_offset_Y,
+            dY.template data<T_DY>() + i * group_offset_Y,
             conv_desc_,
             bwd_data_algo_,
             state->workspace().get(cudnn_ws_nbytes_),
             cudnn_ws_nbytes_,
-            cudnnTypeWrapper<T>::kZero(),
+            cudnnTypeWrapper<T_DX>::kZero(),
             bottom_desc_,
-            dX->template mutable_data<T>() + i * group_offset_X));
+            dX->template mutable_data<T_DX>() + i * group_offset_X));
       }
     });
   }
   return true;
 }
 
-REGISTER_CUDNN_OPERATOR(Conv, CudnnConvOp<float>);
-REGISTER_CUDNN_OPERATOR(ConvGradient, CudnnConvGradientOp<float>);
-
-REGISTER_CUDNN_OPERATOR(ConvFp16, CudnnConvOp<float16>);
-REGISTER_CUDNN_OPERATOR(ConvFp16Gradient, CudnnConvGradientOp<float16>);
-
-class GetConvFp16Gradient : public GradientMakerBase {
-  using GradientMakerBase::GradientMakerBase;
-  vector<OperatorDef> GetGradientDefs() override {
-    CAFFE_ENFORCE(def_.input_size() == 3 || def_.input_size() == 2);
-    if (def_.input_size() == 3) {
-      return SingleGradientDef(
-          "ConvFp16Gradient",
-          "",
-          vector<string>{I(0), I(1), GO(0)},
-          vector<string>{GI(1), GI(2), GI(0)});
-    } else {
-      return SingleGradientDef(
-          "ConvFp16Gradient",
-          "",
-          vector<string>{I(0), I(1), GO(0)},
-          vector<string>{GI(1), GI(0)},
-          vector<Argument>{MakeArgument<int>("no_bias", 1)});
-    }
+// TODO(Yangqing): a lot of the function contents are very similar. Consider
+// consolidating them.
+bool CudnnConvGradientOp::RunOnDevice() {
+  if (Input(0).IsType<float>()) {
+    return DoRunWithType<float,    //  X
+                         float,    // dY
+                         float,    //  W
+                         float,    //  b
+                         float,    // Math
+                         float,    // dX
+                         float,    // dW
+                         float>(); // db
   }
-};
-REGISTER_GRADIENT(ConvFp16, GetConvFp16Gradient);
+  else if (Input(0).IsType<float16>()) {
+    return DoRunWithType<float16,    //  X
+                         float16,    // dY
+                         float16,    //  W
+                         float16,    //  b
+                         float,    // Math
+                         // float16,    // Math
+                         float16,    // dX
+                         float16,    // dW
+                         float16>(); // db
+  } else {
+    CAFFE_THROW("Unsupported inputs");
+  }
+}
+
+REGISTER_CUDNN_OPERATOR(Conv, CudnnConvOp);
+REGISTER_CUDNN_OPERATOR(ConvGradient, CudnnConvGradientOp);
 
 }  // namespace caffe2

--- a/caffe2/operators/pool_op_cudnn.cc
+++ b/caffe2/operators/pool_op_cudnn.cc
@@ -14,25 +14,15 @@ class CuDNNPoolOp : public ConvPoolOpBase<CUDAContext> {
     CUDNN_ENFORCE(cudnnCreatePoolingDescriptor(&pooling_desc_));
     // Figure out the pooling descriptor.
     if (def().type().substr(0, 7) == "MaxPool") {
+#if CUDNN_VERSION_MIN(6,0,0)
+      mode_ = CUDNN_POOLING_MAX_DETERMINISTIC;
+#else
       mode_ = CUDNN_POOLING_MAX;
+#endif
     } else if (def().type().substr(0, 11) == "AveragePool") {
-      mode_ = CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING;
+      mode_ = CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING;
     } else {
       LOG(FATAL) << "Unsupported pooling method: " << def().type();
-    }
-
-    // Choose function body for given math type
-    TensorProto_DataType math = TensorProto_DataType_FLOAT; // hardcode for now
-
-    switch (math) {
-      case TensorProto_DataType_FLOAT:
-         body_ = &CuDNNPoolOp::DoRunWithMathType<float>;
-         break;
-      case TensorProto_DataType_FLOAT16:
-        body_ = &CuDNNPoolOp::DoRunWithMathType<float16>;
-        break;
-      default:
-        CAFFE_THROW("Invalid math type specified");
     }
   }
 
@@ -40,15 +30,6 @@ class CuDNNPoolOp : public ConvPoolOpBase<CUDAContext> {
     CUDNN_ENFORCE(cudnnDestroyTensorDescriptor(bottom_desc_));
     CUDNN_ENFORCE(cudnnDestroyTensorDescriptor(top_desc_));
     CUDNN_ENFORCE(cudnnDestroyPoolingDescriptor(pooling_desc_));
-  }
-
-  template <typename M>
-  bool DoRunWithMathType() {
-    return DispatchHelper<
-      TensorTypes<
-        float,
-        float16>,
-      M>::call(this, Input(0));
   }
 
   template <typename T, typename M>
@@ -98,7 +79,7 @@ class CuDNNPoolOp : public ConvPoolOpBase<CUDAContext> {
       CUDNN_ENFORCE(cudnnSetPooling2dDescriptor(
           pooling_desc_,
           mode_,
-          CUDNN_PROPAGATE_NAN,
+          CUDNN_NOT_PROPAGATE_NAN,
           kernel_h(),
           kernel_w(),
           pad_t(),
@@ -123,7 +104,11 @@ class CuDNNPoolOp : public ConvPoolOpBase<CUDAContext> {
     auto& X = Input(0);
     auto* Y = Output(0);
 
-    return (this->*body_)();
+    if (X.IsType<float>()) {
+      return DoRunWithType<float,float>();
+    } else if (X.IsType<float16>()) {
+      return DoRunWithType<float16,float>();
+    }
   }
 
  protected:
@@ -135,7 +120,6 @@ class CuDNNPoolOp : public ConvPoolOpBase<CUDAContext> {
   cudnnPoolingDescriptor_t pooling_desc_;
   cudnnPoolingMode_t mode_;
  private:
-  bool (CuDNNPoolOp::*body_)();
 };
 
 class CuDNNPoolGradientOp : public ConvPoolOpBase<CUDAContext> {
@@ -150,23 +134,9 @@ class CuDNNPoolGradientOp : public ConvPoolOpBase<CUDAContext> {
     if (def().type() == "MaxPoolGradient") {
       mode_ = CUDNN_POOLING_MAX;
     } else if (def().type() == "AveragePoolGradient") {
-      mode_ = CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING;
+      mode_ = CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING;
     } else {
       LOG(FATAL) << "Unsupported pooling method: " << def().type();
-    }
-    //
-    // Choose function body for given math type
-    TensorProto_DataType math = TensorProto_DataType_FLOAT; // hardcode for now
-
-    switch (math) {
-      case TensorProto_DataType_FLOAT:
-         body_ = &CuDNNPoolGradientOp::DoRunWithMathType<float>;
-         break;
-      case TensorProto_DataType_FLOAT16:
-        body_ = &CuDNNPoolGradientOp::DoRunWithMathType<float16>;
-        break;
-      default:
-        CAFFE_THROW("Invalid math type specified");
     }
   }
 
@@ -174,15 +144,6 @@ class CuDNNPoolGradientOp : public ConvPoolOpBase<CUDAContext> {
     CUDNN_ENFORCE(cudnnDestroyTensorDescriptor(bottom_desc_));
     CUDNN_ENFORCE(cudnnDestroyTensorDescriptor(top_desc_));
     CUDNN_ENFORCE(cudnnDestroyPoolingDescriptor(pooling_desc_));
-  }
-
-  template <typename M>
-  bool DoRunWithMathType() {
-    return DispatchHelper<
-      TensorTypes<
-        float,
-        float16>,
-      M>::call(this, Input(0));
   }
 
   template <typename T, typename M>
@@ -235,7 +196,7 @@ class CuDNNPoolGradientOp : public ConvPoolOpBase<CUDAContext> {
       CUDNN_ENFORCE(cudnnSetPooling2dDescriptor(
           pooling_desc_,
           mode_,
-          CUDNN_PROPAGATE_NAN,
+          CUDNN_NOT_PROPAGATE_NAN,
           kernel_h(),
           kernel_w(),
           pad_t(),
@@ -267,7 +228,11 @@ class CuDNNPoolGradientOp : public ConvPoolOpBase<CUDAContext> {
     auto* dX = Output(0);
     dX->ResizeLike(X);
 
-    return (this->*body_)();
+    if (X.IsType<float>()) {
+      return DoRunWithType<float,float>();
+    } else if (X.IsType<float16>()) {
+      return DoRunWithType<float16,float>();
+    }
   }
 
  protected:
@@ -283,7 +248,6 @@ class CuDNNPoolGradientOp : public ConvPoolOpBase<CUDAContext> {
   // Output: dX
   INPUT_TAGS(IN, OUT, OUT_GRAD);
  private:
-  bool (CuDNNPoolGradientOp::*body_)();
 };
 
 namespace {

--- a/caffe2/operators/pool_op_cudnn.cc
+++ b/caffe2/operators/pool_op_cudnn.cc
@@ -108,7 +108,10 @@ class CuDNNPoolOp : public ConvPoolOpBase<CUDAContext> {
       return DoRunWithType<float,float>();
     } else if (X.IsType<float16>()) {
       return DoRunWithType<float16,float>();
+    } else {
+      LOG(FATAL) << "Unsupported input types";
     }
+    return true;
   }
 
  protected:
@@ -232,7 +235,10 @@ class CuDNNPoolGradientOp : public ConvPoolOpBase<CUDAContext> {
       return DoRunWithType<float,float>();
     } else if (X.IsType<float16>()) {
       return DoRunWithType<float16,float>();
+    } else {
+      LOG(FATAL) << "Unsupported input types";
     }
+    return true;
   }
 
  protected:
@@ -247,7 +253,6 @@ class CuDNNPoolGradientOp : public ConvPoolOpBase<CUDAContext> {
   // Input: X, Y, dY
   // Output: dX
   INPUT_TAGS(IN, OUT, OUT_GRAD);
- private:
 };
 
 namespace {

--- a/caffe2/operators/relu_op.cc
+++ b/caffe2/operators/relu_op.cc
@@ -29,8 +29,9 @@ bool ReluOp<float, CPUContext>::RunOnDevice() {
 
 template <>
 bool ReluGradientOp<float, CPUContext>::RunOnDevice() {
-  auto& Y = Input(0);
-  auto& dY = Input(1);
+  auto& X = Input(0);
+  auto& Y = Input(1);
+  auto& dY = Input(2);
   auto* dX = Output(0);
   DCHECK_EQ(dY.size(), Y.size());
   dX->ResizeLike(Y);
@@ -71,11 +72,11 @@ the tensor elementwise.
 
 // Input: Y, dY, output: dX
 OPERATOR_SCHEMA(ReluGradient)
-  .NumInputs(2)
+  .NumInputs(3)
   .NumOutputs(1)
-  .AllowInplace({{1, 0}})
+  .AllowInplace({{2, 0}})
   .SetDoc(R"DOC(
-ReluGradient takes both Y and dY and uses this to update dX according to the
+ReluGradient takes X, Y and dY and uses this to update dX according to the
 chain rule and derivatives of the rectified linear function.
 )DOC");
 
@@ -84,7 +85,7 @@ class GetReluGradient : public GradientMakerBase {
   vector<OperatorDef> GetGradientDefs() override {
     return SingleGradientDef(
         def_.type() + "Gradient", "",
-        vector<string>{O(0), GO(0)},
+        vector<string>{I(0), O(0), GO(0)},
         vector<string>{GI(0)});
   }
 };

--- a/caffe2/operators/relu_op.cc
+++ b/caffe2/operators/relu_op.cc
@@ -39,10 +39,10 @@ bool ReluGradientOp<float, CPUContext>::RunOnDevice() {
   const float* dYdata = dY.data<float>();
   float* dXdata = dX->mutable_data<float>();
   // TODO: proper vectorization with Eigen
-  EigenVectorArrayMap<float> Xvec(dXdata, dX->size());
+  EigenVectorArrayMap<float> dXvec(dXdata, dX->size());
   ConstEigenVectorArrayMap<float> Yvec(Ydata, Y.size());
   ConstEigenVectorArrayMap<float> dYvec(dYdata, dY.size());
-  Xvec = dYvec * Yvec.cwiseSign();
+  dXvec = dYvec * Yvec.cwiseSign();
   /* Previous implementation
   for (int i = 0; i < Y.size(); ++i) {
     dXdata[i] = Ydata[i] > 0 ? dYdata[i] : 0;

--- a/caffe2/operators/relu_op.cc
+++ b/caffe2/operators/relu_op.cc
@@ -29,7 +29,6 @@ bool ReluOp<float, CPUContext>::RunOnDevice() {
 
 template <>
 bool ReluGradientOp<float, CPUContext>::RunOnDevice() {
-  auto& X = Input(0);
   auto& Y = Input(1);
   auto& dY = Input(2);
   auto* dX = Output(0);

--- a/caffe2/operators/relu_op_cudnn.cc
+++ b/caffe2/operators/relu_op_cudnn.cc
@@ -73,7 +73,10 @@ class CuDNNReluOp final : public Operator<CUDAContext> {
       return DoRunWithType<float,float>();
     } else if (X.IsType<float16>()) {
       return DoRunWithType<float16,float>();
+    } else {
+      LOG(FATAL) << "Unsupported input types";
     }
+    return true;
   }
 
  protected:
@@ -82,7 +85,6 @@ class CuDNNReluOp final : public Operator<CUDAContext> {
   cudnnActivationDescriptor_t activ_desc_;
   vector<TIndex> cudnn_input_dims_;
   StorageOrder order_;
-  bool (CuDNNReluOp::*body_)();
 };
 
 
@@ -166,8 +168,10 @@ class CuDNNReluGradientOp final : public Operator<CUDAContext> {
       return DoRunWithType<float,float>();
     } else if (Y.IsType<float16>()) {
       return DoRunWithType<float16,float>();
+    } else {
+      LOG(FATAL) << "Unsupported input types";
     }
-    // return (this->*body_)();
+    return true;
   }
 
  protected:
@@ -177,8 +181,6 @@ class CuDNNReluGradientOp final : public Operator<CUDAContext> {
   vector<TIndex> cudnn_input_dims_;
   StorageOrder order_;
   // Input: X, Y, dY; Output: dX
- private:
-  bool (CuDNNReluGradientOp::*body_)();
 };
 
 namespace {

--- a/caffe2/operators/spatial_batch_norm_op_cudnn.cc
+++ b/caffe2/operators/spatial_batch_norm_op_cudnn.cc
@@ -14,7 +14,6 @@ namespace caffe2 {
 
 constexpr cudnnBatchNormMode_t kSpatialBNMode = CUDNN_BATCHNORM_SPATIAL;
 
-template <typename T>
 class CudnnSpatialBNOp final : public SpatialBNOp<CUDAContext> {
  public:
   USE_OPERATOR_FUNCTIONS(CUDAContext);
@@ -35,6 +34,9 @@ class CudnnSpatialBNOp final : public SpatialBNOp<CUDAContext> {
     CUDNN_ENFORCE(cudnnDestroyTensorDescriptor(bn_param_desc_));
   }
 
+  template <typename T, typename M>
+  bool DoRunWithType();
+
   bool RunOnDevice() override;
 
  protected:
@@ -44,7 +46,6 @@ class CudnnSpatialBNOp final : public SpatialBNOp<CUDAContext> {
   vector<TIndex> cudnn_input_dims_;
 };
 
-template <typename T>
 class CudnnSpatialBNGradientOp final : public SpatialBNGradientOp<CUDAContext> {
  public:
   USE_OPERATOR_FUNCTIONS(CUDAContext);
@@ -66,6 +67,9 @@ class CudnnSpatialBNGradientOp final : public SpatialBNGradientOp<CUDAContext> {
     CUDNN_ENFORCE(cudnnDestroyTensorDescriptor(bn_param_desc_));
   }
 
+  template <typename T, typename M>
+  bool DoRunWithType();
+
   bool RunOnDevice() override;
 
  protected:
@@ -80,8 +84,12 @@ class CudnnSpatialBNGradientOp final : public SpatialBNGradientOp<CUDAContext> {
 // Implementations
 ////////////////////////////////////////////////////////////////////////////////
 
-template <typename T>
-bool CudnnSpatialBNOp<T>::RunOnDevice() {
+template <typename T, typename M>
+bool CudnnSpatialBNOp::DoRunWithType() {
+
+  // QoL
+  typedef typename cudnnTypeWrapper<T>::BNParamType BNParamType;
+
   const auto& X = Input(INPUT);
   const auto& scale = Input(SCALE);
   const auto& bias = Input(BIAS);
@@ -133,10 +141,10 @@ bool CudnnSpatialBNOp<T>::RunOnDevice() {
         data_desc_,
         Y->template mutable_data<T>(),
         bn_param_desc_,
-        scale.template data<T>(),
-        bias.template data<T>(),
-        est_mean.template data<T>(),
-        est_var.template data<T>(),
+        scale.template data<BNParamType>(),
+        bias.template data<BNParamType>(),
+        est_mean.template data<BNParamType>(),
+        est_var.template data<BNParamType>(),
         epsilon_));
   } else {
     // Run training mode.
@@ -147,8 +155,8 @@ bool CudnnSpatialBNOp<T>::RunOnDevice() {
     auto* running_mean = Output(RUNNING_MEAN);
     auto* running_var = Output(RUNNING_VAR);
     double this_factor = 1. - momentum_;
-    T* running_mean_data = nullptr;
-    T* running_var_data = nullptr;
+    BNParamType* running_mean_data = nullptr;
+    BNParamType* running_var_data = nullptr;
     if (!running_mean->size()) {
       // If the input mean and var are not initialized yet, this is the first
       // run and we will initialize the storage.
@@ -156,30 +164,30 @@ bool CudnnSpatialBNOp<T>::RunOnDevice() {
       // Need to do initialization
       running_mean->Resize(C);
       running_var->Resize(C);
-      running_mean_data = running_mean->template mutable_data<T>();
-      running_var_data = running_var->template mutable_data<T>();
+      running_mean_data = running_mean->template mutable_data<BNParamType>();
+      running_var_data = running_var->template mutable_data<BNParamType>();
       // In principle, setting this_momentum to 1 will wipe existing data.
       // This has a caveat that if cudnn does not deal with 0*NaN cases we
       // will be having an issue. Thus we choose a safe path by explicitly
       // setting zero.
-      math::Set<T, CUDAContext>(C, 0, running_mean_data, &context_);
-      math::Set<T, CUDAContext>(C, 0, running_var_data, &context_);
+      math::Set<BNParamType, CUDAContext>(C, 0, running_mean_data, &context_);
+      math::Set<BNParamType, CUDAContext>(C, 0, running_var_data, &context_);
     } else {
       // Does not need to do initialization.
       DCHECK_EQ(running_mean->ndim(), 1);
       DCHECK_EQ(running_var->ndim(), 1);
       DCHECK_EQ(running_mean->dim32(0), C);
       DCHECK_EQ(running_var->dim32(0), C);
-      running_mean_data = running_mean->template mutable_data<T>();
-      running_var_data = running_var->template mutable_data<T>();
+      running_mean_data = running_mean->template mutable_data<BNParamType>();
+      running_var_data = running_var->template mutable_data<BNParamType>();
     }
     // Save the mean and inv var results.
     auto* save_mean = Output(SAVED_MEAN);
     auto* save_var = Output(SAVED_INV_VAR);
     save_mean->Resize(C);
     save_var->Resize(C);
-    void* save_mean_data = save_mean->template mutable_data<T>();
-    void* save_var_data = save_var->template mutable_data<T>();
+    void* save_mean_data = save_mean->template mutable_data<BNParamType>();
+    void* save_var_data = save_var->template mutable_data<BNParamType>();
 
     CUDNN_ENFORCE(cudnnBatchNormalizationForwardTraining(
         cudnn_wrapper_.inline_cudnn_handle(),
@@ -191,8 +199,8 @@ bool CudnnSpatialBNOp<T>::RunOnDevice() {
         data_desc_,
         Y->template mutable_data<T>(),
         bn_param_desc_,
-        scale.template data<T>(),
-        bias.template data<T>(),
+        scale.template data<BNParamType>(),
+        bias.template data<BNParamType>(),
         this_factor,
         running_mean_data,
         running_var_data,
@@ -203,9 +211,20 @@ bool CudnnSpatialBNOp<T>::RunOnDevice() {
   return true;
 }
 
+bool CudnnSpatialBNOp::RunOnDevice() {
+  if (Input(0).IsType<float>()) {
+    return DoRunWithType<float,float>();
+  } else if (Input(0).IsType<float16>()) {
+    return DoRunWithType<float16,float>();
+  }
+  return false;
+}
 
-template <typename T>
-bool CudnnSpatialBNGradientOp<T>::RunOnDevice() {
+template <typename T, typename M>
+bool CudnnSpatialBNGradientOp::DoRunWithType() {
+  // QoL
+  typedef typename cudnnTypeWrapper<T>::BNParamType BNParamType;
+
   const auto& X = Input(INPUT);
   const auto& scale = Input(SCALE);
   const auto& dY = Input(OUTPUT_GRAD);
@@ -241,8 +260,8 @@ bool CudnnSpatialBNGradientOp<T>::RunOnDevice() {
 
   const auto& saved_mean = Input(SAVED_MEAN);
   const auto& saved_var = Input(SAVED_INV_VAR);
-  const void* saved_mean_data = saved_mean.template data<T>();
-  const void* saved_var_data = saved_var.template data<T>();
+  const void* saved_mean_data = saved_mean.template data<BNParamType>();
+  const void* saved_var_data = saved_var.template data<BNParamType>();
 
   CUDNN_ENFORCE(cudnnBatchNormalizationBackward(
       cudnn_wrapper_.inline_cudnn_handle(),
@@ -258,22 +277,31 @@ bool CudnnSpatialBNGradientOp<T>::RunOnDevice() {
       data_desc_,
       dX->template mutable_data<T>(),
       bn_param_desc_,
-      scale.template data<T>(),
-      dScale->template mutable_data<T>(),
-      dBias->template mutable_data<T>(),
+      scale.template data<BNParamType>(),
+      dScale->template mutable_data<BNParamType>(),
+      dBias->template mutable_data<BNParamType>(),
       epsilon_,
       saved_mean_data,
       saved_var_data));
   return true;
 }
 
+bool CudnnSpatialBNGradientOp::RunOnDevice() {
+  if (Input(0).IsType<float>()) {
+    return DoRunWithType<float,float>();
+  } else if (Input(0).IsType<float16>()) {
+    return DoRunWithType<float16,float>();
+  }
+  return false;
+}
+
 namespace {
 // Since there is no default implementation for spatial batch normalization,
 // we will register the cudnn version as the default as well.
-REGISTER_CUDA_OPERATOR(SpatialBN, CudnnSpatialBNOp<float>);
-REGISTER_CUDA_OPERATOR(SpatialBNGradient, CudnnSpatialBNGradientOp<float>);
+REGISTER_CUDA_OPERATOR(SpatialBN, CudnnSpatialBNOp);
+REGISTER_CUDA_OPERATOR(SpatialBNGradient, CudnnSpatialBNGradientOp);
 
-REGISTER_CUDNN_OPERATOR(SpatialBN, CudnnSpatialBNOp<float>);
-REGISTER_CUDNN_OPERATOR(SpatialBNGradient, CudnnSpatialBNGradientOp<float>);
+REGISTER_CUDNN_OPERATOR(SpatialBN, CudnnSpatialBNOp);
+REGISTER_CUDNN_OPERATOR(SpatialBNGradient, CudnnSpatialBNGradientOp);
 }  // namespace
 }  // namespace caffe2

--- a/caffe2/operators/spatial_batch_norm_op_cudnn.cc
+++ b/caffe2/operators/spatial_batch_norm_op_cudnn.cc
@@ -216,8 +216,10 @@ bool CudnnSpatialBNOp::RunOnDevice() {
     return DoRunWithType<float,float>();
   } else if (Input(0).IsType<float16>()) {
     return DoRunWithType<float16,float>();
+  } else {
+    LOG(FATAL) << "Unsupported input types";
   }
-  return false;
+  return true;
 }
 
 template <typename T, typename M>
@@ -291,8 +293,10 @@ bool CudnnSpatialBNGradientOp::RunOnDevice() {
     return DoRunWithType<float,float>();
   } else if (Input(0).IsType<float16>()) {
     return DoRunWithType<float16,float>();
+  } else {
+    LOG(FATAL) << "Unsupported input types";
   }
-  return false;
+  return true;
 }
 
 namespace {


### PR DESCRIPTION
Adds support for fp16 to main cuDNN ops (conv, relu, pool, BatchNorm).

Done via. runtime dispatch, not using DispatchHelper at this point to allow for more complex dispatch logic in the future if necessary. Using separate template  for all input / output types is for these reasons also - it's easier to add the functionality now and never use it, than need to add it later.