### PR TITLE
fix download progress bar's percentage exceed 100%

### DIFF
--- a/caffe2/python/models/download.py
+++ b/caffe2/python/models/download.py
@@ -65,7 +65,7 @@ def downloadFromURLToFile(url, filename):
                 if not data_chunk:
                     break
                 local_file.write(data_chunk)
-                downloaded_size += chunk
+                downloaded_size += len(data_chunk)
                 progressBar(int(100 * downloaded_size / size))
         print("")  # New line to fix for progress bar
     except HTTPError as e:


### PR DESCRIPTION
downloaded_size need to be added with the length of returned data_chunk.
When the last block's size less than chunk, the percentage should exceed 100%