### PR TITLE
MKL related files with review comments incorporated

### DIFF
--- a/caffe2/mkl/operators/conv_op.cc
+++ b/caffe2/mkl/operators/conv_op.cc
@@ -37,11 +37,9 @@ class MKLConvOp final : public ConvPoolOpBase<MKLContext> {
     CAFFE_ENFORCE(4 == filter.ndim());
     const int M = filter.dim32(0);
 
-    if (cached_input_dims_ != X.dims() ||
-        cached_filter_dims_ != filter.dims()) {
-      cached_input_dims_ = X.dims();
-      cached_filter_dims_ = filter.dims();
-
+    bool dims_changed;
+    CHECK_INPUT_FILTER_DIMS(dims_changed);
+    if (dims_changed) {
       CAFFE_ENFORCE(
           C == filter.dim32(1),
           "Convolution op: # of input channels ",

--- a/caffe2/mkl/operators/fully_connected_op.cc
+++ b/caffe2/mkl/operators/fully_connected_op.cc
@@ -1,0 +1,102 @@
+#include "caffe2/core/context.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/utils/mkl_utils.h"
+
+#ifdef CAFFE2_HAS_MKL_DNN
+
+namespace caffe2 {
+namespace mkl {
+
+template <typename T>
+class MKLFullyConnectedOp final : public MKLOperator<T> {
+ public:
+  MKLFullyConnectedOp(const OperatorDef& operator_def, Workspace* ws)
+      : MKLOperator<T>(operator_def, ws),
+        axis_(OperatorBase::GetSingleArgument<int32_t>("axis", 1)) {}
+  ~MKLFullyConnectedOp() {}
+
+  bool RunOnDevice() override {
+    auto& X = OperatorBase::Input<MKLMemory<float>>(INPUT);
+    auto& filter = OperatorBase::Input<MKLMemory<float>>(FILTER);
+    auto& bias = OperatorBase::Input<MKLMemory<float>>(BIAS);
+    MKLMemory<float>* Y = OperatorBase::Output<MKLMemory<float>>(0);
+
+    CAFFE_ENFORCE(filter.ndim() == 2, filter.ndim());
+    CAFFE_ENFORCE(bias.ndim() == 1, bias.ndim());
+
+    bool dims_changed;
+    CHECK_INPUT_FILTER_DIMS(dims_changed);
+    if (dims_changed) {
+      const int N = filter.dim32(0);
+      CAFFE_ENFORCE(N == bias.dim32(0));
+
+      auto Y_shape = X.dims();
+      Y_shape[1] = N;
+      Y_shape.resize(2);
+
+      size_t inputSizes[4];
+      if (X.ndim() == 2) {
+        inputSizes[0] = X.dim32(1);
+        inputSizes[1] = X.dim32(0);
+      } else {
+        inputSizes[0] = X.dim32(3);
+        inputSizes[1] = X.dim32(2);
+        inputSizes[2] = X.dim32(1);
+        inputSizes[3] = X.dim32(0);
+      }
+
+      size_t outputSizes[2] = {Y_shape[1], Y_shape[0]};
+
+      primitive_.Reset(dnnInnerProductCreateForwardBias<float>, nullptr,
+                       X.ndim(), inputSizes, outputSizes[0]);
+
+      Y->Reset(Y_shape, primitive_, dnnResourceDst);
+      buffer_.Reset(Y_shape, primitive_, dnnResourceDst, true);
+
+      input_layout_.Reset(primitive_, dnnResourceSrc);
+      filter_layout_.Reset(primitive_, dnnResourceFilter);
+    }
+
+    // Try to share from the output: this allows us to avoid unnecessary copy
+    // operations, if the output is already allocated and is having the same
+    // layout as the buffer has.
+    buffer_.ShareFrom(*Y);
+
+    std::shared_ptr<void> X_view =
+        X.View(input_layout_, primitive_, dnnResourceSrc);
+    std::shared_ptr<void> filter_view =
+        filter.View(filter_layout_, primitive_, dnnResourceFilter);
+
+    resources_[dnnResourceSrc] = X_view.get();
+    resources_[dnnResourceFilter] = filter_view.get();
+
+    resources_[dnnResourceBias] = bias.buffer();
+    resources_[dnnResourceDst] = buffer_.buffer();
+
+    MKLDNN_SAFE_CALL(mkl::dnnExecute<T>(primitive_, resources_));
+    buffer_.CopyTo(Y, primitive_, dnnResourceDst);
+    return true;
+  }
+
+ private:
+  // Input: X, W, b
+  // Output: Y
+  size_t axis_{1};
+  vector<TIndex> cached_input_dims_;
+  vector<TIndex> cached_filter_dims_;
+  PrimitiveWrapper<T> primitive_;
+  LayoutWrapper<T> input_layout_;
+  LayoutWrapper<T> filter_layout_;
+  LayoutWrapper<T> bias_layout_;
+  MKLMemory<T> buffer_;
+  void* resources_[dnnResourceNumber] = {0};
+  INPUT_TAGS(INPUT, FILTER, BIAS);
+};
+
+}  // namespace mkl
+
+REGISTER_MKL_OPERATOR(FC, mkl::MKLFullyConnectedOp<float>);
+
+}  // namespace caffe2
+
+#endif  // CAFFE2_HAS_MKL_DNN

--- a/caffe2/mkl/operators/local_response_normalization_op.cc
+++ b/caffe2/mkl/operators/local_response_normalization_op.cc
@@ -1,0 +1,84 @@
+#include "caffe2/operators/local_response_normalization_op.h"
+#include "caffe2/core/context.h"
+#include "caffe2/core/operator.h"
+
+#include "caffe2/utils/mkl_utils.h"
+
+#ifdef CAFFE2_HAS_MKL_DNN
+
+namespace caffe2 {
+namespace mkl {
+
+template <typename T>
+class MKLLRNOp final : public LRNOpBase<T, MKLContext> {
+ public:
+  MKLLRNOp(const OperatorDef &operator_def, Workspace *ws)
+      : LRNOpBase<T, MKLContext>(operator_def, ws) {}
+
+  ~MKLLRNOp() {
+    if (workspace_buffer_ != NULL) {
+      dnnReleaseBuffer<T>(workspace_buffer_);
+      workspace_buffer_ = NULL;
+    }
+  }
+
+  bool RunOnDeviceWithOrderNCHW() override;
+  bool RunOnDeviceWithOrderNHWC() override;
+
+ private:
+  vector<TIndex> cached_input_dims_;
+  LayoutWrapper<T> workspace_layout_;
+  T *workspace_buffer_ = nullptr;
+  PrimitiveWrapper<T> primitive_;
+  MKLMemory<T> buffer_;
+  void *resources_[dnnResourceNumber] = {0};
+};
+
+template <>
+bool MKLLRNOp<float>::RunOnDeviceWithOrderNCHW() {
+  auto &X = OperatorBase::Input<MKLMemory<float>>(0);
+  MKLMemory<float> *Y = OperatorBase::Output<MKLMemory<float>>(0);
+
+  bool dims_changed;
+  CHECK_INPUT_DIMS(dims_changed);
+  if (dims_changed) {
+
+    size_t dim = X.ndim();
+    CAFFE_ENFORCE(4 == dim);
+
+    // Create main primitive.
+    primitive_.Reset(dnnLRNCreateForward_F32, nullptr, X.layout(), size_,
+                     alpha_, beta_, bias_);
+
+    Y->Reset(X.dims(), primitive_, dnnResourceDst);
+    buffer_.Reset(X.dims(), primitive_, dnnResourceDst, true);
+
+    workspace_layout_.Reset(primitive_, dnnResourceWorkspace);
+    MKLDNN_SAFE_CALL(mkl::dnnAllocateBuffer<float>(
+        (void **)(&workspace_buffer_), workspace_layout_));
+  }
+
+  // Try to share from the output: this allows us to avoid unnecessary copy
+  // operations, if the output is already allocated and is having the same
+  // layout as the buffer has.
+  buffer_.ShareFrom(*Y);
+  resources_[dnnResourceSrc] = X.buffer();
+  resources_[dnnResourceDst] = buffer_.buffer();
+  resources_[dnnResourceWorkspace] = workspace_buffer_;
+  MKLDNN_SAFE_CALL(mkl::dnnExecute<float>(primitive_, resources_));
+  buffer_.CopyTo(Y, primitive_, dnnResourceDst);
+  return true;
+}
+
+template <>
+bool MKLLRNOp<float>::RunOnDeviceWithOrderNHWC() {
+  CAFFE_NOT_IMPLEMENTED;
+}
+
+}  // namespace mkl
+
+REGISTER_MKL_OPERATOR(LRN, mkl::MKLLRNOp<float>);
+
+}  // namespace caffe2
+
+#endif  // CAFFE2_HAS_MKL_DNN

--- a/caffe2/mkl/operators/operator_fallback_mkl.cc
+++ b/caffe2/mkl/operators/operator_fallback_mkl.cc
@@ -1,0 +1,26 @@
+
+#include "caffe2/mkl/operators/operator_fallback_mkl.h"
+#include "caffe2/operators/cross_entropy_op.h"
+#include "caffe2/operators/filler_op.h"
+#include "caffe2/operators/loss_op.h"
+#include "caffe2/operators/softmax_op.h"
+
+// can add more non-MKL operators if needed
+namespace caffe2 {
+REGISTER_MKL_OPERATOR(Softmax,
+                      mkl::MKLFallbackOp<SoftmaxOp<float, CPUContext>>);
+REGISTER_MKL_OPERATOR(
+    LabelCrossEntropy,
+    mkl::MKLFallbackOp<LabelCrossEntropyOp<float, CPUContext>>);
+REGISTER_MKL_OPERATOR(AveragedLoss,
+                      mkl::MKLFallbackOp<AveragedLoss<float, CPUContext>>);
+
+// filter operators
+REGISTER_MKL_OPERATOR(XavierFill,
+                      mkl::MKLFallbackOp<XavierFillOp<float, CPUContext>>);
+REGISTER_MKL_OPERATOR(ConstantFill,
+                      mkl::MKLFallbackOp<ConstantFillOp<CPUContext>>);
+REGISTER_MKL_OPERATOR(GaussianFill,
+                      mkl::MKLFallbackOp<GaussianFillOp<float, CPUContext>>);
+
+}  // namespace caffe2

--- a/caffe2/mkl/operators/pool_op.cc
+++ b/caffe2/mkl/operators/pool_op.cc
@@ -1,0 +1,121 @@
+#include "caffe2/core/context.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/operators/conv_pool_op_base.h"
+
+#include "caffe2/utils/mkl_utils.h"
+
+#ifdef CAFFE2_HAS_MKL_DNN
+
+namespace caffe2 {
+
+namespace mkl {
+
+template <typename T>
+class MKLPoolOp final : public ConvPoolOpBase<MKLContext> {
+ public:
+  USE_CONV_POOL_BASE_FUNCTIONS(MKLContext);
+  MKLPoolOp(const OperatorDef &operator_def, Workspace *ws)
+      : ConvPoolOpBase<MKLContext>(operator_def, ws) {
+    CAFFE_ENFORCE((dilation_h() == 1) && (dilation_w() == 1),
+                  "Pooling op does not support dilation right now.");
+    if (!global_pooling_) {
+      CAFFE_ENFORCE(pad_t() < kernel_h() && pad_b() < kernel_h() &&
+                        pad_l() < kernel_w() && pad_r() < kernel_w(),
+                    "Pad should be smaller than kernel.");
+    }
+    // Figure out the pooling descriptor.
+    if (def().type().substr(0, 7) == "MaxPool") {
+      algo = dnnAlgorithmPoolingMax;
+    } else if (def().type().substr(0, 11) == "AveragePool") {
+      algo = dnnAlgorithmPoolingAvg;
+    } else {
+      LOG(FATAL) << "Unsupported pooling method: " << def().type();
+    }
+  }
+
+  ~MKLPoolOp() {
+    if (workspace_buffer_ != NULL) {
+      dnnReleaseBuffer<T>(workspace_buffer_);
+      workspace_buffer_ = NULL;
+    }
+  }
+
+  bool RunOnDeviceWithOrderNCHW() override;
+  bool RunOnDeviceWithOrderNHWC() override;
+
+  // Input: X
+  // Output: Y
+ private:
+  vector<TIndex> cached_input_dims_;
+  //vector<TIndex> cached_avgpool_input_dims_;
+  LayoutWrapper<T> workspace_layout_;
+  T *workspace_buffer_ = nullptr;
+  PrimitiveWrapper<T> primitive_;
+  MKLMemory<T> buffer_;
+  void *resources_[dnnResourceNumber] = {0};
+  dnnAlgorithm_t algo;
+};
+
+template <>
+bool MKLPoolOp<float>::RunOnDeviceWithOrderNCHW() {
+  auto &X = OperatorBase::Input<MKLMemory<float>>(0);
+  MKLMemory<float> *Y = OperatorBase::Output<MKLMemory<float>>(0);
+
+  bool dims_changed;
+  CHECK_INPUT_DIMS(dims_changed);
+  if (dims_changed) {
+
+    // We will utilize the SetOutputSize() function in the base class
+    // with dummy TensorCPU input and output to calculate the sizes.
+    TensorCPU dummy_input(X.dims());
+    TensorCPU dummy_output;
+
+    ConvPoolOpBase<MKLContext>::SetOutputSize(dummy_input, &dummy_output,
+                                              X.dim32(1));
+    size_t dim = X.ndim();
+    CAFFE_ENFORCE(4 == dim);
+
+    int paddings[4] = {-pad_l(), -pad_t(), -pad_r(), -pad_b()};
+    size_t strides[2] = {stride_w(), stride_h()};
+    size_t kernel_size[2] = {kernel_w(), kernel_h()};
+
+    // Create main primitive.
+    primitive_.Reset(dnnPoolingCreateForward_F32, nullptr,
+                     algo, X.layout(), kernel_size, strides,
+                     paddings, dnnBorderZerosAsymm);
+
+    Y->Reset(dummy_output.dims(), primitive_, dnnResourceDst);
+    buffer_.Reset(dummy_output.dims(), primitive_, dnnResourceDst, true);
+
+    workspace_layout_.Reset(primitive_, dnnResourceWorkspace);
+    MKLDNN_SAFE_CALL(mkl::dnnAllocateBuffer<float>(
+        (void **)(&workspace_buffer_), workspace_layout_));
+  }
+
+  // Try to share from the output: this allows us to avoid unnecessary copy
+  // operations, if the output is already allocated and is having the same
+  // layout as the buffer has.
+  buffer_.ShareFrom(*Y);
+  resources_[dnnResourceSrc] = X.buffer();
+  resources_[dnnResourceDst] = buffer_.buffer();
+  resources_[dnnResourceWorkspace] = workspace_buffer_;
+  MKLDNN_SAFE_CALL(mkl::dnnExecute<float>(primitive_, resources_));
+  buffer_.CopyTo(Y, primitive_, dnnResourceDst);
+  return true;
+}
+
+
+template <>
+bool MKLPoolOp<float>::RunOnDeviceWithOrderNHWC() {
+  CAFFE_NOT_IMPLEMENTED;
+}
+
+
+}  // namespace mkl
+
+REGISTER_MKL_OPERATOR(AveragePool, mkl::MKLPoolOp<float>);
+REGISTER_MKL_OPERATOR(MaxPool, mkl::MKLPoolOp<float>);
+
+}  // namespace caffe2
+
+#endif  // CAFFE2_HAS_MKL_DNN

--- a/caffe2/mkl/operators/relu_op.cc
+++ b/caffe2/mkl/operators/relu_op.cc
@@ -14,9 +14,12 @@ class MKLReluOp : public MKLOperator<T> {
   USE_MKLOPERATOR_FUNCTIONS(T);
   USE_SIMPLE_MKL_CTOR_DTOR(MKLReluOp, T);
   bool RunOnDevice() override {
-    auto& X = Input(0);
-    auto* Y = Output(0);
-    if (input_size_cache_.size() != 1 || input_size_cache_[0] != X.dims()) {
+    auto &X = Input(0);
+    auto *Y = Output(0);
+    
+    bool dims_changed;
+    CHECK_INPUT_DIMS(dims_changed);
+    if (dims_changed) {
       // First run or changed input size, will need to recreate environment
       primitive_.Reset(dnnReLUCreateForward<T>, nullptr, X.layout(), 0.f);
       Y->Reset(X.dims(), primitive_, dnnResourceDst);
@@ -32,6 +35,9 @@ class MKLReluOp : public MKLOperator<T> {
     buffer_.CopyTo(Y, primitive_, dnnResourceDst);
     return true;
   }
+
+ private:
+  vector<TIndex> cached_input_dims_;
 };
 
 template <typename T>
@@ -40,13 +46,13 @@ class MKLReluGradientOp : public MKLOperator<T> {
   USE_MKLOPERATOR_FUNCTIONS(T);
   USE_SIMPLE_MKL_CTOR_DTOR(MKLReluGradientOp, T);
   bool RunOnDevice() override {
-    auto& Y = Input(0);
-    auto& dY = Input(1);
-    auto* dX = Output(0);
+    auto &Y = Input(0);
+    auto &dY = Input(1);
+    auto *dX = Output(0);
     if (input_size_cache_.size() != 1 || input_size_cache_[0] != Y.dims()) {
       // First run or changed input size, will need to recreate environment
-      primitive_.Reset(
-          dnnReLUCreateBackward<T>, nullptr, dY.layout(), Y.layout(), 0.f);
+      primitive_.Reset(dnnReLUCreateBackward<T>, nullptr, dY.layout(),
+                       Y.layout(), 0.f);
       dX->Reset(Y.dims(), primitive_, dnnResourceDiffSrc);
       buffer_.Reset(Y.dims(), primitive_, dnnResourceDiffSrc, true);
     }
@@ -62,11 +68,11 @@ class MKLReluGradientOp : public MKLOperator<T> {
     return true;
   }
 };
-} // namespace mkl
+}  // namespace mkl
 
 REGISTER_MKL_OPERATOR(Relu, mkl::MKLReluOp<float>);
 REGISTER_MKL_OPERATOR(ReluGradient, mkl::MKLReluGradientOp<float>);
 
-} // namespace caffe2
+}  // namespace caffe2
 
-#endif // CAFFE2_HAS_MKL_DNN
+#endif  // CAFFE2_HAS_MKL_DNN

--- a/caffe2/mkl/operators/spatial_batch_norm_op.cc
+++ b/caffe2/mkl/operators/spatial_batch_norm_op.cc
@@ -1,0 +1,152 @@
+#include "caffe2/operators/spatial_batch_norm_op.h"
+#include <math.h>
+
+#include "caffe2/utils/mkl_utils.h"
+
+#ifdef CAFFE2_HAS_MKL_DNN
+
+namespace caffe2 {
+namespace mkl {
+
+template <typename T>
+class MKLBNOp final : public SpatialBNOp<MKLContext> {
+ public:
+  MKLBNOp(const OperatorDef& operator_def, Workspace* ws)
+      : SpatialBNOp<MKLContext>(operator_def, ws) {
+    OPERATOR_NEEDS_FEATURE(order_ == StorageOrder::NCHW,
+                           "Only NCHW order supported.");
+  }
+  ~MKLBNOp() {
+    if (scale_bias_buffer_ != NULL) {
+      dnnReleaseBuffer<T>(scale_bias_buffer_);
+      scale_bias_buffer_ = NULL;
+    }
+  }
+  bool RunOnDevice() {
+    auto& X = OperatorBase::Input<MKLMemory<float>>(INPUT);
+    auto& scale = OperatorBase::Input<MKLMemory<float>>(SCALE);
+    auto& bias = OperatorBase::Input<MKLMemory<float>>(BIAS);
+
+    MKLMemory<float>* Y = OperatorBase::Output<MKLMemory<float>>(OUTPUT);
+    // anded with is_test_-1 to avoid uninitialized access in case of testing
+    MKLMemory<float>* running_mean =
+        OperatorBase::Output<MKLMemory<float>>(RUNNING_MEAN & (is_test_ - 1));
+    MKLMemory<float>* running_var =
+        OperatorBase::Output<MKLMemory<float>>(RUNNING_VAR & (is_test_ - 1));
+    MKLMemory<float>* saved_mean =
+        OperatorBase::Output<MKLMemory<float>>(SAVED_MEAN & (is_test_ - 1));
+    MKLMemory<float>* saved_var =
+        OperatorBase::Output<MKLMemory<float>>(SAVED_INV_VAR & (is_test_ - 1));
+
+    // current code supports only NCHW -
+    // have to look for MKL related changes for NHWC later
+    const int N = X.dim32(0);
+    const int C = (order_ == StorageOrder::NCHW ? X.dim32(1) : X.dim32(3));
+    const int H = (order_ == StorageOrder::NCHW ? X.dim32(2) : X.dim32(1));
+    const int W = (order_ == StorageOrder::NCHW ? X.dim32(3) : X.dim32(2));
+
+    DCHECK_EQ(scale.ndim(), 1);
+    DCHECK_EQ(bias.ndim(), 1);
+    DCHECK_EQ(scale.dim32(0), C);
+    DCHECK_EQ(bias.dim32(0), C);
+
+    bool dims_changed;
+    CHECK_INPUT_DIMS(dims_changed);
+    if (dims_changed) {
+      // Create main primitive.
+      if (is_test_) {
+        primitive_.Reset(dnnBatchNormalizationCreateForward_v2<T>, nullptr,
+                         X.layout(), epsilon_,
+                         dnnUseInputMeanVariance | dnnUseScaleShift);
+      } else {
+        primitive_.Reset(dnnBatchNormalizationCreateForward_v2<T>, nullptr,
+                         X.layout(), epsilon_, dnnUseScaleShift);
+
+        // using scale dims as it is also of size C
+        saved_mean->Reset(scale.dims(), primitive_, dnnResourceMean);
+        saved_var->Reset(scale.dims(), primitive_, dnnResourceVariance);
+        running_mean->Reset(scale.dims(), primitive_, dnnResourceMean);
+        running_var->Reset(scale.dims(), primitive_, dnnResourceVariance);
+
+        running_mean_buf = (T*)running_mean->buffer();
+        running_var_buf = (T*)running_var->buffer();
+      }
+
+      Y->Reset(X.dims(), primitive_, dnnResourceDst);
+      buffer_.Reset(X.dims(), primitive_, dnnResourceDst, true);
+
+      scale_bias_layout_.Reset(primitive_, dnnResourceScaleShift);
+      MKLDNN_SAFE_CALL(mkl::dnnAllocateBuffer<float>(
+          (void**)(&scale_bias_buffer_), scale_bias_layout_));
+
+      // fill scale and bias into a single buffer
+      scale_buf = (T*)scale.buffer();
+      bias_buf = (T*)bias.buffer();
+      for (int i = 0; i < C; i++) {
+        scale_bias_buffer_[i] = scale_buf[i];
+        scale_bias_buffer_[C + i] = bias_buf[i];
+      }
+    }
+
+    // Try to share from the output: this allows us to avoid unnecessary copy
+    // operations, if the output is already allocated and is having the same
+    // layout as the buffer has.
+    buffer_.ShareFrom(*Y);
+    resources_[dnnResourceSrc] = X.buffer();
+    resources_[dnnResourceDst] = buffer_.buffer();
+    resources_[dnnResourceScaleShift] = scale_bias_buffer_;
+
+    if (is_test_) {
+      auto& est_mean = OperatorBase::Input<MKLMemory<float>>(EST_MEAN);
+      auto& est_var = OperatorBase::Input<MKLMemory<float>>(EST_VAR);
+
+      resources_[dnnResourceMean] = est_mean.buffer();
+      resources_[dnnResourceVariance] = est_var.buffer();
+    } else {
+      resources_[dnnResourceMean] = saved_mean->buffer();
+      resources_[dnnResourceVariance] = saved_var->buffer();
+    }
+
+    MKLDNN_SAFE_CALL(mkl::dnnExecute<float>(primitive_, resources_));
+
+    if (!is_test_) {
+      // compute running mean and variance
+      saved_mean_buf = (T*)saved_mean->buffer();
+      saved_var_buf = (T*)saved_var->buffer();
+
+      for (int i = 0; i < C; i++) {
+        running_mean_buf[i] = running_mean_buf[i] * momentum_ +
+                              saved_mean_buf[i] * (1. - momentum_);
+        running_var_buf[i] = running_var_buf[i] * momentum_ +
+                             saved_var_buf[i] * (1. - momentum_);
+        saved_var_buf[i] = (1 / sqrt(saved_var_buf[i] + epsilon_));
+      }
+    }
+    buffer_.CopyTo(Y, primitive_, dnnResourceDst);
+    return true;
+  }
+
+ private:
+  vector<TIndex> cached_input_dims_;
+  LayoutWrapper<T> scale_bias_layout_;
+  LayoutWrapper<T> saved_mean_layout_;
+  LayoutWrapper<T> saved_var_layout_;
+  LayoutWrapper<T> running_mean_layout_;
+  LayoutWrapper<T> running_var_layout_;
+  T* scale_bias_buffer_ = nullptr;
+  T* scale_buf = nullptr;
+  T* bias_buf = nullptr;
+  T* saved_mean_buf = nullptr;
+  T* saved_var_buf = nullptr;
+  T* running_mean_buf = nullptr;
+  T* running_var_buf = nullptr;
+  PrimitiveWrapper<T> primitive_;
+  MKLMemory<T> buffer_;
+  void* resources_[dnnResourceNumber] = {0};
+};
+}  // namespace mkl
+
+REGISTER_MKL_OPERATOR(SpatialBN, mkl::MKLBNOp<float>);
+}  // namespace caffe2
+
+#endif  // CAFFE2_HAS_MKL_DNN

--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -1675,6 +1675,11 @@ class Net(object):
         if use_cudnn:
             for op in self._net.op:
                 op.engine = "CUDNN"
+    def RunAllOnMKL(self):
+        """A convenient function to run everything on the GPU."""
+        device_option = caffe2_pb2.DeviceOption()
+        device_option.device_type = caffe2_pb2.MKLDNN
+        self._net.device_option.CopyFrom(device_option)
 
     def _CreateAndAddToSelf(self, op_type, inputs, outputs=None, **kwargs):
         """A helper function to create an operator and add it to self.

--- a/caffe2/python/mkl/convnet_benchmarks.py
+++ b/caffe2/python/mkl/convnet_benchmarks.py
@@ -1,0 +1,686 @@
+## @package convnet_benchmarks
+# Module caffe2.python.convnet_benchmarks
+"""
+Benchmark for common convnets.
+
+Speed on Titan X, with 10 warmup steps and 10 main steps and with different
+versions of cudnn, are as follows (time reported below is per-batch time,
+forward / forward+backward):
+
+                    CuDNN V3        CuDNN v4
+AlexNet         32.5 / 108.0    27.4 /  90.1
+OverFeat       113.0 / 342.3    91.7 / 276.5
+Inception      134.5 / 485.8   125.7 / 450.6
+VGG (batch 64) 200.8 / 650.0   164.1 / 551.7
+
+Speed on Inception with varied batch sizes and CuDNN v4 is as follows:
+
+Batch Size   Speed per batch     Speed per image
+ 16             22.8 /  72.7         1.43 / 4.54
+ 32             38.0 / 127.5         1.19 / 3.98
+ 64             67.2 / 233.6         1.05 / 3.65
+128            125.7 / 450.6         0.98 / 3.52
+
+Speed on Tesla M40, which 10 warmup steps and 10 main steps and with cudnn
+v4, is as follows:
+
+AlexNet         68.4 / 218.1
+OverFeat       210.5 / 630.3
+Inception      300.2 / 1122.2
+VGG (batch 64) 405.8 / 1327.7
+
+(Note that these numbers involve a "full" backprop, i.e. the gradient
+with respect to the input image is also computed.)
+
+To get the numbers, simply run:
+
+for MODEL in AlexNet OverFeat Inception; do
+  PYTHONPATH=../gen:$PYTHONPATH python convnet_benchmarks.py \
+    --batch_size 128 --model $MODEL --forward_only True
+done
+for MODEL in AlexNet OverFeat Inception; do
+  PYTHONPATH=../gen:$PYTHONPATH python convnet_benchmarks.py \
+    --batch_size 128 --model $MODEL
+done
+PYTHONPATH=../gen:$PYTHONPATH python convnet_benchmarks.py \
+  --batch_size 64 --model VGGA --forward_only True
+PYTHONPATH=../gen:$PYTHONPATH python convnet_benchmarks.py \
+  --batch_size 64 --model VGGA
+
+for BS in 16 32 64 128; do
+  PYTHONPATH=../gen:$PYTHONPATH python convnet_benchmarks.py \
+    --batch_size $BS --model Inception --forward_only True
+  PYTHONPATH=../gen:$PYTHONPATH python convnet_benchmarks.py \
+    --batch_size $BS --model Inception
+done
+
+Note that VGG needs to be run at batch 64 due to memory limit on the backward
+pass.
+"""
+
+import argparse
+
+from caffe2.python import cnn, workspace
+import numpy as np
+
+def MLP(order, cudnn_ws, mkl):
+    model = cnn.CNNModelHelper()
+    d = 256
+    depth = 20
+    width = 3
+    for i in range(depth):
+        for j in range(width):
+            current = "fc_{}_{}".format(i, j) if i > 0 else "data"
+            next_ = "fc_{}_{}".format(i + 1, j)
+            model.FC(
+                current, next_,
+                dim_in=d, dim_out=d,
+                weight_init=model.XavierInit,
+                bias_init=model.XavierInit)
+    model.Sum(["fc_{}_{}".format(depth, j) for j in range(width)], ["sum"])
+    model.FC("sum", "last",
+             dim_in=d, dim_out=1000,
+             weight_init=model.XavierInit,
+             bias_init=model.XavierInit)
+    xent = model.LabelCrossEntropy(["last", "label"], "xent")
+    if not mkl:
+        model.AveragedLoss(xent, "loss")
+    return model, d
+
+
+def AlexNet(order, cudnn_ws, mkl):
+    model = cnn.CNNModelHelper(
+        order, name="alexnet",
+        use_cudnn=True, cudnn_exhaustive_search=True,
+        ws_nbytes_limit=cudnn_ws)
+    conv1 = model.Conv(
+        "data",
+        "conv1",
+        3,
+        64,
+        11,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        stride=4,
+        pad=2
+    )
+    relu1 = model.Relu(conv1, "conv1")
+    pool1 = model.MaxPool(relu1, "pool1", kernel=3, stride=2)
+    conv2 = model.Conv(
+        pool1,
+        "conv2",
+        64,
+        192,
+        5,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=2
+    )
+    relu2 = model.Relu(conv2, "conv2")
+    pool2 = model.MaxPool(relu2, "pool2", kernel=3, stride=2)
+    conv3 = model.Conv(
+        pool2,
+        "conv3",
+        192,
+        384,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu3 = model.Relu(conv3, "conv3")
+    conv4 = model.Conv(
+        relu3,
+        "conv4",
+        384,
+        256,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu4 = model.Relu(conv4, "conv4")
+    conv5 = model.Conv(
+        relu4,
+        "conv5",
+        256,
+        256,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu5 = model.Relu(conv5, "conv5")
+    pool5 = model.MaxPool(relu5, "pool5", kernel=3, stride=2)
+    fc6 = model.FC(
+        pool5, "fc6", 256 * 6 * 6, 4096, ('XavierFill', {}),
+        ('ConstantFill', {})
+    )
+    relu6 = model.Relu(fc6, "fc6")
+    fc7 = model.FC(
+        relu6, "fc7", 4096, 4096, ('XavierFill', {}), ('ConstantFill', {})
+    )
+    relu7 = model.Relu(fc7, "fc7")
+    fc8 = model.FC(
+        relu7, "fc8", 4096, 1000, ('XavierFill', {}), ('ConstantFill', {})
+    )
+    pred = model.Softmax(fc8, "pred")
+    xent = model.LabelCrossEntropy([pred, "label"], "xent")
+    if not mkl:
+        loss = model.AveragedLoss(xent, "loss")
+    return model, 224
+
+
+def OverFeat(order, cudnn_ws, mkl):
+    model = cnn.CNNModelHelper(
+        order, name="overfeat",
+        use_cudnn=True, cudnn_exhaustive_search=True,
+        ws_nbytes_limit=cudnn_ws)
+    conv1 = model.Conv(
+        "data",
+        "conv1",
+        3,
+        96,
+        11,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        stride=4
+    )
+    relu1 = model.Relu(conv1, "conv1")
+    pool1 = model.MaxPool(relu1, "pool1", kernel=2, stride=2)
+    conv2 = model.Conv(
+        pool1, "conv2", 96, 256, 5, ('XavierFill', {}), ('ConstantFill', {})
+    )
+    relu2 = model.Relu(conv2, "conv2")
+    pool2 = model.MaxPool(relu2, "pool2", kernel=2, stride=2)
+    conv3 = model.Conv(
+        pool2,
+        "conv3",
+        256,
+        512,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu3 = model.Relu(conv3, "conv3")
+    conv4 = model.Conv(
+        relu3,
+        "conv4",
+        512,
+        1024,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu4 = model.Relu(conv4, "conv4")
+    conv5 = model.Conv(
+        relu4,
+        "conv5",
+        1024,
+        1024,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu5 = model.Relu(conv5, "conv5")
+    pool5 = model.MaxPool(relu5, "pool5", kernel=2, stride=2)
+    fc6 = model.FC(
+        pool5, "fc6", 1024 * 6 * 6, 3072, ('XavierFill', {}),
+        ('ConstantFill', {})
+    )
+    relu6 = model.Relu(fc6, "fc6")
+    fc7 = model.FC(
+        relu6, "fc7", 3072, 4096, ('XavierFill', {}), ('ConstantFill', {})
+    )
+    relu7 = model.Relu(fc7, "fc7")
+    fc8 = model.FC(
+        relu7, "fc8", 4096, 1000, ('XavierFill', {}), ('ConstantFill', {})
+    )
+    pred = model.Softmax(fc8, "pred")
+    xent = model.LabelCrossEntropy([pred, "label"], "xent")
+    if not mkl:
+        loss = model.AveragedLoss(xent, "loss")
+    return model, 231
+
+
+def VGGA(order, cudnn_ws, mkl):
+    model = cnn.CNNModelHelper(
+        order, name='vgg-a',
+        use_cudnn=True, cudnn_exhaustive_search=True,
+        ws_nbytes_limit=cudnn_ws)
+    conv1 = model.Conv(
+        "data",
+        "conv1",
+        3,
+        64,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu1 = model.Relu(conv1, "conv1")
+    pool1 = model.MaxPool(relu1, "pool1", kernel=2, stride=2)
+    conv2 = model.Conv(
+        pool1,
+        "conv2",
+        64,
+        128,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu2 = model.Relu(conv2, "conv2")
+    pool2 = model.MaxPool(relu2, "pool2", kernel=2, stride=2)
+    conv3 = model.Conv(
+        pool2,
+        "conv3",
+        128,
+        256,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu3 = model.Relu(conv3, "conv3")
+    conv4 = model.Conv(
+        relu3,
+        "conv4",
+        256,
+        256,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu4 = model.Relu(conv4, "conv4")
+    pool4 = model.MaxPool(relu4, "pool4", kernel=2, stride=2)
+    conv5 = model.Conv(
+        pool4,
+        "conv5",
+        256,
+        512,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu5 = model.Relu(conv5, "conv5")
+    conv6 = model.Conv(
+        relu5,
+        "conv6",
+        512,
+        512,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu6 = model.Relu(conv6, "conv6")
+    pool6 = model.MaxPool(relu6, "pool6", kernel=2, stride=2)
+    conv7 = model.Conv(
+        pool6,
+        "conv7",
+        512,
+        512,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu7 = model.Relu(conv7, "conv7")
+    conv8 = model.Conv(
+        relu7,
+        "conv8",
+        512,
+        512,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu8 = model.Relu(conv8, "conv8")
+    pool8 = model.MaxPool(relu8, "pool8", kernel=2, stride=2)
+
+    fcix = model.FC(
+        pool8, "fcix", 512 * 7 * 7, 4096, ('XavierFill', {}),
+        ('ConstantFill', {})
+    )
+    reluix = model.Relu(fcix, "fcix")
+    fcx = model.FC(
+        reluix, "fcx", 4096, 4096, ('XavierFill', {}), ('ConstantFill', {})
+    )
+    relux = model.Relu(fcx, "fcx")
+    fcxi = model.FC(
+        relux, "fcxi", 4096, 1000, ('XavierFill', {}), ('ConstantFill', {})
+    )
+    pred = model.Softmax(fcxi, "pred")
+    xent = model.LabelCrossEntropy([pred, "label"], "xent")
+    if not mkl:
+        loss = model.AveragedLoss(xent, "loss")
+    return model, 231
+
+
+def _InceptionModule(
+    model, input_blob, input_depth, output_name, conv1_depth, conv3_depths,
+    conv5_depths, pool_depth
+):
+    # path 1: 1x1 conv
+    conv1 = model.Conv(
+        input_blob, output_name + ":conv1", input_depth, conv1_depth, 1,
+        ('XavierFill', {}), ('ConstantFill', {})
+    )
+    conv1 = model.Relu(conv1, conv1)
+    # path 2: 1x1 conv + 3x3 conv
+    conv3_reduce = model.Conv(
+        input_blob, output_name + ":conv3_reduce", input_depth, conv3_depths[0],
+        1, ('XavierFill', {}), ('ConstantFill', {})
+    )
+    conv3_reduce = model.Relu(conv3_reduce, conv3_reduce)
+    conv3 = model.Conv(
+        conv3_reduce,
+        output_name + ":conv3",
+        conv3_depths[0],
+        conv3_depths[1],
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    conv3 = model.Relu(conv3, conv3)
+    # path 3: 1x1 conv + 5x5 conv
+    conv5_reduce = model.Conv(
+        input_blob, output_name + ":conv5_reduce", input_depth, conv5_depths[0],
+        1, ('XavierFill', {}), ('ConstantFill', {})
+    )
+    conv5_reduce = model.Relu(conv5_reduce, conv5_reduce)
+    conv5 = model.Conv(
+        conv5_reduce,
+        output_name + ":conv5",
+        conv5_depths[0],
+        conv5_depths[1],
+        5,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=2
+    )
+    conv5 = model.Relu(conv5, conv5)
+    # path 4: pool + 1x1 conv
+    pool = model.MaxPool(
+        input_blob,
+        output_name + ":pool",
+        kernel=3,
+        stride=1,
+        pad=1
+    )
+    pool_proj = model.Conv(
+        pool, output_name + ":pool_proj", input_depth, pool_depth, 1,
+        ('XavierFill', {}), ('ConstantFill', {})
+    )
+    pool_proj = model.Relu(pool_proj, pool_proj)
+    output = model.Concat([conv1, conv3, conv5, pool_proj], output_name)
+    return output
+
+
+def Inception(order, cudnn_ws, mkl):
+    model = cnn.CNNModelHelper(
+        order, name="inception",
+        use_cudnn=True, cudnn_exhaustive_search=True,
+        ws_nbytes_limit=cudnn_ws)
+    conv1 = model.Conv(
+        "data",
+        "conv1",
+        3,
+        64,
+        7,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        stride=2,
+        pad=3
+    )
+    relu1 = model.Relu(conv1, "conv1")
+    pool1 = model.MaxPool(relu1, "pool1", kernel=3, stride=2, pad=1)
+    conv2a = model.Conv(
+        pool1, "conv2a", 64, 64, 1, ('XavierFill', {}), ('ConstantFill', {})
+    )
+    conv2a = model.Relu(conv2a, conv2a)
+    conv2 = model.Conv(
+        conv2a,
+        "conv2",
+        64,
+        192,
+        3,
+        ('XavierFill', {}),
+        ('ConstantFill', {}),
+        pad=1
+    )
+    relu2 = model.Relu(conv2, "conv2")
+    pool2 = model.MaxPool(relu2, "pool2", kernel=3, stride=2, pad=1)
+    # Inception modules
+    inc3 = _InceptionModule(
+        model, pool2, 192, "inc3", 64, [96, 128], [16, 32], 32
+    )
+    inc4 = _InceptionModule(
+        model, inc3, 256, "inc4", 128, [128, 192], [32, 96], 64
+    )
+    pool5 = model.MaxPool(inc4, "pool5", kernel=3, stride=2, pad=1)
+    inc5 = _InceptionModule(
+        model, pool5, 480, "inc5", 192, [96, 208], [16, 48], 64
+    )
+    inc6 = _InceptionModule(
+        model, inc5, 512, "inc6", 160, [112, 224], [24, 64], 64
+    )
+    inc7 = _InceptionModule(
+        model, inc6, 512, "inc7", 128, [128, 256], [24, 64], 64
+    )
+    inc8 = _InceptionModule(
+        model, inc7, 512, "inc8", 112, [144, 288], [32, 64], 64
+    )
+    inc9 = _InceptionModule(
+        model, inc8, 528, "inc9", 256, [160, 320], [32, 128], 128
+    )
+    pool9 = model.MaxPool(inc9, "pool9", kernel=3, stride=2, pad=1)
+    inc10 = _InceptionModule(
+        model, pool9, 832, "inc10", 256, [160, 320], [32, 128], 128
+    )
+    inc11 = _InceptionModule(
+        model, inc10, 832, "inc11", 384, [192, 384], [48, 128], 128
+    )
+    pool11 = model.AveragePool(inc11, "pool11", kernel=7, stride=1)
+    fc = model.FC(
+        pool11, "fc", 1024, 1000, ('XavierFill', {}), ('ConstantFill', {})
+    )
+    # It seems that Soumith's benchmark does not have softmax on top
+    # for Inception. We will add it anyway so we can have a proper
+    # backward pass.
+    pred = model.Softmax(fc, "pred")
+    xent = model.LabelCrossEntropy([pred, "label"], "xent")
+    if not mkl:
+        loss = model.AveragedLoss(xent, "loss")
+    return model, 224
+
+
+def AddParameterUpdate(model):
+    """ Simple plain SGD update -- not tuned to actually train the models """
+    ITER = model.Iter("iter")
+    LR = model.LearningRate(
+        ITER, "LR", base_lr=-1e-8, policy="step", stepsize=10000, gamma=0.999)
+    ONE = model.param_init_net.ConstantFill([], "ONE", shape=[1], value=1.0)
+    for param in model.params:
+        param_grad = model.param_to_grad[param]
+        model.WeightedSum([param, ONE, param_grad, LR], param)
+
+
+def Benchmark(model_gen, arg):
+    model, input_size = model_gen(arg.order, arg.cudnn_ws, arg.mkl)
+    model.Proto().type = arg.net_type
+    model.Proto().num_workers = arg.num_workers
+
+    # In order to be able to run everything without feeding more stuff, let's
+    # add the data and label blobs to the parameter initialization net as well.
+    if arg.order == "NCHW":
+        input_shape = [arg.batch_size, 3, input_size, input_size]
+    else:
+        input_shape = [arg.batch_size, input_size, input_size, 3]
+    if arg.model == "MLP":
+        input_shape = [arg.batch_size, input_size]
+
+    model.param_init_net.GaussianFill(
+        [],
+        "data",
+        shape=input_shape,
+        mean=0.0,
+        std=1.0
+    )
+    #MKL doesn't support int, so have to use numpy
+    if arg.mkl:
+        label = np.random.randint(low=0, high=1000, size=(arg.batch_size,)).astype(np.int32)
+        workspace.FeedBlob("label", label)
+    else:
+        model.param_init_net.UniformIntFill(
+            [],
+            "label",
+            shape=[arg.batch_size, ],
+            min=0,
+            max=999
+        )
+
+    if arg.forward_only:
+        print('{}: running forward only.'.format(arg.model))
+    else:
+        if arg.mkl:
+            print(
+                '==WARNING==\n'
+                'forward-backward not supported yet in MKL, so exiting'
+            )
+        print('{}: running forward-backward.'.format(arg.model))
+        model.AddGradientOperators(["loss"])
+        AddParameterUpdate(model)
+        if arg.order == 'NHWC':
+            print(
+                '==WARNING==\n'
+                'NHWC order with CuDNN may not be supported yet, so I might\n'
+                'exit suddenly.'
+            )
+
+    if not arg.cpu:
+        if arg.mkl:
+            model.param_init_net.RunAllOnMKL()
+            model.net.RunAllOnMKL()
+        else:
+            model.param_init_net.RunAllOnGPU()
+            model.net.RunAllOnGPU()            
+
+    if arg.engine:
+        for op in model.net.Proto().op:
+            op.engine = arg.engine
+
+    if arg.dump_model:
+        # Writes out the pbtxt for benchmarks on e.g. Android
+        with open(
+            "{0}_init_batch_{1}.pbtxt".format(arg.model, arg.batch_size), "w"
+        ) as fid:
+            fid.write(str(model.param_init_net.Proto()))
+        with open("{0}.pbtxt".format(arg.model, arg.batch_size), "w") as fid:
+            fid.write(str(model.net.Proto()))
+
+    workspace.RunNetOnce(model.param_init_net)
+    workspace.CreateNet(model.net)
+    workspace.BenchmarkNet(
+        model.net.Proto().name, arg.warmup_iterations, arg.iterations,
+        arg.layer_wise_benchmark)
+
+
+def GetArgumentParser():
+    parser = argparse.ArgumentParser(description="Caffe2 benchmark.")
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=128,
+        help="The batch size."
+    )
+    parser.add_argument("--model", type=str, help="The model to benchmark.")
+    parser.add_argument(
+        "--order",
+        type=str,
+        default="NCHW",
+        help="The order to evaluate."
+    )
+    parser.add_argument(
+        "--cudnn_ws",
+        type=int,
+        help="The cudnn workspace size."
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=10,
+        help="Number of iterations to run the network."
+    )
+    parser.add_argument(
+        "--warmup_iterations",
+        type=int,
+        default=10,
+        help="Number of warm-up iterations before benchmarking."
+    )
+    parser.add_argument(
+        "--forward_only",
+        action='store_true',
+        help="If set, only run the forward pass."
+    )
+    parser.add_argument(
+        "--layer_wise_benchmark",
+        action='store_true',
+        help="If True, run the layer-wise benchmark as well."
+    )
+    parser.add_argument(
+        "--cpu",
+        action='store_true',
+        help="If True, run testing on CPU instead of GPU."
+    )
+    parser.add_argument(
+        "--mkl",
+        action='store_true',
+        help="If True, run testing on CPU-MKL instead of GPU."
+    )
+    parser.add_argument(
+        "--engine",
+        type=str,
+        default="",
+        help="If set, blindly prefer the given engine(s) for every op.")
+    parser.add_argument(
+        "--dump_model",
+        action='store_true',
+        help="If True, dump the model prototxts to disk."
+    )
+    parser.add_argument("--net_type", type=str, default="simple")
+    parser.add_argument("--num_workers", type=int, default=2)
+    parser.add_argument("--use-nvtx", default=False, action='store_true')
+    parser.add_argument("--htrace_span_log_path", type=str)
+    return parser
+
+
+if __name__ == '__main__':
+    args = GetArgumentParser().parse_args()
+    if (
+        not args.batch_size or not args.model or not args.order
+    ):
+        GetArgumentParser().print_help()
+    else:
+        workspace.GlobalInit(
+            ['caffe2', '--caffe2_log_level=0'] +
+            (['--caffe2_use_nvtx'] if args.use_nvtx else []) +
+            (['--caffe2_htrace_span_log_path=' + args.htrace_span_log_path]
+                if args.htrace_span_log_path else []))
+
+        model_map = {
+            'AlexNet': AlexNet,
+            'OverFeat': OverFeat,
+            'VGGA': VGGA,
+            'Inception': Inception,
+            'MLP': MLP,
+        }
+        Benchmark(model_map[args.model], args)

--- a/caffe2/python/mkl/mkl_LRN_op_test.py
+++ b/caffe2/python/mkl/mkl_LRN_op_test.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+import hypothesis.strategies as st
+from hypothesis import given, settings
+import numpy as np
+from caffe2.python import core, workspace
+import caffe2.python.hypothesis_test_util as hu
+import caffe2.python.mkl_test_util as mu
+
+
+@unittest.skipIf(not workspace.C.has_mkldnn,
+                 "Skipping as we do not have mkldnn.")
+
+
+class MKLLRNTest(hu.HypothesisTestCase):
+    @given(input_channels=st.integers(1, 3),
+           batch_size=st.integers(1, 3),
+           im_size=st.integers(1, 10),
+           order=st.sampled_from(["NCHW"]),
+           **mu.gcs)
+    
+    def test_mkl_LRN(self, input_channels, 
+                            batch_size, im_size, order,
+                             gc, dc):
+        op = core.CreateOperator(
+            "LRN",
+            ["X"],
+            ["Y", "Y_scale"],
+            size=5,
+            alpha=0.001, 
+            beta=0.75, 
+            bias=2.0,
+            order=order,
+        )
+        X = np.random.rand(
+            batch_size, input_channels, im_size, im_size).astype(np.float32)
+        
+        self.assertDeviceChecks(dc, op, [X], [0])
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()

--- a/caffe2/python/mkl/mkl_LRN_speed_test.py
+++ b/caffe2/python/mkl/mkl_LRN_speed_test.py
@@ -1,0 +1,79 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+import unittest
+
+import numpy as np
+from caffe2.proto import caffe2_pb2
+from caffe2.python import cnn, core, workspace, test_util
+
+
+@unittest.skipIf(not workspace.C.has_mkldnn, "Skipping as we do not have mkldnn.")
+class TestMKLBasic(test_util.TestCase):
+    def testLRNSpeed(self):
+        # We randomly select a shape to test the speed. Intentionally we
+        # test a batch size of 1 since this may be the most frequent use
+        # case for MKL during deployment time.
+        X = np.random.rand(1, 2, 224, 224).astype(np.float32)
+        mkl_do = core.DeviceOption(caffe2_pb2.MKLDNN)
+        # Makes sure that feed works.
+        workspace.FeedBlob("X", X)
+        workspace.FeedBlob("X_mkl", X, device_option=mkl_do)
+        net = core.Net("test")
+        # Makes sure that we can run relu.
+        net.LRN("X", ["Y", "Y_Scale"], size=5, alpha=0.001, beta=0.75, bias=2.0, order="NCHW")
+        net.LRN("X_mkl", ["Y_mkl", "Y_Scale_mkl"], size=5, alpha=0.001, beta=0.75, bias=2.0, order="NCHW", device_option=mkl_do)
+        workspace.CreateNet(net)
+        workspace.RunNet(net)
+
+        # makes sure that the results are good.
+        np.testing.assert_allclose(
+            workspace.FetchBlob("Y"),
+            workspace.FetchBlob("Y_mkl"),
+            atol=1e-2,
+            rtol=1e-2)
+        runtime = workspace.BenchmarkNet(net.Proto().name, 1, 100, True)
+
+        print("LRN CPU runtime {}, MKL runtime {}.".format(runtime[1], runtime[2]))
+    
+    def testConvReluLRNSpeed(self):
+        # We randomly select a shape to test the speed. Intentionally we
+        # test a batch size of 1 since this may be the most frequent use
+        # case for MKL during deployment time.
+        X = np.random.rand(1, 3, 224, 224).astype(np.float32) - 0.5
+        W = np.random.rand(64, 3, 11, 11).astype(np.float32) - 0.5
+        b = np.random.rand(64).astype(np.float32) - 0.5
+        
+        mkl_do = core.DeviceOption(caffe2_pb2.MKLDNN)
+        # Makes sure that feed works.
+        workspace.FeedBlob("X", X)
+        workspace.FeedBlob("W", W)
+        workspace.FeedBlob("b", b)
+        workspace.FeedBlob("X_mkl", X, device_option=mkl_do)
+        workspace.FeedBlob("W_mkl", W, device_option=mkl_do)
+        workspace.FeedBlob("b_mkl", b, device_option=mkl_do)
+        
+        net = core.Net("test")
+        
+        net.Conv(["X", "W", "b"], "C", pad=1, stride=1, kernel=11)
+        net.Conv(["X_mkl", "W_mkl", "b_mkl"], "C_mkl",
+                 pad=1, stride=1, kernel=11, device_option=mkl_do)
+        net.Relu("C", "R")
+        net.Relu("C_mkl", "R_mkl", device_option=mkl_do)
+        net.LRN("R", ["Y", "Y_Scale"], size=5, alpha=0.001, beta=0.75, bias=2.0, order="NCHW")
+        net.LRN("R_mkl", ["Y_mkl", "Y_Scale_mkl"],size=5, alpha=0.001, beta=0.75, bias=2.0, order="NCHW", device_option=mkl_do)
+
+        workspace.CreateNet(net)
+        workspace.RunNet(net)
+        # makes sure that the results are good.
+        np.testing.assert_allclose(
+            workspace.FetchBlob("Y"),
+            workspace.FetchBlob("Y_mkl"),
+            atol=1e-2,
+            rtol=1e-2)
+        runtime = workspace.BenchmarkNet(net.Proto().name, 1, 100, True)
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/caffe2/python/mkl/mkl_conv_op_test.py
+++ b/caffe2/python/mkl/mkl_conv_op_test.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+import hypothesis.strategies as st
+from hypothesis import given, settings
+import numpy as np
+from caffe2.python import core, workspace
+import caffe2.python.hypothesis_test_util as hu
+import caffe2.python.mkl_test_util as mu
+
+
+@unittest.skipIf(not workspace.C.has_mkldnn,
+                 "Skipping as we do not have mkldnn.")
+class MKLConvTest(hu.HypothesisTestCase):
+    @given(stride=st.integers(1, 3),
+           pad=st.integers(0, 3),
+           kernel=st.integers(3, 5),
+           size=st.integers(8, 8),
+           input_channels=st.integers(1, 3),
+           output_channels=st.integers(1, 3),
+           batch_size=st.integers(1, 3),
+           **mu.gcs)
+    @settings(max_examples=2, timeout=100)
+    def test_mkl_convolution(self, stride, pad, kernel, size,
+                             input_channels, output_channels,
+                             batch_size, gc, dc):
+        op = core.CreateOperator(
+            "Conv",
+            ["X", "w", "b"],
+            ["Y"],
+            stride=stride,
+            pad=pad,
+            kernel=kernel,
+        )
+        X = np.random.rand(
+            batch_size, input_channels, size, size).astype(np.float32) - 0.5
+        w = np.random.rand(
+                output_channels, input_channels, kernel, kernel) \
+            .astype(np.float32) - 0.5
+        b = np.random.rand(output_channels).astype(np.float32) - 0.5
+
+        inputs = [X, w, b]
+        self.assertDeviceChecks(dc, op, inputs, [0])
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()

--- a/caffe2/python/mkl/mkl_fc_op_test.py
+++ b/caffe2/python/mkl/mkl_fc_op_test.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+import hypothesis.strategies as st
+from hypothesis import given, settings
+import numpy as np
+from caffe2.python import core, workspace
+import caffe2.python.hypothesis_test_util as hu
+import caffe2.python.mkl_test_util as mu
+
+
+@unittest.skipIf(not workspace.C.has_mkldnn,
+                 "Skipping as we do not have mkldnn.")
+class MKLFcTest(hu.HypothesisTestCase):
+    @given(n=st.integers(1, 5), m=st.integers(1, 5),
+           k=st.integers(1, 5), **mu.gcs)
+    
+    def test_mkl_fc(self,n, m, k, gc, dc):
+        X = np.random.rand(m, k).astype(np.float32) - 0.5
+        W = np.random.rand(n, k).astype(np.float32) - 0.5
+        b = np.random.rand(n).astype(np.float32) - 0.5
+        
+        op = core.CreateOperator(
+            'FC',
+            ['X', 'W', 'b'],
+            ["Y"]
+            )
+        
+        self.assertDeviceChecks(dc, op, [X, W, b], [0])
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()

--- a/caffe2/python/mkl/mkl_fc_speed_test.py
+++ b/caffe2/python/mkl/mkl_fc_speed_test.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+import unittest
+
+import numpy as np
+from caffe2.proto import caffe2_pb2
+from caffe2.python import cnn, core, workspace, test_util
+
+
+@unittest.skipIf(not workspace.C.has_mkldnn, "Skipping as we do not have mkldnn.")
+class TestMKLBasic(test_util.TestCase):
+    def testFCSpeed(self):
+        # We randomly select a shape to test the speed. Intentionally we
+        # test a batch size of 1 since this may be the most frequent use
+        # case for MKL during deployment time.
+        X = np.random.rand(1, 256, 6, 6).astype(np.float32) - 0.5
+        #X = np.random.rand(32, 256*6*6).astype(np.float32) - 0.5
+        W = np.random.rand(4096, 9216).astype(np.float32) - 0.5
+        b = np.random.rand(4096).astype(np.float32) - 0.5
+        mkl_do = core.DeviceOption(caffe2_pb2.MKLDNN)
+        # Makes sure that feed works.
+        workspace.FeedBlob("X", X)
+        workspace.FeedBlob("W", W)
+        workspace.FeedBlob("b", b)
+        workspace.FeedBlob("X_mkl", X, device_option=mkl_do)
+        workspace.FeedBlob("W_mkl", W, device_option=mkl_do)
+        workspace.FeedBlob("b_mkl", b, device_option=mkl_do)
+        net = core.Net("test")
+        # Makes sure that we can run relu.
+        net.FC(["X", "W", "b"], "Y")
+        net.FC(["X_mkl", "W_mkl", "b_mkl"], "Y_mkl", device_option=mkl_do)
+
+        workspace.CreateNet(net)
+        workspace.RunNet(net)
+        # makes sure that the results are good.
+        np.testing.assert_allclose(
+            workspace.FetchBlob("Y"),
+            workspace.FetchBlob("Y_mkl"),
+            atol=1e-2,
+            rtol=1e-2)
+        runtime = workspace.BenchmarkNet(net.Proto().name, 1, 100, True)
+
+        print("FC CPU runtime {}, MKL runtime {}.".format(runtime[1], runtime[2]))
+
+    def testConvReluMaxPoolFcSpeed(self):
+        # We randomly select a shape to test the speed. Intentionally we
+        # test a batch size of 1 since this may be the most frequent use
+        # case for MKL during deployment time.
+        X = np.random.rand(1, 256, 13, 13).astype(np.float32) - 0.5
+        W = np.random.rand(256, 256, 3, 3).astype(np.float32) - 0.5
+        b = np.random.rand(256).astype(np.float32) - 0.5
+
+        w_fc = np.random.rand(4096, 9216).astype(np.float32) - 0.5
+        b_fc = np.random.rand(4096).astype(np.float32) - 0.5        
+        mkl_do = core.DeviceOption(caffe2_pb2.MKLDNN)
+        # Makes sure that feed works.
+        workspace.FeedBlob("X", X)
+        workspace.FeedBlob("W", W)
+        workspace.FeedBlob("b", b)
+        workspace.FeedBlob("w_fc", w_fc)
+        workspace.FeedBlob("b_fc", b_fc)        
+        workspace.FeedBlob("X_mkl", X, device_option=mkl_do)
+        workspace.FeedBlob("W_mkl", W, device_option=mkl_do)
+        workspace.FeedBlob("b_mkl", b, device_option=mkl_do)
+        workspace.FeedBlob("w_fc_mkl", w_fc, device_option=mkl_do)
+        workspace.FeedBlob("b_fc_mkl", b_fc, device_option=mkl_do)        
+
+        net = core.Net("test")
+        
+        net.Conv(["X", "W", "b"], "C", pad=1, stride=1, kernel=3)
+        net.Relu("C", "R")
+        net.MaxPool("R", "P", stride=2, kernel=3)
+        net.FC(["P","w_fc", "b_fc"], "Y")
+        
+        net.Conv(["X_mkl", "W_mkl", "b_mkl"], "C_mkl",
+                 pad=1, stride=1, kernel=3, device_option=mkl_do)
+        net.Relu("C_mkl", "R_mkl", device_option=mkl_do)        
+        net.MaxPool("R_mkl", "P_mkl",
+                 stride=2, kernel=3, device_option=mkl_do)
+        net.FC(["P_mkl","w_fc_mkl", "b_fc_mkl"], "Y_mkl", device_option=mkl_do)
+
+        workspace.CreateNet(net)
+        workspace.RunNet(net)
+        # makes sure that the results are good.
+        np.testing.assert_allclose(
+            workspace.FetchBlob("Y"),
+            workspace.FetchBlob("Y_mkl"),
+            atol=1e-2,
+            rtol=1e-2)
+        runtime = workspace.BenchmarkNet(net.Proto().name, 1, 100, True)
+
+    
+if __name__ == '__main__':
+    unittest.main()

--- a/caffe2/python/mkl/mkl_pool_op_test.py
+++ b/caffe2/python/mkl/mkl_pool_op_test.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+import hypothesis.strategies as st
+from hypothesis import given, settings
+import numpy as np
+from caffe2.python import core, workspace
+import caffe2.python.hypothesis_test_util as hu
+import caffe2.python.mkl_test_util as mu
+
+
+@unittest.skipIf(not workspace.C.has_mkldnn,
+                 "Skipping as we do not have mkldnn.")
+class MKLPoolTest(hu.HypothesisTestCase):
+    @given(stride=st.integers(1, 3),
+           pad=st.integers(0, 3),
+           kernel=st.integers(3, 5),
+           size=st.integers(7, 9),
+           input_channels=st.integers(1, 3),
+           batch_size=st.integers(1, 3),
+           method=st.sampled_from(["MaxPool", "AveragePool"]),
+           **mu.gcs)
+    @settings(max_examples=2, timeout=100)
+    def test_mkl_pooling(self, stride, pad, kernel, size,
+                             input_channels, batch_size, 
+                             method, gc, dc):
+        op = core.CreateOperator(
+            method,
+            ["X"],
+            ["Y"],
+            stride=stride,
+            pad=pad,
+            kernel=kernel,
+        )
+        X = np.random.rand(
+            batch_size, input_channels, size, size).astype(np.float32)
+        
+        self.assertDeviceChecks(dc, op, [X], [0])
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()

--- a/caffe2/python/mkl/mkl_pool_speed_test.py
+++ b/caffe2/python/mkl/mkl_pool_speed_test.py
@@ -1,0 +1,106 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+import unittest
+
+import numpy as np
+from caffe2.proto import caffe2_pb2
+from caffe2.python import cnn, core, workspace, test_util
+
+
+@unittest.skipIf(not workspace.C.has_mkldnn, "Skipping as we do not have mkldnn.")
+class TestMKLBasic(test_util.TestCase):
+    def testMaxPoolingSpeed(self):
+        # We randomly select a shape to test the speed. Intentionally we
+        # test a batch size of 1 since this may be the most frequent use
+        # case for MKL during deployment time.
+        X = np.random.rand(1, 64, 224, 224).astype(np.float32)
+        mkl_do = core.DeviceOption(caffe2_pb2.MKLDNN)
+        # Makes sure that feed works.
+        workspace.FeedBlob("X", X)
+        workspace.FeedBlob("X_mkl", X, device_option=mkl_do)
+        net = core.Net("test")
+        # Makes sure that we can run relu.
+        net.MaxPool("X", "Y", stride=2, kernel=3)
+        net.MaxPool("X_mkl", "Y_mkl",
+                 stride=2, kernel=3, device_option=mkl_do)
+        workspace.CreateNet(net)
+        workspace.RunNet(net)
+        # makes sure that the results are good.
+        np.testing.assert_allclose(
+            workspace.FetchBlob("Y"),
+            workspace.FetchBlob("Y_mkl"),
+            atol=1e-2,
+            rtol=1e-2)
+        runtime = workspace.BenchmarkNet(net.Proto().name, 1, 100, True)
+
+        print("Maxpooling CPU runtime {}, MKL runtime {}.".format(runtime[1], runtime[2]))
+
+    def testAveragePoolingSpeed(self):
+        # We randomly select a shape to test the speed. Intentionally we
+        # test a batch size of 1 since this may be the most frequent use
+        # case for MKL during deployment time.
+        X = np.random.rand(1, 64, 224, 224).astype(np.float32)
+        mkl_do = core.DeviceOption(caffe2_pb2.MKLDNN)
+        # Makes sure that feed works.
+        workspace.FeedBlob("X", X)
+        workspace.FeedBlob("X_mkl", X, device_option=mkl_do)
+        net = core.Net("test")
+        # Makes sure that we can run relu.
+        net.AveragePool("X", "Y", stride=2, kernel=3)
+        net.AveragePool("X_mkl", "Y_mkl",
+                 stride=2, kernel=3, device_option=mkl_do)
+        workspace.CreateNet(net)
+        workspace.RunNet(net)
+        # makes sure that the results are good.
+        np.testing.assert_allclose(
+            workspace.FetchBlob("Y"),
+            workspace.FetchBlob("Y_mkl"),
+            atol=1e-2,
+            rtol=1e-2)
+        runtime = workspace.BenchmarkNet(net.Proto().name, 1, 100, True)
+
+        print("Averagepooling CPU runtime {}, MKL runtime {}.".format(runtime[1], runtime[2]))
+
+    def testConvReluMaxPoolSpeed(self):
+        # We randomly select a shape to test the speed. Intentionally we
+        # test a batch size of 1 since this may be the most frequent use
+        # case for MKL during deployment time.
+        X = np.random.rand(1, 3, 224, 224).astype(np.float32) - 0.5
+        W = np.random.rand(64, 3, 11, 11).astype(np.float32) - 0.5
+        b = np.random.rand(64).astype(np.float32) - 0.5
+        
+        mkl_do = core.DeviceOption(caffe2_pb2.MKLDNN)
+        # Makes sure that feed works.
+        workspace.FeedBlob("X", X)
+        workspace.FeedBlob("W", W)
+        workspace.FeedBlob("b", b)
+        workspace.FeedBlob("X_mkl", X, device_option=mkl_do)
+        workspace.FeedBlob("W_mkl", W, device_option=mkl_do)
+        workspace.FeedBlob("b_mkl", b, device_option=mkl_do)
+        
+        net = core.Net("test")
+        
+        net.Conv(["X", "W", "b"], "C", pad=1, stride=1, kernel=11)
+        net.Conv(["X_mkl", "W_mkl", "b_mkl"], "C_mkl",
+                 pad=1, stride=1, kernel=11, device_option=mkl_do)
+        net.Relu("C", "R")
+        net.Relu("C_mkl", "R_mkl", device_option=mkl_do)
+        net.AveragePool("R", "Y", stride=2, kernel=3)
+        net.AveragePool("R_mkl", "Y_mkl",
+                 stride=2, kernel=3, device_option=mkl_do)
+
+        workspace.CreateNet(net)
+        workspace.RunNet(net)
+        # makes sure that the results are good.
+        np.testing.assert_allclose(
+            workspace.FetchBlob("Y"),
+            workspace.FetchBlob("Y_mkl"),
+            atol=1e-2,
+            rtol=1e-2)
+        runtime = workspace.BenchmarkNet(net.Proto().name, 1, 100, True)
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/caffe2/python/mkl/mkl_sbn_op_test.py
+++ b/caffe2/python/mkl/mkl_sbn_op_test.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+import hypothesis.strategies as st
+from hypothesis import given, settings
+import numpy as np
+from caffe2.python import core, workspace
+import caffe2.python.hypothesis_test_util as hu
+import caffe2.python.mkl_test_util as mu
+
+
+@unittest.skipIf(not workspace.C.has_mkldnn,
+                 "Skipping as we do not have mkldnn.")
+class MKLSpatialBNTest(hu.HypothesisTestCase):
+    @given(size=st.integers(7, 10),
+           input_channels=st.integers(1, 10),
+           batch_size=st.integers(1, 3),
+           seed=st.integers(0, 65535),
+           #order=st.sampled_from(["NCHW", "NHWC"]),
+           order=st.sampled_from(["NCHW"]),
+           epsilon=st.floats(1e-5, 1e-2),
+           **mu.gcs)    
+    def test_mkl_BN(self, size, input_channels, batch_size, seed, order, epsilon,
+            gc, dc):
+        
+        scale = np.random.rand(input_channels).astype(np.float32) + 0.5
+        bias = np.random.rand(input_channels).astype(np.float32) - 0.5
+        mean = np.random.randn(input_channels).astype(np.float32)
+        var = np.random.rand(input_channels).astype(np.float32) + 0.5
+        X = np.random.rand(
+            batch_size, input_channels, size, size).astype(np.float32) - 0.5
+
+        op = core.CreateOperator(
+            "SpatialBN",
+            ["X", "scale", "bias", "mean", "var"],
+            ["Y"],
+            order=order,
+            is_test=True,
+            epsilon=epsilon,
+        )
+
+        self.assertDeviceChecks(dc, op, [X, scale, bias, mean, var], [0])
+    
+    @given(size=st.integers(7, 10),
+           input_channels=st.integers(1, 10),
+           batch_size=st.integers(1, 3),
+           seed=st.integers(0, 65535),
+           #order=st.sampled_from(["NCHW", "NHWC"]),
+           order=st.sampled_from(["NCHW"]),
+           epsilon=st.floats(1e-5, 1e-2),
+           **mu.gcs)
+    def test_spatialbn_train_mode(
+            self, size, input_channels, batch_size, seed, order, epsilon,
+            gc, dc):
+        op = core.CreateOperator(
+            "SpatialBN",
+            ["X", "scale", "bias", "running_mean", "running_var"],
+            ["Y", "running_mean", "running_var", "saved_mean", "saved_var"],
+            order=order,
+            is_test=False,
+            epsilon=epsilon,
+        )
+        np.random.seed(1701)
+        scale = np.random.rand(input_channels).astype(np.float32) + 0.5
+        bias = np.random.rand(input_channels).astype(np.float32) - 0.5
+        mean = np.random.randn(input_channels).astype(np.float32)
+        var = np.random.rand(input_channels).astype(np.float32) + 0.5
+        X = np.random.rand(
+            batch_size, input_channels, size, size).astype(np.float32) - 0.5
+
+        self.assertDeviceChecks(dc, op, [X, scale, bias, mean, var],
+                                [0, 1, 2, 3, 4])
+
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()

--- a/caffe2/python/mkl/mkl_sbn_speed_test.py
+++ b/caffe2/python/mkl/mkl_sbn_speed_test.py
@@ -1,0 +1,120 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+import unittest
+
+import numpy as np
+from caffe2.proto import caffe2_pb2
+from caffe2.python import cnn, core, workspace, test_util
+
+
+@unittest.skipIf(not workspace.C.has_mkldnn, "Skipping as we do not have mkldnn.")
+class TestMKLBasic(test_util.TestCase):
+    def testSpatialBNTestingSpeed(self):
+        
+        input_channel = 10
+        X = np.random.rand(1, input_channel, 100, 100).astype(np.float32) - 0.5
+        scale = np.random.rand(input_channel).astype(np.float32) + 0.5
+        bias = np.random.rand(input_channel).astype(np.float32) - 0.5
+        mean = np.random.randn(input_channel).astype(np.float32)
+        var = np.random.rand(input_channel).astype(np.float32) + 0.5
+        
+        mkl_do = core.DeviceOption(caffe2_pb2.MKLDNN)
+        # Makes sure that feed works.
+        workspace.FeedBlob("X", X)
+        workspace.FeedBlob("scale", scale)
+        workspace.FeedBlob("bias", bias)
+        workspace.FeedBlob("mean", mean)
+        workspace.FeedBlob("var", var)
+        workspace.FeedBlob("X_mkl", X, device_option=mkl_do)
+        workspace.FeedBlob("scale_mkl", scale, device_option=mkl_do)
+        workspace.FeedBlob("bias_mkl", bias, device_option=mkl_do)
+        workspace.FeedBlob("mean_mkl", mean, device_option=mkl_do)
+        workspace.FeedBlob("var_mkl", var, device_option=mkl_do)
+        net = core.Net("test")
+        # Makes sure that we can run relu.
+        net.SpatialBN(["X", "scale", "bias","mean","var"], "Y", order="NCHW",
+            is_test=True,
+            epsilon=1e-5)
+        net.SpatialBN(["X_mkl", "scale_mkl", "bias_mkl","mean_mkl","var_mkl"], "Y_mkl", order="NCHW",
+            is_test=True,
+            epsilon=1e-5, device_option=mkl_do)
+
+        workspace.CreateNet(net)
+        workspace.RunNet(net)
+        # makes sure that the results are good.
+        np.testing.assert_allclose(
+            workspace.FetchBlob("Y"),
+            workspace.FetchBlob("Y_mkl"),
+            atol=1e-2,
+            rtol=1e-2)
+        runtime = workspace.BenchmarkNet(net.Proto().name, 1, 100, True)
+
+        print("FC CPU runtime {}, MKL runtime {}.".format(runtime[1], runtime[2]))
+
+    def testSpatialBNTrainingSpeed(self):
+        input_channel = 10
+        X = np.random.rand(1, input_channel, 100, 100).astype(np.float32) - 0.5
+        scale = np.random.rand(input_channel).astype(np.float32) + 0.5
+        bias = np.random.rand(input_channel).astype(np.float32) - 0.5
+        mean = np.random.randn(input_channel).astype(np.float32)
+        var = np.random.rand(input_channel).astype(np.float32) + 0.5
+
+        #mean = np.zeros(input_channel)
+        #var = np.zeros(input_channel)
+        
+        mkl_do = core.DeviceOption(caffe2_pb2.MKLDNN)
+        # Makes sure that feed works.
+        workspace.FeedBlob("X", X)
+        workspace.FeedBlob("scale", scale)
+        workspace.FeedBlob("bias", bias)
+        workspace.FeedBlob("mean", mean)
+        workspace.FeedBlob("var", var)
+        workspace.FeedBlob("X_mkl", X, device_option=mkl_do)
+        workspace.FeedBlob("scale_mkl", scale, device_option=mkl_do)
+        workspace.FeedBlob("bias_mkl", bias, device_option=mkl_do)
+        workspace.FeedBlob("mean_mkl", mean, device_option=mkl_do)
+        workspace.FeedBlob("var_mkl", var, device_option=mkl_do)
+        net = core.Net("test")
+        # Makes sure that we can run relu.
+        net.SpatialBN(["X", "scale", "bias","mean", "var"],
+            ["Y", "mean", "var", "saved_mean", "saved_var"], 
+            order="NCHW",
+            is_test=False,
+            epsilon=1e-5)
+        net.SpatialBN(["X_mkl", "scale_mkl", "bias_mkl","mean_mkl","var_mkl"], 
+            ["Y_mkl", "mean_mkl", "var_mkl", "saved_mean_mkl", "saved_var_mkl"],
+            order="NCHW",
+            is_test=False,
+            epsilon=1e-5, 
+            device_option=mkl_do)
+
+        workspace.CreateNet(net)
+        workspace.RunNet(net)
+                
+        # makes sure that the results are good.
+        np.testing.assert_allclose(
+            workspace.FetchBlob("Y"),
+            workspace.FetchBlob("Y_mkl"),
+            atol=1e-2,
+            rtol=1e-2)
+        np.testing.assert_allclose(
+            workspace.FetchBlob("mean"),
+            workspace.FetchBlob("mean_mkl"),
+            atol=1e-2,
+            rtol=1e-2)
+        np.testing.assert_allclose(
+            workspace.FetchBlob("var"),
+            workspace.FetchBlob("var_mkl"),
+            atol=1e-2,
+            rtol=1e-2)
+
+        runtime = workspace.BenchmarkNet(net.Proto().name, 1, 100, True)
+
+        print("FC CPU runtime {}, MKL runtime {}.".format(runtime[1], runtime[2]))
+
+   
+    
+if __name__ == '__main__':
+    unittest.main()

--- a/caffe2/python/mkl/mkl_speed_test.py
+++ b/caffe2/python/mkl/mkl_speed_test.py
@@ -1,0 +1,80 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+import unittest
+
+import numpy as np
+from caffe2.proto import caffe2_pb2
+from caffe2.python import cnn, core, workspace, test_util
+
+
+@unittest.skipIf(not workspace.C.has_mkldnn, "Skipping as we do not have mkldnn.")
+class TestMKLBasic(test_util.TestCase):
+    def testReLUSpeed(self):
+        X = np.random.randn(128, 4096).astype(np.float32)
+        mkl_do = core.DeviceOption(caffe2_pb2.MKLDNN)
+        # Makes sure that feed works.
+        workspace.FeedBlob("X", X)
+        workspace.FeedBlob("X_mkl", X, device_option=mkl_do)
+        net = core.Net("test")
+        # Makes sure that we can run relu.
+        net.Relu("X", "Y")
+        net.Relu("X_mkl", "Y_mkl", device_option=mkl_do)
+        workspace.CreateNet(net)
+        workspace.RunNet(net)
+        # makes sure that the results are good.
+        np.testing.assert_allclose(
+            workspace.FetchBlob("Y"),
+            workspace.FetchBlob("Y_mkl"),
+            atol=1e-10,
+            rtol=1e-10)
+        runtime = workspace.BenchmarkNet(net.Proto().name, 1, 100, True)
+
+        # The returned runtime is the time of
+        # [whole_net, cpu_op, mkl_op]
+        # so we will assume that the MKL one runs faster than the CPU one.
+
+        # Note(Yangqing): in fact, it seems that in optimized mode, this is
+        # not always guaranteed - MKL runs slower than the Eigen vectorized
+        # version, so I am turning this assertion off.
+        #self.assertTrue(runtime[1] >= runtime[2])
+
+        print("Relu CPU runtime {}, MKL runtime {}.".format(runtime[1], runtime[2]))
+
+
+    def testConvSpeed(self):
+        # We randomly select a shape to test the speed. Intentionally we
+        # test a batch size of 1 since this may be the most frequent use
+        # case for MKL during deployment time.
+        X = np.random.rand(1, 256, 27, 27).astype(np.float32) - 0.5
+        W = np.random.rand(192, 256, 3, 3).astype(np.float32) - 0.5
+        b = np.random.rand(192).astype(np.float32) - 0.5
+        mkl_do = core.DeviceOption(caffe2_pb2.MKLDNN)
+        # Makes sure that feed works.
+        workspace.FeedBlob("X", X)
+        workspace.FeedBlob("W", W)
+        workspace.FeedBlob("b", b)
+        workspace.FeedBlob("X_mkl", X, device_option=mkl_do)
+        workspace.FeedBlob("W_mkl", W, device_option=mkl_do)
+        workspace.FeedBlob("b_mkl", b, device_option=mkl_do)
+        net = core.Net("test")
+        # Makes sure that we can run relu.
+        net.Conv(["X", "W", "b"], "Y", pad=1, stride=1, kernel=3)
+        net.Conv(["X_mkl", "W_mkl", "b_mkl"], "Y_mkl",
+                 pad=1, stride=1, kernel=3, device_option=mkl_do)
+        workspace.CreateNet(net)
+        workspace.RunNet(net)
+        # makes sure that the results are good.
+        np.testing.assert_allclose(
+            workspace.FetchBlob("Y"),
+            workspace.FetchBlob("Y_mkl"),
+            atol=1e-2,
+            rtol=1e-2)
+        runtime = workspace.BenchmarkNet(net.Proto().name, 1, 100, True)
+
+        print("Conv CPU runtime {}, MKL runtime {}.".format(runtime[1], runtime[2]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/caffe2/utils/mkl/mkl_dnn_cppwrapper.h
+++ b/caffe2/utils/mkl/mkl_dnn_cppwrapper.h
@@ -1086,6 +1086,184 @@ dnnBatchNormalizationCreateBackwardScaleShift<double>(
       pBatchNormalization, attributes, dataLayout, eps);
 }
 
+
+C2_MKL_TEMPLATE_PREFIX dnnError_t dnnBatchNormalizationCreateForward_v2(
+    dnnPrimitive_t* pBatchNormalization,
+    dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout,
+    float eps,
+    unsigned int flags);
+C2_MKL_SPEC_PREFIX dnnError_t dnnBatchNormalizationCreateForward_v2<float>(
+    dnnPrimitive_t* pBatchNormalization,
+    dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout,
+    float eps,
+    unsigned int flags) {
+  return dnnBatchNormalizationCreateForward_v2_F32(
+      pBatchNormalization, attributes, dataLayout, eps, flags);
+}
+C2_MKL_SPEC_PREFIX dnnError_t dnnBatchNormalizationCreateForward_v2<double>(
+    dnnPrimitive_t* pBatchNormalization,
+    dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout,
+    float eps,
+    unsigned int flags) {
+  return dnnBatchNormalizationCreateForward_v2_F64(
+      pBatchNormalization, attributes, dataLayout, eps, flags);
+}
+
+C2_MKL_TEMPLATE_PREFIX dnnError_t dnnBatchNormalizationCreateBackward_v2(
+    dnnPrimitive_t* pBatchNormalization,
+    dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout,
+    float eps,
+    unsigned int flags);
+C2_MKL_SPEC_PREFIX dnnError_t dnnBatchNormalizationCreateBackward_v2<float>(
+    dnnPrimitive_t* pBatchNormalization,
+    dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout,
+    float eps,
+    unsigned int flags) {
+  return dnnBatchNormalizationCreateBackward_v2_F32(
+      pBatchNormalization, attributes, dataLayout, eps, flags);
+}
+
+C2_MKL_SPEC_PREFIX dnnError_t dnnBatchNormalizationCreateBackward_v2<double>(
+    dnnPrimitive_t* pBatchNormalization,
+    dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout,
+    float eps,
+    unsigned int flags) {
+  return dnnBatchNormalizationCreateBackward_v2_F64(
+      pBatchNormalization, attributes, dataLayout, eps, flags);
+}
+
+
+
+
+C2_MKL_TEMPLATE_PREFIX dnnError_t dnnInnerProductCreateForward(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels);
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateForward<float>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateForward_F32(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateForward<double>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateForward_F64(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+
+C2_MKL_TEMPLATE_PREFIX dnnError_t dnnInnerProductCreateForwardBias(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels);
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateForwardBias<float>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateForwardBias_F32(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateForwardBias<double>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateForwardBias_F64(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+
+C2_MKL_TEMPLATE_PREFIX dnnError_t dnnInnerProductCreateBackwardData(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels);
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateBackwardData<float>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateBackwardData_F32(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateBackwardData<double>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateBackwardData_F64(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+
+C2_MKL_TEMPLATE_PREFIX dnnError_t dnnInnerProductCreateBackwardFilter(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels);
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateBackwardFilter<float>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateBackwardFilter_F32(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateBackwardFilter<double>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[],
+        size_t outputChannels) {
+  return dnnInnerProductCreateBackwardFilter_F64(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+
+C2_MKL_TEMPLATE_PREFIX dnnError_t dnnInnerProductCreateBackwardBias(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[]);
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateBackwardBias<float>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[]) {
+  return dnnInnerProductCreateBackwardBias_F32(
+      pInnerProduct, attributes, dimensions, srcSize);
+}
+C2_MKL_SPEC_PREFIX dnnError_t dnnInnerProductCreateBackwardBias<double>(
+        dnnPrimitive_t *pInnerProduct,
+        dnnPrimitiveAttributes_t attributes,
+        size_t dimensions,
+        const size_t srcSize[]) {
+  return dnnInnerProductCreateBackwardBias_F64(
+      pInnerProduct, attributes, dimensions, srcSize);
+}
+
+
 } // namespace mkl
 } // namespace caffe2
 

--- a/caffe2/utils/mkl_utils.h
+++ b/caffe2/utils/mkl_utils.h
@@ -34,6 +34,31 @@
         error);                     \
   } while (0)
 
+#define CHECK_INPUT_FILTER_DIMS(condition)  \
+  do {                                           \
+    if (cached_input_dims_ != X.dims() ||        \
+        cached_filter_dims_ != filter.dims()){   \
+      cached_input_dims_ = X.dims();             \
+      cached_filter_dims_ = filter.dims();       \
+      condition = true;                          \
+    }                                            \
+    else{                                        \
+      condition = false;                         \
+    }                                            \
+  } while (0)
+
+#define CHECK_INPUT_DIMS(condition)  \
+  do {                                           \
+    if (cached_input_dims_ != X.dims()){         \
+      cached_input_dims_ = X.dims();             \
+      condition = true;                          \
+    }                                            \
+    else{                                        \
+      condition = false;                         \
+    }                                            \
+  } while (0)
+
+
 // All caffe2 mkl related headers
 
 #ifdef CAFFE2_HAS_MKL_DNN
@@ -49,3 +74,4 @@
 
 #endif // CAFFE2_USE_MKL
 #endif // CAFFE2_UTILS_MKL_UTILS_H_
+

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -226,7 +226,7 @@ endif()
 # ---[ OpenMP
 if(USE_OPENMP)
   find_package(OpenMP)
-  if(OpenMP_FOUND)
+  if(OPENMP_FOUND)
     message(STATUS "Adding " ${OpenMP_CXX_FLAGS})
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")


### PR DESCRIPTION
This PR is based on commit "977c6b3" as this version allows MKL to use all the cores available.
All MKL related files are added here after incorporating review comments, major changes include

1. usage of Clang-format(Linter) with --style = Google
2. usage of macros for checking input and filter dimension in the mkl operators
3. merged Max and Average pooling functions
4. created a new folder for mkl related python scripts in Python folder and moved them there
5. there is no mkl_alexnet_test.py as that was redundant while convnet_benchmark.py does the same thing