### PR TITLE
[FIX] build error in context_gpu_test.cc

### DIFF
--- a/caffe2/core/context_gpu_test.cc
+++ b/caffe2/core/context_gpu_test.cc
@@ -2,6 +2,7 @@
 #include <future>
 #include <random>
 #include <thread>
+#include <array>
 
 #include "caffe2/proto/caffe2.pb.h"
 #include "caffe2/core/context_gpu.h"

--- a/caffe2/core/net_gpu.cc
+++ b/caffe2/core/net_gpu.cc
@@ -4,7 +4,7 @@
 #include <mutex>
 #include <stack>
 
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER) && !defined(__APPLE__)
 #include <sched.h>
 #endif
 
@@ -264,7 +264,7 @@ void GPUExecutor::set_affinity() {
 // TODO: find a Windows-compatible affinity setting approach.
 // Currently, set_affinity has no effect in Windows. The code is still
 // correct with possible slowdowns.
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER) && !defined(__APPLE__)
   /* Set CPU affinity */
   int num_cores = std::thread::hardware_concurrency();
   if (num_cores > 0) {


### PR DESCRIPTION
caffe2/caffe2/core/context_gpu_test.cc:97:31: error: implicit instantiation of undefined template 'std::__1::array<CUstream_st *, 2>' std::array<cudaStream_t, 2> temp = {0};

(fixes build issue on macOS 10.11.6)