### PR TITLE
Fix typo and fragmented sentences in Basics.ipynb

### DIFF
--- a/caffe2/python/tutorials/Basics.ipynb
+++ b/caffe2/python/tutorials/Basics.ipynb
@@ -424,9 +424,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is working if you're expected output matches your Y output in this example.\n",
+    "This is working if your Expected output matches your Y output in this example.\n",
     "\n",
-    "Operators also take optional arguments if needed. They are specified as key-value pairs. Let's take a look at one simple example, which is to create a tensor and fills it with Gaussian random variables."
+    "Operators also take optional arguments if needed. They are specified as key-value pairs. Let's take a look at one simple example, which takes a tensor and fills it with Gaussian random variables."
    ]
   },
   {


### PR DESCRIPTION
You're --> your, etc