### PR TITLE
Added Python_ADDITIONAL_VERSIONS to cmake so python 2 is default.

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -182,6 +182,7 @@ add_definitions(-DEIGEN_MPL2_ONLY)
 
 # ---[ Python + Numpy
 if (BUILD_PYTHON)
+  set(Python_ADDITIONAL_VERSIONS 2.8 2.7 2.6)
   find_package(PythonInterp 2.7)
   find_package(PythonLibs 2.7)
   find_package(NumPy REQUIRED)


### PR DESCRIPTION
When installing on systems such as Arch Linux where the default python version is 3 the build will fail. To fix this instead of changing the python link in the shell it is more efficient to set the default python version allowed by cmake.