### PR TITLE
Support fp16 output from ImageInputOp

### DIFF
--- a/caffe2/image/image_input_op.h
+++ b/caffe2/image/image_input_op.h
@@ -61,11 +61,13 @@ class ImageInputOp final
   bool is_test_;
   bool use_caffe_datum_;
   bool gpu_transform_;
-  TensorProto_DataType output_type_;
 
   // thread pool for parse + decode
   int num_decode_threads_;
   std::shared_ptr<TaskThreadPool> thread_pool_;
+
+  // Output type for GPU transform path
+  TensorProto_DataType output_type_;
 };
 
 

--- a/caffe2/image/image_input_op.h
+++ b/caffe2/image/image_input_op.h
@@ -7,6 +7,7 @@
 
 #include "caffe/proto/caffe.pb.h"
 #include "caffe2/core/db.h"
+#include "caffe2/utils/cast.h"
 #include "caffe2/utils/math.h"
 #include "caffe2/utils/thread_pool.h"
 #include "caffe2/operators/prefetch_op.h"
@@ -60,6 +61,7 @@ class ImageInputOp final
   bool is_test_;
   bool use_caffe_datum_;
   bool gpu_transform_;
+  TensorProto_DataType output_type_;
 
   // thread pool for parse + decode
   int num_decode_threads_;
@@ -88,7 +90,9 @@ ImageInputOp<Context>::ImageInputOp(
               "use_gpu_transform", 0)),
         num_decode_threads_(OperatorBase::template GetSingleArgument<int>(
               "decode_threads", 4)),
-        thread_pool_(new TaskThreadPool(num_decode_threads_))
+        thread_pool_(new TaskThreadPool(num_decode_threads_)),
+        // output type only supported with CUDA and use_gpu_transform for now
+        output_type_(cast::GetCastDataType(this->arg_helper(), "output_type"))
 {
   if (operator_def.input_size() == 0) {
     LOG(ERROR) << "You are using an old ImageInputOp format that creates "
@@ -122,7 +126,9 @@ ImageInputOp<Context>::ImageInputOp(
   LOG(INFO) << "    " << (is_test_ ? "Central" : "Random") << " cropping image to " << crop_
             << (mirror_ ? " with " : " without ") << "random mirroring;";
   LOG(INFO) << "    Subtract mean " << mean_ << " and divide by std " << std_
-            << ".";
+            << ";";
+  LOG(INFO) << "    Outputting images as "
+            << OperatorBase::template GetSingleArgument<string>("output_type", "unknown") << ".";
   prefetched_image_.Resize(
       TIndex(batch_size_),
       TIndex(crop_),
@@ -454,8 +460,8 @@ bool ImageInputOp<Context>::Prefetch() {
     randgen_per_thread.emplace_back(meta_randgen());
   }
 
+  std::bernoulli_distribution mirror_this_image(0.5);
   for (int item_id = 0; item_id < batch_size_; ++item_id) {
-    std::bernoulli_distribution mirror_this_image(0.5);
     std::mt19937* randgen = &randgen_per_thread[item_id % num_decode_threads_];
     std::string key, value;
     cv::Mat img;
@@ -531,7 +537,14 @@ bool ImageInputOp<Context>::CopyPrefetched() {
     label_output->CopyFrom(prefetched_label_, &context_);
   } else {
     if (gpu_transform_) {
-      TransformOnGPU<uint8_t,float,Context>(prefetched_image_on_device_, image_output, std_, mean_, &context_);
+      // GPU transform kernel allows explicitly setting output type
+      if (output_type_ == TensorProto_DataType_FLOAT) {
+        TransformOnGPU<uint8_t,float,Context>(prefetched_image_on_device_, image_output, std_, mean_, &context_);
+      } else if (output_type_ == TensorProto_DataType_FLOAT16) {
+        TransformOnGPU<uint8_t,float16,Context>(prefetched_image_on_device_, image_output, std_, mean_, &context_);
+      }  else {
+        return false;
+      }
     } else {
       image_output->CopyFrom(prefetched_image_on_device_, &context_);
     }

--- a/caffe2/image/transform_gpu.cu
+++ b/caffe2/image/transform_gpu.cu
@@ -1,5 +1,6 @@
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/image/transform_gpu.h"
+#include "caffe2/utils/conversions.h"
 
 /**
  *
@@ -32,9 +33,7 @@ void transform_kernel(const int N, const int C, const int H, const int W,
         int in_idx = c + C*w + C*W*h;  // HWC
         int out_idx = c*H*W + h*W + w;  // CHW
 
-        //out[out_idx] = static_cast<Out>(
-        //                static_cast<In>(in[in_idx]-mean)/std);
-        output_ptr[out_idx] = (static_cast<Out>(input_ptr[in_idx])-mean) / std;
+        output_ptr[out_idx] = convert::To<float,Out>((convert::To<In,float>(input_ptr[in_idx])-mean) / std);
       }
     }
   }
@@ -43,7 +42,7 @@ void transform_kernel(const int N, const int C, const int H, const int W,
 }
 
 template <typename T_IN, typename T_OUT, class Context>
-bool TransformOnGPU(Tensor<Context>& X, Tensor<Context> *Y, T_OUT mean, T_OUT std, Context *context) {
+bool TransformOnGPU(Tensor<Context>& X, Tensor<Context> *Y, float mean, float std, Context *context) {
   return true;
 };
 
@@ -59,6 +58,21 @@ bool TransformOnGPU<uint8_t, float, CUDAContext>(Tensor<CUDAContext>& X, Tensor<
   auto* output_data = Y->mutable_data<float>();
 
   transform_kernel<uint8_t,float><<<N, dim3(16,16), 0, context->cuda_stream()>>>(N,C,H,W, mean, std, input_data, output_data);
+  return true;
+}
+
+template <>
+bool TransformOnGPU<uint8_t, float16, CUDAContext>(Tensor<CUDAContext>& X, Tensor<CUDAContext> *Y, float std, float mean, CUDAContext *context)
+{
+  // data comes in as NHWC
+  const int N = X.dim32(0), C = X.dim32(3), H = X.dim32(1), W = X.dim32(2);
+  // data goes out as NCHW
+  Y->Resize(std::vector<int>{N,C,H,W});
+
+  auto* input_data = X.data<uint8_t>();
+  auto* output_data = Y->mutable_data<float16>();
+
+  transform_kernel<uint8_t,float16><<<N, dim3(16,16), 0, context->cuda_stream()>>>(N,C,H,W, mean, std, input_data, output_data);
   return true;
 }
 

--- a/caffe2/image/transform_gpu.h
+++ b/caffe2/image/transform_gpu.h
@@ -31,7 +31,7 @@
 namespace caffe2 {
 
 template <typename T_IN, typename T_OUT, class Context>
-bool TransformOnGPU(Tensor<Context>& X, Tensor<Context> *Y, T_OUT mean, T_OUT std, Context *context);
+bool TransformOnGPU(Tensor<Context>& X, Tensor<Context> *Y, float mean, float std, Context *context);
 
 }  // namespace caffe2
 

--- a/caffe2/operators/cast_op.cc
+++ b/caffe2/operators/cast_op.cc
@@ -17,6 +17,72 @@ bool CastOp<CPUContext>::DoRunWithType() {
   return true;
 }
 
+template <>
+void CastOp<CPUContext>::SetBody(TensorProto_DataType to) {
+  switch (to) {
+    case TensorProto_DataType_FLOAT:
+      // body_ = &CastOp::DoRunIncFp16WithDstType<float>;
+      body_ = &CastOp<CPUContext>::DoRunWithDstType<float>;
+      break;
+    case TensorProto_DataType_INT32:
+      body_ = &CastOp<CPUContext>::DoRunWithDstType<int>;
+      break;
+    case TensorProto_DataType_BYTE:
+      LOG(FATAL) << "BYTE is deprecated";
+      break;
+    case TensorProto_DataType_STRING:
+      CAFFE_THROW("Casting to and from strings is not supported yet");
+      // break;
+    case TensorProto_DataType_BOOL:
+      body_ = &CastOp<CPUContext>::DoRunWithDstType<bool>;
+      break;
+    case TensorProto_DataType_UINT8:
+      body_ = &CastOp<CPUContext>::DoRunWithDstType<uint8_t>;
+      break;
+    case TensorProto_DataType_INT8:
+      body_ = &CastOp<CPUContext>::DoRunWithDstType<int8_t>;
+      break;
+    case TensorProto_DataType_UINT16:
+      body_ = &CastOp<CPUContext>::DoRunWithDstType<uint16_t>;
+      break;
+    case TensorProto_DataType_INT16:
+      body_ = &CastOp<CPUContext>::DoRunWithDstType<int16_t>;
+      break;
+    case TensorProto_DataType_INT64:
+      body_ = &CastOp<CPUContext>::DoRunWithDstType<int64_t>;
+      break;
+    case TensorProto_DataType_FLOAT16:
+      CAFFE_THROW("Casting to and from float16 on CPU is not supported yet");
+      // break;
+    case TensorProto_DataType_DOUBLE:
+      //body_ = &CastOp::DoRunIncFp16WithDstType<double>;
+      body_ = &CastOp<CPUContext>::DoRunWithDstType<double>;
+      break;
+    case TensorProto_DataType_UNDEFINED:
+      CAFFE_THROW("Cast op must have 'to' argument of type DataType");
+      // break;
+    default:
+      CAFFE_THROW("Unexpected 'to' argument value: ", to);
+  }
+}
+
+template <>
+template <typename DstType>
+bool CastOp<CPUContext>::DoRunWithDstType() {
+  return DispatchHelper<
+      TensorTypes<
+          float,
+          int32_t,
+          bool,
+          uint8_t,
+          int8_t,
+          uint16_t,
+          int16_t,
+          int64_t,
+          double>,
+      DstType>::call(this, Input(0));
+}
+
 REGISTER_CPU_OPERATOR(Cast, CastOp<CPUContext>);
 
 OPERATOR_SCHEMA(Cast)
@@ -27,7 +93,7 @@ OPERATOR_SCHEMA(Cast)
           ArgumentHelper helper(def);
           vector<TensorShape> out;
           out.push_back(in[0]);
-          out[0].set_data_type(cast::GetCastDataType(helper));
+          out[0].set_data_type(cast::GetCastDataType(helper, "to"));
           return out;
         })
     .SetDoc(R"DOC(
@@ -52,6 +118,38 @@ NOTE: Casting to and from strings is not supported yet.
         "specified by the 'to' argument");
 
 // Some Casts are compatible with gradients, but for now we don't support it
-GRADIENT_NOT_IMPLEMENTED_YET(Cast);
+// GRADIENT_NOT_IMPLEMENTED_YET(Cast);
+
+class GetCastGradient : public GradientMakerBase {
+  using GradientMakerBase::GradientMakerBase;
+  vector<OperatorDef> GetGradientDefs() override {
+
+    vector<OperatorDef> defs = SingleGradientDef("Cast", "", vector<string>{GO(0)}, vector<string>{GI(0)});
+
+    // now modify the arguments in defs[0]
+    ArgumentHelper argsHelper(def_);
+
+    auto to_name = argsHelper.GetSingleArgument<string>("to", "");
+    auto from_name = argsHelper.GetSingleArgument<string>("from_type", "");
+    Argument *to = defs[0].add_arg();
+    to->set_name("to");
+    to->set_s(from_name);
+
+    Argument *from = defs[0].add_arg();
+    from->set_name("from_type");
+    from->set_s(to_name);
+
+    return defs;
+  }
+
+  bool CopyArguments() const override {
+    return false;
+  }
+};
+
+REGISTER_GRADIENT(Cast, GetCastGradient);
+
+
+
 
 }  // namespace caffe2

--- a/caffe2/operators/cast_op.cu
+++ b/caffe2/operators/cast_op.cu
@@ -1,5 +1,6 @@
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/operators/cast_op.h"
+#include "caffe2/utils/conversions.h"
 
 namespace caffe2 {
 
@@ -7,7 +8,8 @@ namespace {
 template <typename DstType, typename SrcType>
 __global__ void CastKernel(const int N, const SrcType* X, DstType* Y) {
   CUDA_1D_KERNEL_LOOP(i, N) {
-    Y[i] = static_cast<DstType>(X[i]);
+    // Y[i] = static_cast<DstType>(X[i]);
+    Y[i] = convert::To<SrcType, DstType>(X[i]);
   }
 }
 }  // namespace
@@ -26,6 +28,99 @@ bool CastOp<CUDAContext>::DoRunWithType() {
       CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS,
       0, context_.cuda_stream()>>>(N, data, out);
   return true;
+}
+
+template <>
+template <typename DstType>
+bool CastOp<CUDAContext>::DoRunWithDstType() {
+  return DispatchHelper<
+      TensorTypes<
+          float,
+          int32_t,
+          bool,
+          uint8_t,
+          int8_t,
+          uint16_t,
+          int16_t,
+          int64_t,
+          double>,
+      DstType>::call(this, Input(0));
+}
+
+// specific version that allows for casting to fp16
+template <>
+template <>
+bool CastOp<CUDAContext>::DoRunWithDstType<float>() {
+  return DispatchHelper<
+      TensorTypes<
+          float,
+          float16,
+          int32_t,
+          bool,
+          uint8_t,
+          int8_t,
+          uint16_t,
+          int16_t,
+          int64_t,
+          double>,
+      float /* DstType */>::call(this, Input(0));
+}
+
+// specific version for casting _from_ fp16
+template <>
+template <>
+bool CastOp<CUDAContext>::DoRunWithDstType<float16>() {
+  return DispatchHelper<
+      TensorTypes<
+          float,
+          float16>,
+      float16 /* DstType */>::call(this, Input(0));
+}
+template <>
+void CastOp<CUDAContext>::SetBody(TensorProto_DataType to) {
+  switch (to) {
+    case TensorProto_DataType_FLOAT:
+      body_ = &CastOp<CUDAContext>::DoRunWithDstType<float>;
+      break;
+    case TensorProto_DataType_INT32:
+      body_ = &CastOp<CUDAContext>::DoRunWithDstType<int>;
+      break;
+    case TensorProto_DataType_BYTE:
+      LOG(FATAL) << "BYTE is deprecated";
+      break;
+    case TensorProto_DataType_STRING:
+      CAFFE_THROW("Casting to and from strings is not supported yet");
+      // break;
+    case TensorProto_DataType_BOOL:
+      body_ = &CastOp<CUDAContext>::DoRunWithDstType<bool>;
+      break;
+    case TensorProto_DataType_UINT8:
+      body_ = &CastOp<CUDAContext>::DoRunWithDstType<uint8_t>;
+      break;
+    case TensorProto_DataType_INT8:
+      body_ = &CastOp<CUDAContext>::DoRunWithDstType<int8_t>;
+      break;
+    case TensorProto_DataType_UINT16:
+      body_ = &CastOp<CUDAContext>::DoRunWithDstType<uint16_t>;
+      break;
+    case TensorProto_DataType_INT16:
+      body_ = &CastOp<CUDAContext>::DoRunWithDstType<int16_t>;
+      break;
+    case TensorProto_DataType_INT64:
+      body_ = &CastOp<CUDAContext>::DoRunWithDstType<int64_t>;
+      break;
+    case TensorProto_DataType_FLOAT16:
+      body_ = &CastOp<CUDAContext>::DoRunWithDstType<float16>;
+      break;
+    case TensorProto_DataType_DOUBLE:
+      body_ = &CastOp<CUDAContext>::DoRunWithDstType<double>;
+      break;
+    case TensorProto_DataType_UNDEFINED:
+      CAFFE_THROW("Cast op must have 'to' argument of type DataType");
+      // break;
+    default:
+      CAFFE_THROW("Unexpected 'to' argument value: ", to);
+  }
 }
 
 REGISTER_CUDA_OPERATOR(Cast, CastOp<CUDAContext>);

--- a/caffe2/operators/cast_op.h
+++ b/caffe2/operators/cast_op.h
@@ -1,33 +1,14 @@
-#ifndef CAFFE2_OPERATORS_CAST_OP_H_
-#define CAFFE2_OPERATORS_CAST_OP_H_
+#pragma once
 
 #include "caffe2/core/context.h"
-#include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/utils/cast.h"
+#include "caffe2/utils/conversions.h"
 #include "caffe2/utils/math.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/types.h"
 
 namespace caffe2 {
-
-namespace cast {
-
-inline TensorProto_DataType GetCastDataType(const ArgumentHelper& helper) {
-  TensorProto_DataType to;
-  if (helper.HasSingleArgumentOfType<string>("to")) {
-#ifndef CAFFE2_USE_LITE_PROTO
-    string s = helper.GetSingleArgument<string>("to", "");
-    std::transform(s.begin(), s.end(), s.begin(), ::toupper);
-    CAFFE_ENFORCE(
-        TensorProto_DataType_Parse(s, &to), "Unknown 'to' argument: ", s);
-#else
-    CAFFE_THROW("String cast op not supported");
-#endif
-  } else {
-    to = static_cast<TensorProto_DataType>(
-        helper.GetSingleArgument<int>("to", TensorProto_DataType_UNDEFINED));
-  }
-  return to;
-}
-} // namespace cast
 
 template <class Context>
 class CastOp : public Operator<Context> {
@@ -36,71 +17,21 @@ class CastOp : public Operator<Context> {
 
   CastOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws) {
-    TensorProto_DataType to = cast::GetCastDataType(this->arg_helper());
-    switch (to) {
-      case TensorProto_DataType_FLOAT:
-        body_ = &CastOp::DoRunWithDstType<float>;
-        break;
-      case TensorProto_DataType_INT32:
-        body_ = &CastOp::DoRunWithDstType<int>;
-        break;
-      case TensorProto_DataType_BYTE:
-        LOG(FATAL) << "BYTE is deprecated";
-        break;
-      case TensorProto_DataType_STRING:
-        CAFFE_THROW("Casting to and from strings is not supported yet");
-      // break;
-      case TensorProto_DataType_BOOL:
-        body_ = &CastOp::DoRunWithDstType<bool>;
-        break;
-      case TensorProto_DataType_UINT8:
-        body_ = &CastOp::DoRunWithDstType<uint8_t>;
-        break;
-      case TensorProto_DataType_INT8:
-        body_ = &CastOp::DoRunWithDstType<int8_t>;
-        break;
-      case TensorProto_DataType_UINT16:
-        body_ = &CastOp::DoRunWithDstType<uint16_t>;
-        break;
-      case TensorProto_DataType_INT16:
-        body_ = &CastOp::DoRunWithDstType<int16_t>;
-        break;
-      case TensorProto_DataType_INT64:
-        body_ = &CastOp::DoRunWithDstType<int64_t>;
-        break;
-      case TensorProto_DataType_FLOAT16:
-        CAFFE_THROW("Casting to and from float16 is not supported yet");
-      // break;
-      case TensorProto_DataType_DOUBLE:
-        body_ = &CastOp::DoRunWithDstType<double>;
-        break;
-      case TensorProto_DataType_UNDEFINED:
-        CAFFE_THROW("Cast op must have 'to' argument of type DataType");
-      // break;
-      default:
-        CAFFE_THROW("Unexpected 'to' argument value: ", to);
-    }
+    TensorProto_DataType to = cast::GetCastDataType(this->arg_helper(), "to");
+    TensorProto_DataType from = cast::GetCastDataType(this->arg_helper(), "from_type");
+
+    SetBody(to);
   }
 
   bool RunOnDevice() override {
     return (this->*body_)();
   }
 
+  // Allow for Context-specific implementations
+  void SetBody(TensorProto_DataType to);
+
   template <typename DstType>
-  bool DoRunWithDstType() {
-    return DispatchHelper<
-        TensorTypes<
-            float,
-            int32_t,
-            bool,
-            uint8_t,
-            int8_t,
-            uint16_t,
-            int16_t,
-            int64_t,
-            double>,
-        DstType>::call(this, Input(0));
-  }
+  bool DoRunWithDstType();
 
   template <typename DstType, typename SrcType>
   bool DoRunWithType() {
@@ -120,6 +51,4 @@ class CastOp : public Operator<Context> {
   bool (CastOp::*body_)();
 };
 
-} // namespace caffe2
-
-#endif // CAFFE2_OPERATORS_CAST_OP_H_
+}  // namespace caffe2

--- a/caffe2/utils/cast.h
+++ b/caffe2/utils/cast.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <caffe2/utils/proto_utils.h>
+
+namespace caffe2 {
+
+namespace cast {
+
+inline TensorProto_DataType GetCastDataType(const ArgumentHelper& helper, std::string arg) {
+  TensorProto_DataType to;
+  if (helper.HasSingleArgumentOfType<string>(arg)) {
+#ifndef CAFFE2_USE_LITE_PROTO
+    string s = helper.GetSingleArgument<string>(arg, "float");
+    std::transform(s.begin(), s.end(), s.begin(), ::toupper);
+    CAFFE_ENFORCE(TensorProto_DataType_Parse(s, &to), "Unknown 'to' argument: ", s);
+#else
+    CAFFE_THROW("String cast op not supported");
+#endif
+  } else {
+    to = static_cast<TensorProto_DataType>(
+        helper.GetSingleArgument<int>(arg, TensorProto_DataType_FLOAT));
+  }
+  return to;
+}
+
+};  // namespace cast
+
+};  // namespace caffe2

--- a/caffe2/utils/conversions.h
+++ b/caffe2/utils/conversions.h
@@ -134,10 +134,14 @@ CONVERSIONS_DECL float16 To(const float in) {
 #if __CUDA_ARCH__
   // hacky interface between C2 fp16 and CUDA
   float16 ret;
+#if 0
+  // alternative truncation scheme
   __half r;
-  // r.x = __float2half_rn(in);
-  // ret.x = inf_clip(r).x;
+  r.x = __float2half_rn(in);
+  ret.x = inf_clip(r).x;
+#else
   ret.x = __float2half(in).x;
+#endif
   return ret;
 #else
   return cpu_float2half_rn(in);


### PR DESCRIPTION
Refactors out option -> datatype cast
Allows native fp16 output from GPU transformation path
Expanded CastOp to allow fp16 in/out on GPU