### PR TITLE
Add ScatterWeightedSum for GPU.

### DIFF
--- a/caffe2/operators/utility_ops.h
+++ b/caffe2/operators/utility_ops.h
@@ -473,6 +473,10 @@ class ScatterWeightedSumOp : public Operator<Context> {
     }
     return true;
   }
+  Tensor<CPUContext> x_data_host_;
+  Tensor<CPUContext> weights_host_;
+  Tensor<Context> x_data_device_;
+  Tensor<Context> weights_device_;
 };
 
 

--- a/caffe2/python/operator_test/sparse_ops_test.py
+++ b/caffe2/python/operator_test/sparse_ops_test.py
@@ -3,79 +3,77 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 import numpy as np
-from caffe2.python import core, workspace
-from caffe2.python.test_util import TestCase, rand_array
+from caffe2.python import core
+from caffe2.python.test_util import rand_array
+import caffe2.python.hypothesis_test_util as hu
+from hypothesis import given
+import hypothesis.strategies as st
 
+class TestScatterOps(hu.HypothesisTestCase):
+    # TODO(dzhulgakov): add test cases for failure scenarios
+    @given(num_args=st.integers(1, 5),
+           first_dim=st.integers(1, 20),
+           index_dim=st.integers(1, 10),
+           extra_dims=st.lists(st.integers(1, 4), min_size=0, max_size=3),
+           ind_type=st.sampled_from([np.int32, np.int64]),
+           **hu.gcs)
+    def testScatterWeightedSum(
+        self, num_args, first_dim, index_dim, extra_dims, ind_type, gc, dc):
+        ins = ['data', 'w0', 'indices']
+        for i in range(1, num_args + 1):
+            ins.extend(['x' + str(i), 'w' + str(i)])
+        op = core.CreateOperator(
+            'ScatterWeightedSum',
+            ins,
+            ['data'],
+            device_option=gc)
+        def ref(d, w0, ind, *args):
+            r = d.copy()
+            for i in ind:
+                r[i] *= w0
+            for i in xrange(0, len(args), 2):
+                x = args[i]
+                w = args[i+1]
+                for i, j in enumerate(ind):
+                    r[j] += w * x[i]
+            return [r]
 
-class TestScatterOps(TestCase):
-    def test_configs(self):
-        return [
-            # first_dim, index_num, data_dims
-            (1, 2, []),
-            (5, 5, []),
-            (2, 5, []),
-            (1, 1, []),
-            (13, 7, []),
-            (13, 7, [2]),
-            (1, 5, [3, 4]),
-            (17, 8, [2, 2, 2]),
-        ]
-        # TODO(dzhulgakov): add test cases for failure scenarios
+        d = rand_array(first_dim, *extra_dims)
+        ind = np.random.randint(0, first_dim, index_dim).astype(ind_type)
+        # ScatterWeightedSumOp only supports w0=1.0 in CUDAContext
+        if(gc == hu.gpu_do):
+            w0 = np.array(1.0).astype(np.float32)
+        else:
+            w0 = rand_array()
+        inputs = [d, w0, ind]
+        for inp in range(1, num_args + 1):
+            x = rand_array(index_dim, *extra_dims)
+            w = rand_array()
+            inputs.extend([x,w])
+        self.assertReferenceChecks(gc, op, inputs, ref, threshold=1e-3)
 
-    def testScatterWeightedSum(self):
-        for num_args in [1, 2]:
-            ins = ['data', 'w0', 'indices']
-            for i in range(1, num_args + 1):
-                ins.extend(['x' + str(i), 'w' + str(i)])
-            op = core.CreateOperator('ScatterWeightedSum', ins, ['data'])
-            for first_dim, index_dim, extra_dims in self.test_configs():
-                for dtype in [np.int32, np.int64]:
-                    d = rand_array(first_dim, *extra_dims)
-                    ind = np.random.randint(0, first_dim,
-                                            index_dim).astype(dtype)
-                    w0 = rand_array()
-                    r = d.copy()
-                    for i in ind:
-                        r[i] *= w0
-
-                    # forward
-                    workspace.FeedBlob('data', d)
-                    workspace.FeedBlob('w0', w0)
-                    workspace.FeedBlob('indices', ind)
-                    for inp in range(1, num_args + 1):
-                        w = rand_array()
-                        x = rand_array(index_dim, *extra_dims)
-                        workspace.FeedBlob('x' + str(inp), x)
-                        workspace.FeedBlob('w' + str(inp), w)
-                        for i, j in enumerate(ind):
-                            r[j] += w * x[i]
-                    workspace.RunOperatorOnce(op)
-                    out = workspace.FetchBlob('data')
-                    np.testing.assert_allclose(out, r, rtol=1e-3)
-
-    def testScatterAssign(self):
+    @given(first_dim=st.integers(1, 20),
+           index_dim=st.integers(1, 10),
+           extra_dims=st.lists(st.integers(1, 4), min_size=0, max_size=3),
+           ind_type=st.sampled_from([np.int32, np.int64]),
+           **hu.gcs_cpu_only)
+    def testScatterAssign(
+        self, first_dim, index_dim, extra_dims, ind_type, gc, dc):
         op = core.CreateOperator('ScatterAssign',
                                  ['data', 'indices', 'slices'], ['data'])
-        for first_dim, index_dim, extra_dims in self.test_configs():
-            # let's have indices unique
-            if first_dim < index_dim:
-                first_dim, index_dim = index_dim, first_dim
-            for dtype in [np.int32, np.int64]:
-                d = rand_array(first_dim, *extra_dims)
-                ind = np.random.choice(first_dim, index_dim,
-                                       replace=False).astype(dtype)
-                x = rand_array(index_dim, *extra_dims)
+        def ref(d, ind, x):
+            r = d.copy()
+            r[ind] = x
+            return [r]
 
-                r = d.copy()
-                r[ind] = x
-
-                # forward
-                workspace.FeedBlob('data', d)
-                workspace.FeedBlob('indices', ind)
-                workspace.FeedBlob('slices', x)
-                workspace.RunOperatorOnce(op)
-                out = workspace.FetchBlob('data')
-                np.testing.assert_allclose(out, r, rtol=1e-3)
+        # let's have indices unique
+        if first_dim < index_dim:
+            first_dim, index_dim = index_dim, first_dim
+        d = rand_array(first_dim, *extra_dims)
+        ind = np.random.choice(first_dim, index_dim,
+                               replace=False).astype(ind_type)
+        x = rand_array(index_dim, *extra_dims)
+        self.assertReferenceChecks(gc, op, [d, ind, x], ref, threshold=1e-3)
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
- Adding ScatterWeightedSumOp for CUDA.
- This version does not support input weight (weight0). In other words, the input weight has to be 1.0, otherwise the op exits.
- To check the value of weight0, we copy its value from device to host at: https://github.com/caffe2/caffe2/pull/443/files#diff-2a77f80797072e8443f4867cb709fb40R244