### PR TITLE
Add six to Tegra X1 install script

### DIFF
--- a/scripts/build_tegra_x1.sh
+++ b/scripts/build_tegra_x1.sh
@@ -41,6 +41,10 @@ sudo apt-get install \
 # the one provided by apt-get is quite old so we install it via pip
 sudo pip install hypothesis
 
+# Install the six module, which includes Python 2 and 3 compatibility utilities,
+# and is required for Caffe2
+sudo pip install six
+
 # Now, actually build the android target.
 echo "Building caffe2"
 cd $BUILD_ROOT


### PR DESCRIPTION
When compiling Caffe2 on a Jetson TX2 using JetPack 3.0, the compilation with the Tegra X1 build script runs through perfectly fine. However, when running

    from caffe2.python import workspace

the following error shows up:

> ImportError: No module named six

After installing `six` manually using

    sudo pip install six

this works fine. I thus added the `six` module to the install script.

I assume this will also be required for the `build_raspbian.sh` script, however as I could test this, I didn't add it (yet).