### PR TITLE
Fix python support problems caused by building script errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This makefile does nothing but delegating the actual building to cmake.
 
 all:
-	@mkdir -p build && cd build && cmake .. $(python ./scripts/get_python_cmake_flags.py) && $(MAKE)
+	@mkdir -p build && cd build && cmake .. $(shell python ../scripts/get_python_cmake_flags.py) && $(MAKE)
 
 local:
 	@./scripts/build_local.sh

--- a/scripts/get_python_cmake_flags.py
+++ b/scripts/get_python_cmake_flags.py
@@ -35,7 +35,9 @@ lib = sysconfig.get_config_var("LIBDIR")
 if sys.platform == "darwin":
     lib = os.path.dirname(lib) + '/Python'
     if os.path.isfile(lib):
-        flags += '-DPYTHON_LIBRARY={lib}'.format(lib=lib)
+        flags += '-DPYTHON_LIBRARY={lib} '.format(lib=lib)
 
 if os.path.isfile(inc + '/Python.h'):
-    flags += '-DPYTHON_INCLUDE_DIR={inc}'.format(inc=inc)
+    flags += '-DPYTHON_INCLUDE_DIR={inc} '.format(inc=inc)
+
+print(flags, end='')


### PR DESCRIPTION
When trying to build caffe2 with python provided by homebrew, I find out there are some errors in the building scripts. The "get_python_cmake_flags.py" script is supposed to find out the correct python library and header file locations. However, due to these errors, this script does not function correctly. After building, caffe2 is linked against the default python library provided by Apple which causes a crash when trying to validate whether or not the installation is successful:
```shell
python -c 'from caffe2.python import core' 2>/dev/null && echo "Success" || echo "Failure"
```
The fix is as simple as follows:

- Add "shell" so that command substitution could work under Makefile.

- Add blank spaces between -D options so that they are treated as options not makefile targets.

- Print the "flags" variable without the newline character so that they could be utilized by command substitution correctly.