### PR TITLE
string -> std::string in common_rtc.h

### DIFF
--- a/caffe2/cuda_rtc/common_rtc.h
+++ b/caffe2/cuda_rtc/common_rtc.h
@@ -1,11 +1,11 @@
 #ifndef CAFFE2_CUDA_RTC_COMMON_RTC_H_
 #define CAFFE2_CUDA_RTC_COMMON_RTC_H_
 
+#include <sstream>
+#include <string>
+
 #include <cuda.h>
 #include <nvrtc.h>
-
-#include <string>
-#include <sstream>
 
 #define NVRTC_CHECK(condition)                                                 \
   do {                                                                         \

--- a/caffe2/cuda_rtc/common_rtc.h
+++ b/caffe2/cuda_rtc/common_rtc.h
@@ -4,6 +4,9 @@
 #include <cuda.h>
 #include <nvrtc.h>
 
+#include <string>
+#include <sstream>
+
 #define NVRTC_CHECK(condition)                                                 \
   do {                                                                         \
     nvrtcResult result = condition;                                            \

--- a/caffe2/cuda_rtc/common_rtc.h
+++ b/caffe2/cuda_rtc/common_rtc.h
@@ -99,7 +99,7 @@ class CudaRTCFunction {
 };
 
 // TODO: this is in no way unique and is just a hack right now.
-inline string GetUniqueName() {
+inline std::string GetUniqueName() {
   static constexpr int len = 20;
   static const char alpha[] =
       "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";


### PR DESCRIPTION
In its current form, common_rtc.h can only be included in a file where 
```
using namespace std;
```
comes before the include