### PR TITLE
Missing CUDA_NVCC_FLAGS & CUDA_HOST_COMPILER flags at GPU arch detection.

### DIFF
--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -27,7 +27,7 @@ function(caffe2_detect_installed_gpus out_variable)
       "  return 0;\n"
       "}\n")
 
-    execute_process(COMMAND "${CUDA_NVCC_EXECUTABLE}" "--run" "${__cufile}"
+    execute_process(COMMAND "${CUDA_NVCC_EXECUTABLE}" "-ccbin=${CUDA_HOST_COMPILER}" ${CUDA_NVCC_FLAGS} "--run" "${__cufile}"
                     WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/CMakeFiles/"
                     RESULT_VARIABLE __nvcc_res OUTPUT_VARIABLE __nvcc_out
                     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
This tiny patch fix missing ```CUDA_NVCC_FLAGS``` & ```CUDA_HOST_ARCH``` from ```caffe_detect_installed_gpus()```. 

-----------------

People may want define their custom flags or compilers that are more CUDA compatible. Automatic gpu arch detection ignores these flags and fail. Example of such custom flags:

```
cmake . \
-DCUDA_ARCH_NAME="Auto" \
-DCUDA_HOST_COMPILER="/usr/bin/gcc5"
```

* Autodetection part fails regardless proper compiler flags are passed, due to system gcc 7.0 that doesnt work with CUDA thus all arch will be enabled:
```
-- The C compiler identification is GNU 7.0.1
-- The CXX compiler identification is GNU 7.0.1
...//\\...
-- CUDA detected: 8.0
...//\\...
-- Automatic GPU detection failed. Building for all known architectures.
-- Added CUDA NVCC flags for: sm_20 sm_21 sm_30 sm_35 sm_50 sm_60 sm_61
```
* Patch fix the autodetection time as expected:
```
$ cmake ../ -DCUDA_NVCC_FLAGS="-Xcompiler=-std=c++03 -I/usr/include/cuda/"
-- The C compiler identification is GNU 7.0.1
-- The CXX compiler identification is GNU 7.0.1
...//\\...
-- CUDA detected: 8.0
...//\\...
-- Added CUDA NVCC flags for: sm_52
```
* Or by passing a compatible gcc5 (distros ships older compat compilers too) can avoid the gcc (version 7) for cuda:

```
cmake . -DCUDA_ARCH_NAME="Auto"  -DCUDA_HOST_COMPILER="/usr/bin/gcc5"
-- The C compiler identification is GNU 7.0.1
-- The CXX compiler identification is GNU 7.0.1
...//\\...
-- CUDA detected: 8.0
...//\\...
-- Added CUDA NVCC flags for: sm_52
```