### PR TITLE
Fix url to original Caffe external resource in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Caffe2
 
-Caffe2 is a lightweight, modular, and scalable deep learning framework. Building on the original [Caffe](caffe.berkeleyvision.org), Caffe2 is designed with expression, speed, and modularity in mind.
+Caffe2 is a lightweight, modular, and scalable deep learning framework. Building on the original [Caffe](http://caffe.berkeleyvision.org), Caffe2 is designed with expression, speed, and modularity in mind.
 
 ## Questions and Feedback
 


### PR DESCRIPTION
This fixes the destination to the original Caffe website in `README.md` by adding the protocol to the url. Otherwise, the link will attempt to open up the file `caffe.berkeleyvision.org` in this repo, which doesn't exist.