### PR TITLE
Repro for FC ULT failing if omp_num_threads set to 2

### DIFF
--- a/caffe2/core/init_omp.cc
+++ b/caffe2/core/init_omp.cc
@@ -11,7 +11,7 @@
 #include "caffe2/core/init.h"
 
 CAFFE2_DEFINE_int(
-    caffe2_omp_num_threads, 0,
+    caffe2_omp_num_threads, 2,
     "The number of openmp threads. 0 to use default value. "
     "Does not have effect if OpenMP is disabled.");
 CAFFE2_DEFINE_int(

--- a/caffe2/mkl/operators/fully_connected_op.cc
+++ b/caffe2/mkl/operators/fully_connected_op.cc
@@ -1,0 +1,111 @@
+#include "caffe2/core/context.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/utils/mkl_utils.h"
+
+#ifdef CAFFE2_HAS_MKL_DNN
+
+namespace caffe2 {
+namespace mkl {
+
+template <typename T>
+class MKLFullyConnectedOp final : public MKLOperator<T> {
+ public:
+
+  MKLFullyConnectedOp(const OperatorDef& operator_def, Workspace* ws)
+      : MKLOperator<T>(operator_def, ws),
+        axis_(OperatorBase::GetSingleArgument<int32_t>("axis", 1)) {}
+  ~MKLFullyConnectedOp() {}
+
+  bool RunOnDevice() override {
+    auto& X = OperatorBase::Input<MKLMemory<float>>(INPUT);
+    auto& filter = OperatorBase::Input<MKLMemory<float>>(FILTER);
+    auto& bias = OperatorBase::Input<MKLMemory<float>>(BIAS);
+    MKLMemory<float>* Y = OperatorBase::Output<MKLMemory<float>>(0);
+
+    CAFFE_ENFORCE(filter.ndim() == 2, filter.ndim());
+    CAFFE_ENFORCE(bias.ndim() == 1, bias.ndim());
+
+    if (cached_input_dims_ != X.dims() ||
+        cached_filter_dims_ != filter.dims()) {
+      cached_input_dims_ = X.dims();
+      cached_filter_dims_ = filter.dims();
+
+        const int N = filter.dim32(0);
+        CAFFE_ENFORCE(N == bias.dim32(0));
+        
+        auto Y_shape = X.dims();
+        Y_shape[1] = N;        
+        Y_shape.resize(2);
+        
+        size_t inputSizes[4];
+        if (X.ndim() == 2) {
+          inputSizes[0] = X.dim32(1);
+          inputSizes[1] = X.dim32(0);
+        } else {
+          inputSizes[0] = X.dim32(3);
+          inputSizes[1] = X.dim32(2);
+          inputSizes[2] = X.dim32(1);
+          inputSizes[3] = X.dim32(0);
+        }
+       
+        size_t outputSizes[2] = {Y_shape[1], Y_shape[0]};
+        
+        primitive_.Reset(
+          dnnInnerProductCreateForwardBias<float>,
+          nullptr,
+          X.ndim(),
+          inputSizes,
+        outputSizes[0]);
+
+      Y->Reset(Y_shape, primitive_, dnnResourceDst);
+      buffer_.Reset(Y_shape, primitive_, dnnResourceDst, true);    
+
+      input_layout_.Reset(primitive_, dnnResourceSrc);
+      filter_layout_.Reset(primitive_, dnnResourceFilter);
+    }
+
+    // Try to share from the output: this allows us to avoid unnecessary copy
+    // operations, if the output is already allocated and is having the same
+    // layout as the buffer has.
+    buffer_.ShareFrom(*Y);
+
+    std::shared_ptr<void> X_view = X.View(
+        input_layout_, primitive_, dnnResourceSrc);
+    std::shared_ptr<void> filter_view = filter.View(
+        filter_layout_, primitive_, dnnResourceFilter);
+            
+    resources_[dnnResourceSrc] = X_view.get();
+    resources_[dnnResourceFilter] = filter_view.get();
+    
+    resources_[dnnResourceBias] = bias.buffer();
+    resources_[dnnResourceDst] = buffer_.buffer();
+
+    MKLDNN_SAFE_CALL(mkl::dnnExecute<T>(primitive_, resources_));
+    buffer_.CopyTo(Y, primitive_, dnnResourceDst);    
+    return true;
+  }
+
+
+ private:
+  // Input: X, W, b
+  // Output: Y
+  size_t axis_{1};
+  vector<TIndex> cached_input_dims_;
+  vector<TIndex> cached_filter_dims_;
+  PrimitiveWrapper<T> primitive_;
+  LayoutWrapper<T> input_layout_;
+  LayoutWrapper<T> filter_layout_;
+  LayoutWrapper<T> bias_layout_;
+  MKLMemory<T> buffer_;
+  void* resources_[dnnResourceNumber] = {0};
+  INPUT_TAGS(INPUT, FILTER, BIAS);
+};
+
+} // namespace mkl
+
+
+REGISTER_MKL_OPERATOR(FC, mkl::MKLFullyConnectedOp<float>);
+
+}  // namespace caffe2
+
+#endif // CAFFE2_HAS_MKL_DNN

--- a/caffe2/python/operator_test/mkl_fc_op_test.py
+++ b/caffe2/python/operator_test/mkl_fc_op_test.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+import hypothesis.strategies as st
+from hypothesis import given, settings
+import numpy as np
+from caffe2.python import core, workspace
+import caffe2.python.hypothesis_test_util as hu
+import caffe2.python.mkl_test_util as mu
+
+
+@unittest.skipIf(not workspace.C.has_mkldnn,
+                 "Skipping as we do not have mkldnn.")
+class MKLFcTest(hu.HypothesisTestCase):
+    @given(n=st.integers(1, 5), m=st.integers(1, 5),
+           k=st.integers(1, 5), **mu.gcs)
+    
+    def test_mkl_fc(self,n, m, k, gc, dc):
+        X = np.random.rand(m, k).astype(np.float32) - 0.5
+        W = np.random.rand(n, k).astype(np.float32) - 0.5
+        b = np.random.rand(n).astype(np.float32) - 0.5
+        
+        op = core.CreateOperator(
+            'FC',
+            ['X', 'W', 'b'],
+            ["Y"]
+            )
+        
+        self.assertDeviceChecks(dc, op, [X, W, b], [0])
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()

--- a/caffe2/python/operator_test/mkl_fc_speed_test.py
+++ b/caffe2/python/operator_test/mkl_fc_speed_test.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+import unittest
+
+import numpy as np
+from caffe2.proto import caffe2_pb2
+from caffe2.python import cnn, core, workspace, test_util
+
+
+@unittest.skipIf(not workspace.C.has_mkldnn, "Skipping as we do not have mkldnn.")
+class TestMKLBasic(test_util.TestCase):
+    def testFCSpeed(self):
+        # We randomly select a shape to test the speed. Intentionally we
+        # test a batch size of 1 since this may be the most frequent use
+        # case for MKL during deployment time.
+        X = np.random.rand(1, 256, 6, 6).astype(np.float32) - 0.5
+        #X = np.random.rand(32, 256*6*6).astype(np.float32) - 0.5
+        W = np.random.rand(4096, 9216).astype(np.float32) - 0.5
+        b = np.random.rand(4096).astype(np.float32) - 0.5
+        mkl_do = core.DeviceOption(caffe2_pb2.MKLDNN)
+        # Makes sure that feed works.
+        workspace.FeedBlob("X", X)
+        workspace.FeedBlob("W", W)
+        workspace.FeedBlob("b", b)
+        workspace.FeedBlob("X_mkl", X, device_option=mkl_do)
+        workspace.FeedBlob("W_mkl", W, device_option=mkl_do)
+        workspace.FeedBlob("b_mkl", b, device_option=mkl_do)
+        net = core.Net("test")
+        # Makes sure that we can run relu.
+        net.FC(["X", "W", "b"], "Y")
+        net.FC(["X_mkl", "W_mkl", "b_mkl"], "Y_mkl", device_option=mkl_do)
+
+        workspace.CreateNet(net)
+        workspace.RunNet(net)
+        # makes sure that the results are good.
+        np.testing.assert_allclose(
+            workspace.FetchBlob("Y"),
+            workspace.FetchBlob("Y_mkl"),
+            atol=1e-2,
+            rtol=1e-2)
+        runtime = workspace.BenchmarkNet(net.Proto().name, 1000, 1000, True)
+
+        print("FC CPU runtime {}, MKL runtime {}.".format(runtime[1], runtime[2]))
+
+    '''def testConvReluMaxPoolFcSpeed(self):
+        # We randomly select a shape to test the speed. Intentionally we
+        # test a batch size of 1 since this may be the most frequent use
+        # case for MKL during deployment time.
+        X = np.random.rand(1, 256, 13, 13).astype(np.float32) - 0.5
+        W = np.random.rand(256, 256, 3, 3).astype(np.float32) - 0.5
+        b = np.random.rand(256).astype(np.float32) - 0.5
+
+        w_fc = np.random.rand(4096, 9216).astype(np.float32) - 0.5
+        b_fc = np.random.rand(4096).astype(np.float32) - 0.5        
+        mkl_do = core.DeviceOption(caffe2_pb2.MKLDNN)
+        # Makes sure that feed works.
+        workspace.FeedBlob("X", X)
+        workspace.FeedBlob("W", W)
+        workspace.FeedBlob("b", b)
+        workspace.FeedBlob("w_fc", w_fc)
+        workspace.FeedBlob("b_fc", b_fc)        
+        workspace.FeedBlob("X_mkl", X, device_option=mkl_do)
+        workspace.FeedBlob("W_mkl", W, device_option=mkl_do)
+        workspace.FeedBlob("b_mkl", b, device_option=mkl_do)
+        workspace.FeedBlob("w_fc_mkl", w_fc, device_option=mkl_do)
+        workspace.FeedBlob("b_fc_mkl", b_fc, device_option=mkl_do)        
+
+        net = core.Net("test")
+        
+        net.Conv(["X", "W", "b"], "C", pad=1, stride=1, kernel=3)
+        net.Relu("C", "R")
+        net.MaxPool("R", "P", stride=2, kernel=3)
+        net.FC(["P","w_fc", "b_fc"], "Y")
+        
+        net.Conv(["X_mkl", "W_mkl", "b_mkl"], "C_mkl",
+                 pad=1, stride=1, kernel=3, device_option=mkl_do)
+        net.Relu("C_mkl", "R_mkl", device_option=mkl_do)        
+        net.MaxPool("R_mkl", "P_mkl",
+                 stride=2, kernel=3, device_option=mkl_do)
+        net.FC(["P_mkl","w_fc_mkl", "b_fc_mkl"], "Y_mkl", device_option=mkl_do)
+
+        workspace.CreateNet(net)
+        workspace.RunNet(net)
+        # makes sure that the results are good.
+        np.testing.assert_allclose(
+            workspace.FetchBlob("Y"),
+            workspace.FetchBlob("Y_mkl"),
+            atol=1e-2,
+            rtol=1e-2)
+        runtime = workspace.BenchmarkNet(net.Proto().name, 1, 100, True)'''
+
+    
+if __name__ == '__main__':
+    unittest.main()

--- a/caffe2/utils/mkl/mkl_dnn_cppwrapper.h
+++ b/caffe2/utils/mkl/mkl_dnn_cppwrapper.h
@@ -1086,6 +1086,184 @@ dnnBatchNormalizationCreateBackwardScaleShift<double>(
       pBatchNormalization, attributes, dataLayout, eps);
 }
 
+
+C2_MKL_TEMPLATE_PREFIX dnnError_t dnnBatchNormalizationCreateForward_v2(
+    dnnPrimitive_t* pBatchNormalization,
+    dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout,
+    float eps,
+    unsigned int flags);
+C2_MKL_SPEC_PREFIX dnnError_t dnnBatchNormalizationCreateForward_v2<float>(
+    dnnPrimitive_t* pBatchNormalization,
+    dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout,
+    float eps,
+    unsigned int flags) {
+  return dnnBatchNormalizationCreateForward_v2_F32(
+      pBatchNormalization, attributes, dataLayout, eps, flags);
+}
+C2_MKL_SPEC_PREFIX dnnError_t dnnBatchNormalizationCreateForward_v2<double>(
+    dnnPrimitive_t* pBatchNormalization,
+    dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout,
+    float eps,
+    unsigned int flags) {
+  return dnnBatchNormalizationCreateForward_v2_F64(
+      pBatchNormalization, attributes, dataLayout, eps, flags);
+}
+
+C2_MKL_TEMPLATE_PREFIX dnnError_t dnnBatchNormalizationCreateBackward_v2(
+    dnnPrimitive_t* pBatchNormalization,
+    dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout,
+    float eps,
+    unsigned int flags);
+C2_MKL_SPEC_PREFIX dnnError_t dnnBatchNormalizationCreateBackward_v2<float>(
+    dnnPrimitive_t* pBatchNormalization,
+    dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout,
+    float eps,
+    unsigned int flags) {
+  return dnnBatchNormalizationCreateBackward_v2_F32(
+      pBatchNormalization, attributes, dataLayout, eps, flags);
+}
+
+C2_MKL_SPEC_PREFIX dnnError_t dnnBatchNormalizationCreateBackward_v2<double>(
+    dnnPrimitive_t* pBatchNormalization,
+    dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout,
+    float eps,
+    unsigned int flags) {
+  return dnnBatchNormalizationCreateBackward_v2_F64(
+      pBatchNormalization, attributes, dataLayout, eps, flags);
+}
+
+
+
+
+C2_MKL_TEMPLATE_PREFIX dnnError_t dnnInnerProductCreateForward(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels);
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateForward<float>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateForward_F32(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateForward<double>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateForward_F64(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+
+C2_MKL_TEMPLATE_PREFIX dnnError_t dnnInnerProductCreateForwardBias(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels);
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateForwardBias<float>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateForwardBias_F32(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateForwardBias<double>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateForwardBias_F64(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+
+C2_MKL_TEMPLATE_PREFIX dnnError_t dnnInnerProductCreateBackwardData(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels);
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateBackwardData<float>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateBackwardData_F32(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateBackwardData<double>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateBackwardData_F64(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+
+C2_MKL_TEMPLATE_PREFIX dnnError_t dnnInnerProductCreateBackwardFilter(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels);
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateBackwardFilter<float>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateBackwardFilter_F32(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateBackwardFilter<double>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateBackwardFilter_F64(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+
+C2_MKL_TEMPLATE_PREFIX dnnError_t dnnInnerProductCreateBackwardBias(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[]);
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateBackwardBias<float>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[]) {
+  return dnnInnerProductCreateBackwardBias_F32(
+      pInnerProduct, attributes, dimensions, srcSize);
+}
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateBackwardBias<double>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[]) {
+  return dnnInnerProductCreateBackwardBias_F64(
+      pInnerProduct, attributes, dimensions, srcSize);
+}
+
+
 } // namespace mkl
 } // namespace caffe2
 


### PR DESCRIPTION
Please run the mkl_fc_op_test.py or mkl_fc_speed_test.py.
I set the caffe2_omp_num_threads to 2
there should be mismatch with default code.

