### PR TITLE
Conv no dx

### DIFF
--- a/caffe2/operators/conv_gradient_op.cc
+++ b/caffe2/operators/conv_gradient_op.cc
@@ -11,19 +11,41 @@ class GetConvGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;
   vector<OperatorDef> GetGradientDefs() override {
     CAFFE_ENFORCE(def_.input_size() == 3 || def_.input_size() == 2);
+
+    ArgumentHelper argsHelper(def_);
+
+    auto compute_dX = !argsHelper.GetSingleArgument<bool>("no_gradient_to_input", 0);
+
     if (def_.input_size() == 3) {
-      return SingleGradientDef(
-          "ConvGradient",
-          "",
-          vector<string>{I(0), I(1), GO(0)},
-          vector<string>{GI(1), GI(2), GI(0)});
+      if (compute_dX) {
+        return SingleGradientDef(
+            "ConvGradient",
+            "",
+            vector<string>{I(0), I(1), GO(0)},
+            vector<string>{GI(1), GI(2), GI(0)});
+      } else {
+        return SingleGradientDef(
+            "ConvGradient",
+            "",
+            vector<string>{I(0), I(1), GO(0)},
+            vector<string>{GI(1), GI(2)});
+      }
     } else {
-      return SingleGradientDef(
-          "ConvGradient",
-          "",
-          vector<string>{I(0), I(1), GO(0)},
-          vector<string>{GI(1), GI(0)},
-          vector<Argument>{MakeArgument<int>("no_bias", 1)});
+      if (compute_dX) {
+        return SingleGradientDef(
+            "ConvGradient",
+            "",
+            vector<string>{I(0), I(1), GO(0)},
+            vector<string>{GI(1), GI(0)},
+            vector<Argument>{MakeArgument<int>("no_bias", 1)});
+      } else {
+        return SingleGradientDef(
+            "ConvGradient",
+            "",
+            vector<string>{I(0), I(1), GO(0)},
+            vector<string>{GI(1)},
+            vector<Argument>{MakeArgument<int>("no_bias", 1)});
+      }
     }
   }
 };

--- a/caffe2/operators/conv_gradient_op.cc
+++ b/caffe2/operators/conv_gradient_op.cc
@@ -6,7 +6,7 @@ namespace caffe2 {
 namespace {
 
 REGISTER_CPU_OPERATOR(ConvGradient, ConvGradientOp<float, CPUContext>);
-OPERATOR_SCHEMA(ConvGradient).NumInputs(2, 3).NumOutputs(2, 3);
+OPERATOR_SCHEMA(ConvGradient).NumInputs(2, 3).NumOutputs(1, 3);
 class GetConvGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;
   vector<OperatorDef> GetGradientDefs() override {


### PR DESCRIPTION
Based on a discussion with @Yangqing, optionally disables the calculation of dX for a convolution op (i.e. conv1 in Alexnet), where the data gradient is not needed.