### PR TITLE
Add tests and GPU impls for sparse optimizers

### DIFF
--- a/caffe2/python/operator_test/adagrad_test.py
+++ b/caffe2/python/operator_test/adagrad_test.py
@@ -1,0 +1,77 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import functools
+
+from hypothesis import given
+import numpy as np
+
+from caffe2.python import core
+import caffe2.python.hypothesis_test_util as hu
+
+
+class TestAdagrad(hu.HypothesisTestCase):
+
+    @staticmethod
+    def ref_adagrad(param_in, mom_in, grad, lr, epsilon):
+        mom_out = mom_in + np.square(grad)
+        grad_adj = lr * grad / (np.sqrt(mom_out) + epsilon)
+        param_out = param_in + grad_adj
+        return (param_out, mom_out)
+
+    @given(inputs=hu.tensors(n=3), **hu.gcs)
+    def test_adagrad(self, inputs, gc, dc):
+        # Inputs
+        param, momentum, grad = inputs
+        lr = np.random.rand(1).astype(np.float32)
+
+        # Op parameters
+        epsilon = np.random.rand(1).astype(np.float32)[0]
+
+        op = core.CreateOperator(
+            "Adagrad",
+            ["param", "momentum", "grad", "lr"],
+            ["param", "momentum"],
+            epsilon=epsilon,
+            device_option=gc,
+        )
+
+        self.assertReferenceChecks(
+            gc, op,
+            [param, momentum, grad, lr],
+            functools.partial(self.ref_adagrad, epsilon=epsilon))
+
+    @given(inputs=hu.tensors(n=3), **hu.gcs)
+    def test_sparse_adagrad(self, inputs, gc, dc):
+        # Inputs
+        param, momentum, grad = inputs
+        indices = np.arange(grad.shape[0])
+        indices = indices[indices % 2 == 0]
+        grad = grad[indices]
+        momentum = np.abs(momentum)
+        lr = np.random.rand(1).astype(np.float32)
+
+        # Op parameters
+        epsilon = np.random.rand(1).astype(np.float32)[0]
+
+        op = core.CreateOperator(
+            "SparseAdagrad",
+            ["param", "momentum", "indices", "grad", "lr"],
+            ["param", "momentum"],
+            epsilon=epsilon,
+            device_option=gc)
+
+        def ref_sparse(param, momentum, indices, grad, lr):
+            param_out = np.copy(param)
+            momentum_out = np.copy(momentum)
+            for i, index in enumerate(indices):
+                param_out[index], momentum_out[index] = self.ref_adagrad(
+                    param[index], momentum[index], grad[i], lr, epsilon)
+            return (param_out, momentum_out)
+
+        self.assertReferenceChecks(
+            gc, op,
+            [param, momentum, indices, grad, lr],
+            ref_sparse)

--- a/caffe2/python/operator_test/adam_test.py
+++ b/caffe2/python/operator_test/adam_test.py
@@ -1,0 +1,110 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import functools
+
+from hypothesis import given
+import hypothesis.strategies as st
+import numpy as np
+
+from caffe2.python import core
+import caffe2.python.hypothesis_test_util as hu
+
+
+class TestAdam(hu.HypothesisTestCase):
+
+    @staticmethod
+    def ref_adam(param, mom1, mom2, grad, LR, ITER,
+                 beta1, beta2, epsilon):
+        t = ITER + 1
+        corrected_local_rate = LR * np.sqrt(1 - np.power(beta2, t)) / \
+            (1 - np.power(beta1, t))
+        mom1_out = (beta1 * mom1) + (1 - beta1) * grad
+        mom2_out = (beta2 * mom2) + (1 - beta2) * np.square(grad)
+        param_out = param + corrected_local_rate * mom1_out / \
+            (np.sqrt(mom2_out) + epsilon)
+        return param_out, mom1_out, mom2_out
+
+    @given(inputs=hu.tensors(n=4),
+           ITER=st.integers(min_value=0, max_value=10000),
+           LR=st.floats(min_value=0.01, max_value=0.99,
+                        allow_nan=False, allow_infinity=False),
+           beta1=st.floats(min_value=0.01, max_value=0.99,
+                           allow_nan=False, allow_infinity=False),
+           beta2=st.floats(min_value=0.01, max_value=0.99,
+                           allow_nan=False, allow_infinity=False),
+           epsilon=st.floats(min_value=0.01, max_value=0.99,
+                             allow_nan=False, allow_infinity=False),
+           **hu.gcs)
+    def test_adam(self, inputs, ITER, LR, beta1, beta2, epsilon, gc, dc):
+        param, mom1, mom2, grad = inputs
+        ITER = np.array([ITER], dtype=np.int64)
+        LR = np.array([LR], dtype=np.float32)
+
+        op = core.CreateOperator(
+            "Adam",
+            ["param", "mom1", "mom2", "grad", "lr", "iter"],
+            ["output_param", "output_mom1", "output_mom2"],
+            beta1=beta1, beta2=beta2, epsilon=epsilon)
+
+        # Iter lives on the CPU
+        input_device_options = {'iter': hu.cpu_do}
+
+        self.assertReferenceChecks(
+            gc, op,
+            [param, mom1, mom2, grad, LR, ITER],
+            functools.partial(
+                self.ref_adam,
+                beta1=beta1, beta2=beta2, epsilon=epsilon),
+            input_device_options=input_device_options)
+
+    @given(inputs=hu.tensors(n=4),
+           ITER=st.integers(min_value=0, max_value=10000),
+           LR=st.floats(min_value=0.01, max_value=0.99,
+                        allow_nan=False, allow_infinity=False),
+           beta1=st.floats(min_value=0.01, max_value=0.99,
+                           allow_nan=False, allow_infinity=False),
+           beta2=st.floats(min_value=0.01, max_value=0.99,
+                           allow_nan=False, allow_infinity=False),
+           epsilon=st.floats(min_value=0.01, max_value=0.99,
+                             allow_nan=False, allow_infinity=False),
+           **hu.gcs)
+    def test_sparse_adam(self, inputs, ITER, LR, beta1, beta2, epsilon,
+                         gc, dc):
+        param, mom1, mom2, grad = inputs
+        mom1 = np.absolute(mom1)
+        mom2 = np.absolute(mom2)
+        ITER = np.array([ITER], dtype=np.int64)
+        LR = np.array([LR], dtype=np.float32)
+
+        indices = np.arange(grad.shape[0])
+        indices = indices[indices % 2 == 0]
+        grad = grad[indices]
+
+        op = core.CreateOperator(
+            "SparseAdam",
+            ["param", "mom1", "mom2", "indices", "grad", "lr", "iter"],
+            ["param", "mom1", "mom2"],
+            beta1=beta1, beta2=beta2, epsilon=epsilon)
+
+        def ref_sparse(param, mom1, mom2, indices, grad, LR, ITER):
+            param_out = np.copy(param)
+            mom1_out = np.copy(mom1)
+            mom2_out = np.copy(mom2)
+            for i, index in enumerate(indices):
+                param_out[index], mom1_out[index], mom2_out[index] = \
+                    self.ref_adam(param[index], mom1[index], mom2[index],
+                                  grad[i], LR, ITER,
+                                  beta1, beta2, epsilon)
+            return (param_out, mom1_out, mom2_out)
+
+        # Iter lives on the CPU
+        input_device_options = {'iter': hu.cpu_do}
+
+        self.assertReferenceChecks(
+            gc, op,
+            [param, mom1, mom2, indices, grad, LR, ITER],
+            ref_sparse,
+            input_device_options=input_device_options)

--- a/caffe2/python/operator_test/momentum_sgd_test.py
+++ b/caffe2/python/operator_test/momentum_sgd_test.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 from caffe2.python import core
 import caffe2.python.hypothesis_test_util as hu
 
+import hypothesis
 from hypothesis import given
 import hypothesis.strategies as st
 import numpy as np
@@ -64,15 +65,28 @@ class TestMomentumSGD(hu.HypothesisTestCase):
            momentum=st.floats(min_value=0.1, max_value=0.9),
            nesterov=st.booleans(),
            lr=st.floats(min_value=0.1, max_value=0.9),
+           data_strategy=st.data(),
            **hu.gcs)
     def test_sparse_momentum_sgd(
-            self, inputs, momentum, nesterov, lr, gc, dc):
+            self, inputs, momentum, nesterov, lr, data_strategy, gc, dc):
         w, grad, m = inputs
-        indices = np.arange(m.shape[0])
-        indices = indices[indices % 2 == 0]
 
+        # Create an indexing array containing values which index into grad
+        indices = data_strategy.draw(
+            hu.tensor(dtype=np.int64,
+                      elements=st.sampled_from(np.arange(grad.shape[0]))),
+        )
+        hypothesis.note('indices.shape: %s' % str(indices.shape))
+
+        # For now, the indices must be unique
+        hypothesis.assume(np.array_equal(np.unique(indices.flatten()),
+                                         np.sort(indices.flatten())))
+
+        # Sparsify grad
         grad = grad[indices]
+        # Make momentum >= 0
         m = np.abs(m)
+        # Convert lr to a numpy array
         lr = np.asarray([lr], dtype=np.float32)
 
         op = core.CreateOperator(

--- a/caffe2/python/operator_test/momentum_sgd_test.py
+++ b/caffe2/python/operator_test/momentum_sgd_test.py
@@ -64,7 +64,7 @@ class TestMomentumSGD(hu.HypothesisTestCase):
            momentum=st.floats(min_value=0.1, max_value=0.9),
            nesterov=st.booleans(),
            lr=st.floats(min_value=0.1, max_value=0.9),
-           **hu.gcs_cpu_only)
+           **hu.gcs)
     def test_sparse_momentum_sgd(
             self, inputs, momentum, nesterov, lr, gc, dc):
         w, grad, m = inputs

--- a/caffe2/sgd/adagrad_op.cc
+++ b/caffe2/sgd/adagrad_op.cc
@@ -32,7 +32,7 @@ REGISTER_CPU_OPERATOR(SparseAdagrad, SparseAdagradOp<float, CPUContext>);
 OPERATOR_SCHEMA(SparseAdagrad)
     .NumInputs(5)
     .NumOutputs(2)
-    .AllowInplace({{0, 0}, {1, 1}})
+    .EnforceInplace({{0, 0}, {1, 1}})
     .SetDoc(R"DOC(
 
 Given inputs (param, history, indices, grad, lr), runs the dense AdaGrad

--- a/caffe2/sgd/adagrad_op.h
+++ b/caffe2/sgd/adagrad_op.h
@@ -75,9 +75,6 @@ class SparseAdagradOp final : public Operator<Context> {
   template <typename SIndex>
   bool DoRunWithType() {
     const auto* lr = Input(LR).template data<T>();
-    Output(OUTPUT_PARAM)->ResizeLike(Input(PARAM));
-    Output(OUTPUT_MOMENT_1)->ResizeLike(Input(MOMENT_1));
-
     auto n = Input(GRAD).dim(0);
 
     const auto* indices = Input(INDICES).template data<SIndex>();

--- a/caffe2/sgd/adagrad_op.h
+++ b/caffe2/sgd/adagrad_op.h
@@ -7,37 +7,18 @@ namespace caffe2 {
 template <typename Context>
 void adagrad_update(
     int N,
-    const float* g,
-    const float* h,
-    float* ng,
-    float* nh,
-    float epsilon,
-    const float* lr,
-    Context* context) {
-  // TODO(cxj): use OMP when it is reliable
-  // #pragma omp parallel for
-  for (auto i = 0; i < N; ++i) {
-    float gi = g[i];
-    float hi = nh[i] = h[i] + gi * gi;
-    ng[i] = lr[0] * gi / (std::sqrt(hi) + epsilon);
-  }
-}
-
-template <typename Context>
-void adagrad_compute(
-    int N,
     const float* w,
     const float* g,
     const float* h,
     float* nw,
     float* nh,
     float epsilon,
-    float lr,
+    const float *lr,
     Context* context) {
   for (auto i = 0; i < N; ++i) {
     float gi = g[i];
     float hi = nh[i] = h[i] + gi * gi;
-    nw[i] = w[i] + lr * gi / (std::sqrt(hi) + epsilon);
+    nw[i] = w[i] + lr[0] * gi / (std::sqrt(hi) + epsilon);
   }
 }
 
@@ -53,7 +34,7 @@ class AdagradOp final : public Operator<Context> {
     CAFFE_ENFORCE(Input(GRAD).size() == Input(PARAM).size());
     Output(OUTPUT_PARAM)->ResizeLike(Input(PARAM));
     Output(OUTPUT_MOMENT_1)->ResizeLike(Input(MOMENT_1));
-    adagrad_compute<Context>(
+    adagrad_update<Context>(
         Input(GRAD).size(),
         Input(PARAM).template data<T>(),
         Input(GRAD).template data<T>(),
@@ -61,7 +42,7 @@ class AdagradOp final : public Operator<Context> {
         Output(OUTPUT_PARAM)->template mutable_data<T>(),
         Output(OUTPUT_MOMENT_1)->template mutable_data<T>(),
         epsilon_,
-        Input(LR).template data<T>()[0],
+        Input(LR).template data<T>(),
         &context_);
     return true;
   }
@@ -81,6 +62,24 @@ class SparseAdagradOp final : public Operator<Context> {
         epsilon_(OperatorBase::GetSingleArgument<float>("epsilon", 1e-5f)) {}
 
   bool RunOnDevice() override {
+    // Enforce types
+    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(PARAM));
+    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(MOMENT_1));
+    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(INDICES));
+    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(GRAD));
+    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(LR));
+
+    // Enforce shapes
+    CAFFE_ENFORCE(Input(PARAM).size() == Input(MOMENT_1).size());
+    CAFFE_ENFORCE(Input(LR).size() == 1);
+
+    // These must be in-place for the sparse op. If out-of-place is required,
+    // we need to copy input to output before running.
+    CAFFE_ENFORCE_EQ(&Input(PARAM), Output(OUTPUT_PARAM),
+        "PARAM must be in-place");
+    CAFFE_ENFORCE_EQ(&Input(MOMENT_1), Output(OUTPUT_MOMENT_1),
+        "MOMENTUM must be in-place");
+
     return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
         this, Input(INDICES));
   }
@@ -114,7 +113,7 @@ class SparseAdagradOp final : public Operator<Context> {
       } else {
         auto offsetI = i * block_size;
         auto offsetIdx = idx * block_size;
-        adagrad_compute(
+        adagrad_update(
             block_size,
             paramIn + offsetIdx,
             gradIn + offsetI,
@@ -122,7 +121,7 @@ class SparseAdagradOp final : public Operator<Context> {
             paramOut + offsetIdx,
             momentOut + offsetIdx,
             epsilon_,
-            lr[0],
+            lr,
             &context_);
       }
     }

--- a/caffe2/sgd/adagrad_op.h
+++ b/caffe2/sgd/adagrad_op.h
@@ -62,25 +62,11 @@ class SparseAdagradOp final : public Operator<Context> {
         epsilon_(OperatorBase::GetSingleArgument<float>("epsilon", 1e-5f)) {}
 
   bool RunOnDevice() override {
-    // Enforce types
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(PARAM));
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(MOMENT_1));
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(INDICES));
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(GRAD));
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(LR));
-
     // Enforce shapes
-    CAFFE_ENFORCE(Input(PARAM).size() == Input(MOMENT_1).size());
-    CAFFE_ENFORCE(Input(LR).size() == 1);
-    CAFFE_ENFORCE(Input(PARAM).size_from_dim(1) ==
-            Input(GRAD).size_from_dim(Input(INDICES).ndim()));
-
-    // These must be in-place for the sparse op. If out-of-place is required,
-    // we need to copy input to output before running.
-    CAFFE_ENFORCE_EQ(&Input(PARAM), Output(OUTPUT_PARAM),
-        "PARAM must be in-place");
-    CAFFE_ENFORCE_EQ(&Input(MOMENT_1), Output(OUTPUT_MOMENT_1),
-        "MOMENTUM must be in-place");
+    CAFFE_ENFORCE_EQ(Input(PARAM).size(), Input(MOMENT_1).size());
+    CAFFE_ENFORCE_EQ(Input(LR).size(), 1);
+    CAFFE_ENFORCE_EQ(Input(PARAM).size_from_dim(1),
+        Input(GRAD).size_from_dim(Input(INDICES).ndim()));
 
     return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
         this, Input(INDICES));

--- a/caffe2/sgd/adagrad_op.h
+++ b/caffe2/sgd/adagrad_op.h
@@ -72,6 +72,8 @@ class SparseAdagradOp final : public Operator<Context> {
     // Enforce shapes
     CAFFE_ENFORCE(Input(PARAM).size() == Input(MOMENT_1).size());
     CAFFE_ENFORCE(Input(LR).size() == 1);
+    CAFFE_ENFORCE(Input(PARAM).size_from_dim(1) ==
+            Input(GRAD).size_from_dim(Input(INDICES).ndim()));
 
     // These must be in-place for the sparse op. If out-of-place is required,
     // we need to copy input to output before running.

--- a/caffe2/sgd/adagrad_op_gpu.cu
+++ b/caffe2/sgd/adagrad_op_gpu.cu
@@ -6,25 +6,27 @@ namespace caffe2 {
 
 __global__ void AdagradUpdate(
     int N,
+    const float* w,
     const float* g,
     const float* h,
-    float* ng,
+    float* nw,
     float* nh,
     float epsilon,
     const float* lr) {
   CUDA_1D_KERNEL_LOOP(i, N) {
     float gi = g[i];
     float hi = nh[i] = h[i] + gi * gi;
-    ng[i] = lr[0] * gi / (std::sqrt(hi) + epsilon);
+    nw[i] = w[i] + lr[0] * gi / (std::sqrt(hi) + epsilon);
   }
 }
 
 template <>
 void adagrad_update<CUDAContext>(
     int N,
+    const float* w,
     const float* g,
     const float* h,
-    float* ng,
+    float* nw,
     float* nh,
     float epsilon,
     const float* lr,
@@ -33,10 +35,54 @@ void adagrad_update<CUDAContext>(
       CAFFE_GET_BLOCKS(N),
       CAFFE_CUDA_NUM_THREADS,
       0,
-      context->cuda_stream()>>>(N, g, h, ng, nh, epsilon, lr);
+      context->cuda_stream()>>>(N, w, g, h, nw, nh, epsilon, lr);
+}
+
+template <typename SIndex>
+__global__ void SparseAdagradKernel(
+    const size_t N,
+    const size_t grad_slice_sz,
+    const float epsilon,
+    float *param,
+    float *param_mom,
+    const SIndex *indices,
+    const float *grad,
+    const float *lr)
+{
+  const float LR = lr[0];
+  CUDA_1D_KERNEL_LOOP(i, N)
+  {
+    const size_t gradIdx = i;
+    const SIndex index = indices[i / grad_slice_sz];
+    const size_t paramIdx = index * grad_slice_sz + (i % grad_slice_sz);
+
+    const float mom_new = param_mom[paramIdx] + grad[gradIdx] * grad[gradIdx];
+    param_mom[paramIdx] = mom_new;
+    param[paramIdx] += LR * grad[gradIdx] / (sqrt(mom_new) + epsilon);
+  }
+}
+
+template<>
+template<typename SIndex>
+bool SparseAdagradOp<float, CUDAContext>::DoRunWithType()
+{
+  auto N = Input(GRAD).size();
+  auto grad_slice_sz = Input(GRAD).size() / Input(GRAD).dim(0);
+
+  SparseAdagradKernel<SIndex><<<
+    CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS, 0,
+    context_.cuda_stream()>>>(
+        N, grad_slice_sz, epsilon_,
+        Output(OUTPUT_PARAM)->template mutable_data<float>(),
+        Output(OUTPUT_MOMENT_1)->template mutable_data<float>(),
+        Input(INDICES).template data<SIndex>(),
+        Input(GRAD).template data<float>(),
+        Input(LR).template data<float>());
+  return true;
 }
 
 namespace {
 REGISTER_CUDA_OPERATOR(Adagrad, AdagradOp<float, CUDAContext>);
+REGISTER_CUDA_OPERATOR(SparseAdagrad, SparseAdagradOp<float, CUDAContext>);
 }
 }

--- a/caffe2/sgd/adagrad_op_gpu.cu
+++ b/caffe2/sgd/adagrad_op_gpu.cu
@@ -67,7 +67,7 @@ template<typename SIndex>
 bool SparseAdagradOp<float, CUDAContext>::DoRunWithType()
 {
   auto N = Input(GRAD).size();
-  auto grad_slice_sz = Input(GRAD).size() / Input(GRAD).dim(0);
+  auto grad_slice_sz = Input(GRAD).size_from_dim(Input(INDICES).ndim());
 
   SparseAdagradKernel<SIndex><<<
     CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS, 0,

--- a/caffe2/sgd/adam_op.cc
+++ b/caffe2/sgd/adam_op.cc
@@ -43,7 +43,7 @@ REGISTER_CPU_OPERATOR(SparseAdam, SparseAdamOp<float, CPUContext>);
 OPERATOR_SCHEMA(SparseAdam)
     .NumInputs(7)
     .NumOutputs(3)
-    .AllowInplace({{0, 0}, {1, 1}, {2, 2}})
+    .EnforceInplace({{0, 0}, {1, 1}, {2, 2}})
     .SetDoc(R"DOC(
 
 Computes the Adam Update for the sparse case.

--- a/caffe2/sgd/adam_op.h
+++ b/caffe2/sgd/adam_op.h
@@ -115,30 +115,12 @@ class SparseAdamOp final : public Operator<Context> {
         epsilon_(OperatorBase::GetSingleArgument<float>("epsilon", 1e-5f)) {}
 
   bool RunOnDevice() override {
-    // Enforce types
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(PARAM));
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(MOMENT_1));
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(MOMENT_2));
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(INDICES));
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(GRAD));
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(LR));
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<CPUContext>>(ITER));
-
     // Enforce shapes
-    CAFFE_ENFORCE(Input(PARAM).size() == Input(MOMENT_1).size());
-    CAFFE_ENFORCE(Input(PARAM).size() == Input(MOMENT_2).size());
-    CAFFE_ENFORCE(Input(PARAM).size_from_dim(1) ==
-            Input(GRAD).size_from_dim(Input(INDICES).ndim()));
-    CAFFE_ENFORCE(Input(LR).size() == 1);
-
-    // These must be in-place for the sparse op. If out-of-place is required,
-    // we need to copy input to output before running.
-    CAFFE_ENFORCE_EQ(&Input(PARAM), Output(OUTPUT_PARAM),
-        "PARAM must be in-place");
-    CAFFE_ENFORCE_EQ(&Input(MOMENT_1), Output(OUTPUT_MOMENT_1),
-        "MOMENT_1 must be in-place");
-    CAFFE_ENFORCE_EQ(&Input(MOMENT_2), Output(OUTPUT_MOMENT_2),
-        "MOMENT_2 must be in-place");
+    CAFFE_ENFORCE_EQ(Input(PARAM).size(), Input(MOMENT_1).size());
+    CAFFE_ENFORCE_EQ(Input(PARAM).size(), Input(MOMENT_2).size());
+    CAFFE_ENFORCE_EQ(Input(PARAM).size_from_dim(1),
+        Input(GRAD).size_from_dim(Input(INDICES).ndim()));
+    CAFFE_ENFORCE_EQ(Input(LR).size(), 1);
 
     return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
         this, Input(INDICES));

--- a/caffe2/sgd/adam_op.h
+++ b/caffe2/sgd/adam_op.h
@@ -127,6 +127,8 @@ class SparseAdamOp final : public Operator<Context> {
     // Enforce shapes
     CAFFE_ENFORCE(Input(PARAM).size() == Input(MOMENT_1).size());
     CAFFE_ENFORCE(Input(PARAM).size() == Input(MOMENT_2).size());
+    CAFFE_ENFORCE(Input(PARAM).size_from_dim(1) ==
+            Input(GRAD).size_from_dim(Input(INDICES).ndim()));
     CAFFE_ENFORCE(Input(LR).size() == 1);
 
     // These must be in-place for the sparse op. If out-of-place is required,

--- a/caffe2/sgd/adam_op_gpu.cu
+++ b/caffe2/sgd/adam_op_gpu.cu
@@ -122,7 +122,7 @@ template<typename SIndex>
 bool SparseAdamOp<float, CUDAContext>::DoRunWithType()
 {
   auto N = Input(GRAD).size();
-  auto grad_slice_sz = Input(GRAD).size() / Input(GRAD).dim(0);
+  auto grad_slice_sz = Input(GRAD).size_from_dim(Input(INDICES).ndim());
   const auto iter =
       OperatorBase::Input<TensorCPU>(ITER).template data<int64_t>()[0];
   const float correction = std::sqrt(1.0f - std::pow(beta2_, iter + 1)) /

--- a/caffe2/sgd/adam_op_gpu.cu
+++ b/caffe2/sgd/adam_op_gpu.cu
@@ -87,9 +87,66 @@ void adam_compute<CUDAContext>(
       N, w, g, m, v, nw, nm, nv, beta1, beta2, eps_hat, correction, lr);
 }
 
+template <typename SIndex>
+__global__ void SparseAdamKernel(
+    const size_t N,
+    const size_t grad_slice_sz,
+    const float beta1,
+    const float beta2,
+    const float epsilon,
+    float *param,
+    float *mom1,
+    float *mom2,
+    const SIndex *indices,
+    const float *grad,
+    const float correction,
+    const float *lr,
+    const float iter)
+{
+  CUDA_1D_KERNEL_LOOP(i, N)
+  {
+    const size_t gradIdx = i;
+    const SIndex index = indices[i / grad_slice_sz];
+    const size_t paramIdx = index * grad_slice_sz + (i % grad_slice_sz);
+
+    float m1n = mom1[paramIdx] = mom1[paramIdx] * beta1 +
+        grad[gradIdx] * (1.0f - beta1);
+    float m2n = mom2[paramIdx] = mom2[paramIdx] * beta2 +
+        grad[gradIdx] * grad[gradIdx] * (1.0f - beta2);
+    param[paramIdx] += lr[0] * correction * m1n / (sqrt(m2n) + epsilon);
+  }
+}
+
+template<>
+template<typename SIndex>
+bool SparseAdamOp<float, CUDAContext>::DoRunWithType()
+{
+  auto N = Input(GRAD).size();
+  auto grad_slice_sz = Input(GRAD).size() / Input(GRAD).dim(0);
+  const auto iter =
+      OperatorBase::Input<TensorCPU>(ITER).template data<int64_t>()[0];
+  const float correction = std::sqrt(1.0f - std::pow(beta2_, iter + 1)) /
+      (1.0f - std::pow(beta1_, iter + 1));
+
+  SparseAdamKernel<SIndex><<<
+    CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS, 0,
+    context_.cuda_stream()>>>(
+        N, grad_slice_sz,
+        beta1_, beta2_, epsilon_,
+        Output(OUTPUT_PARAM)->template mutable_data<float>(),
+        Output(OUTPUT_MOMENT_1)->template mutable_data<float>(),
+        Output(OUTPUT_MOMENT_2)->template mutable_data<float>(),
+        Input(INDICES).template data<SIndex>(),
+        Input(GRAD).template data<float>(),
+        correction,
+        Input(LR).template data<float>(),
+        iter);
+  return true;
+}
 
 namespace {
 REGISTER_CUDA_OPERATOR(Adam, AdamOp<float, CUDAContext>);
+REGISTER_CUDA_OPERATOR(SparseAdam, SparseAdamOp<float, CUDAContext>);
 }
 
 }

--- a/caffe2/sgd/momentum_sgd_op.cc
+++ b/caffe2/sgd/momentum_sgd_op.cc
@@ -79,7 +79,8 @@ REGISTER_CPU_OPERATOR(
 OPERATOR_SCHEMA(SparseMomentumSGDUpdate)
     .NumInputs(5)
     .NumOutputs(3)
-    .AllowInplace({{0, 0}, {1, 1}, {3, 2}})
+    .AllowInplace({{0, 0}})
+    .EnforceInplace({{1, 1}, {3, 2}})
     .TensorInferenceFunction(
         [](const OperatorDef& /* unused */, const vector<TensorShape>& in) {
           vector<TensorShape> out(3);

--- a/caffe2/sgd/momentum_sgd_op.h
+++ b/caffe2/sgd/momentum_sgd_op.h
@@ -137,6 +137,8 @@ class SparseMomentumSGDUpdateOp final : public Operator<Context> {
     // Enforce shapes
     CAFFE_ENFORCE(Input(LR).size() == 1);
     CAFFE_ENFORCE(Input(PARAM).size() == Input(MOMENTUM).size());
+    CAFFE_ENFORCE(Input(PARAM).size_from_dim(1) ==
+            Input(GRAD).size_from_dim(Input(INDICES).ndim()));
 
     // These must be in-place for the sparse op. If out-of-place is required,
     // we need to copy input to output before running.

--- a/caffe2/sgd/momentum_sgd_op.h
+++ b/caffe2/sgd/momentum_sgd_op.h
@@ -126,26 +126,11 @@ class SparseMomentumSGDUpdateOp final : public Operator<Context> {
     // Resize [potentially] out-of-place blobs
     Output(OUTPUT_GRAD)->ResizeLike(Input(GRAD));
 
-    // Enforce types
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(GRAD));
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(MOMENTUM));
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(LR));
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(PARAM));
-    CAFFE_ENFORCE(OperatorBase::InputIsType<Tensor<Context>>(INDICES));
-    CAFFE_ENFORCE(OperatorBase::OutputIsType<Tensor<Context>>(OUTPUT_GRAD));
-
     // Enforce shapes
-    CAFFE_ENFORCE(Input(LR).size() == 1);
-    CAFFE_ENFORCE(Input(PARAM).size() == Input(MOMENTUM).size());
-    CAFFE_ENFORCE(Input(PARAM).size_from_dim(1) ==
-            Input(GRAD).size_from_dim(Input(INDICES).ndim()));
-
-    // These must be in-place for the sparse op. If out-of-place is required,
-    // we need to copy input to output before running.
-    CAFFE_ENFORCE_EQ(&Input(MOMENTUM), Output(OUTPUT_MOMENTUM),
-        "MOMENTUM must be in-place");
-    CAFFE_ENFORCE_EQ(&Input(PARAM), Output(OUTPUT_PARAM),
-        "PARAM must be in-place");
+    CAFFE_ENFORCE_EQ(Input(LR).size(), 1);
+    CAFFE_ENFORCE_EQ(Input(PARAM).size(), Input(MOMENTUM).size());
+    CAFFE_ENFORCE_EQ(Input(PARAM).size_from_dim(1),
+        Input(GRAD).size_from_dim(Input(INDICES).ndim()));
 
     return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
         this, Input(INDICES));

--- a/caffe2/sgd/momentum_sgd_op_gpu.cu
+++ b/caffe2/sgd/momentum_sgd_op_gpu.cu
@@ -57,9 +57,72 @@ void momentum_sgd_update<CUDAContext>(
       N, g, m, ng, nm, lr, momentum, nesterov, param);
 }
 
+
+template <typename SIndex>
+__global__ void SparseMomentumSGDKernel(
+    const size_t N,
+    const size_t sz,
+    const float momentum,
+    const bool nesterov,
+    float *param,
+    float *param_mom,
+    const SIndex *indices,
+    const float *gradIn,
+    float *gradOut,
+    const float *lr)
+{
+  const float LR = lr[0];
+  CUDA_1D_KERNEL_LOOP(i, N)
+  {
+    const size_t gradIdx = i;
+    const SIndex index = indices[i / sz];
+    const size_t paramIdx = index * sz + (i % sz);
+
+    if (!nesterov)
+    {
+      const float adjusted_gradient = LR * gradIn[gradIdx] +
+          momentum * param_mom[paramIdx];
+      gradOut[gradIdx] = adjusted_gradient;
+      param_mom[paramIdx] = adjusted_gradient;
+      param[paramIdx] -= adjusted_gradient;
+    } else {
+      const float mom_old = param_mom[paramIdx];
+      const float mom_new = LR * gradIn[gradIdx] + momentum * mom_old;
+      param_mom[paramIdx] = mom_new;
+      const float adjusted_gradient = (1 + momentum) * mom_new -
+          momentum * mom_old;
+      gradOut[gradIdx] = adjusted_gradient;
+      param[paramIdx] -= adjusted_gradient;
+    }
+  }
+}
+
+
+// Specialization of DoRunWithType for CUDA
+template <>
+template <typename SIndex>
+bool SparseMomentumSGDUpdateOp<float, CUDAContext>::DoRunWithType() {
+  auto N = Input(GRAD).size();
+  auto grad_slice_sz = Input(GRAD).size() / Input(GRAD).dim(0);
+
+  SparseMomentumSGDKernel<SIndex><<<
+    CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS, 0,
+    context_.cuda_stream()>>>(
+        N, grad_slice_sz,
+        momentum_, nesterov_,
+        Output(OUTPUT_PARAM)->template mutable_data<float>(),
+        Output(OUTPUT_MOMENTUM)->template mutable_data<float>(),
+        Input(INDICES).template data<SIndex>(),
+        Input(GRAD).template data<float>(),
+        Output(OUTPUT_GRAD)->template mutable_data<float>(),
+        Input(LR).template data<float>());
+  return true;
+}
+
 namespace {
 REGISTER_CUDA_OPERATOR(MomentumSGD, MomentumSGDOp<float, CUDAContext>);
 REGISTER_CUDA_OPERATOR(MomentumSGDUpdate, MomentumSGDUpdateOp<float, CUDAContext>);
+REGISTER_CUDA_OPERATOR(SparseMomentumSGDUpdate, SparseMomentumSGDUpdateOp<float, CUDAContext>);
 
 }
 

--- a/caffe2/sgd/momentum_sgd_op_gpu.cu
+++ b/caffe2/sgd/momentum_sgd_op_gpu.cu
@@ -103,7 +103,7 @@ template <>
 template <typename SIndex>
 bool SparseMomentumSGDUpdateOp<float, CUDAContext>::DoRunWithType() {
   auto N = Input(GRAD).size();
-  auto grad_slice_sz = Input(GRAD).size() / Input(GRAD).dim(0);
+  auto grad_slice_sz = Input(GRAD).size_from_dim(Input(INDICES).ndim());
 
   SparseMomentumSGDKernel<SIndex><<<
     CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS, 0,


### PR DESCRIPTION
These GPU paths are probably even buggier than the CPU paths for sparse gradients with duplicate indices. Both paths cause multiple momentum updates in a single iteration, but only the GPU path is non-deterministic. Depending on how we decide to address the issues on the CPU path, @pooyadavoodi has a good idea for how to match dense behavior with the sparse GPU ops.