### PR TITLE
Fix parallel build support in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This makefile does nothing but delegating the actual building to cmake.
 
 all:
-	@mkdir -p build && cd build && cmake .. $(python ./scripts/get_python_cmake_flags.py) && make
+	@mkdir -p build && cd build && cmake .. $(python ./scripts/get_python_cmake_flags.py) && $(MAKE)
 
 local:
 	@./scripts/build_local.sh


### PR DESCRIPTION
Top-level makefile had `make` hardcoded, resulting in slow build and the following message when following installation instructions:

    warning: jobserver unavailable: using -j1. Add `+' to parent make rule.

Replacing this recursive make command with the variable MAKE fixes the issue.