### PR TITLE
Fix not showing histogram in Basics.ipynb

### DIFF
--- a/caffe2/python/tutorials/Basics.ipynb
+++ b/caffe2/python/tutorials/Basics.ipynb
@@ -26,7 +26,10 @@
     "\n",
     "# These are the droids you are looking for.\n",
     "from caffe2.python import core, workspace\n",
-    "from caffe2.proto import caffe2_pb2"
+    "from caffe2.proto import caffe2_pb2\n",
+    "\n",
+    "# Let's show all plots inline.\n",
+    "%matplotlib inline"
    ]
   },
   {


### PR DESCRIPTION
Histogram of Gaussian random variables doesn't show while running "Basics.ipynb" iPython notebook.

There are two ways to resolve this issue:
1. Add "%matplotlib inline" after importing matplotlib.
2. Or just add "pyplot.show()" to show this plot.

I prefer the first solution, so I've prepared a change for that. If you prefer the second one - just give me a feedback and I'll update this PR.