### PR TITLE
Enable bitcode for iOS builds

### DIFF
--- a/scripts/build_host_protoc.sh
+++ b/scripts/build_host_protoc.sh
@@ -15,9 +15,26 @@ mkdir -p $BUILD_ROOT/build
 
 cd $BUILD_ROOT/build
 CMAKE=$(which cmake || which /usr/bin/cmake || which /usr/local/bin/cmake)
-$CMAKE $CAFFE2_ROOT/third_party/protobuf/cmake \
-    -DCMAKE_INSTALL_PREFIX=$BUILD_ROOT \
-    -Dprotobuf_BUILD_TESTS=OFF \
-    || exit 1
+
+SHARED="$CAFFE2_ROOT/third_party/protobuf/cmake -DCMAKE_INSTALL_PREFIX=$BUILD_ROOT -Dprotobuf_BUILD_TESTS=OFF "
+OTHER_FLAGS=""
+
+while true; do
+    case "$1" in
+        --other-flags)
+            shift;
+            echo "Other flags passed to cmake: $@";
+            OTHER_FLAGS=" $@ ";
+            break ;;
+        "")
+            break ;;
+        *)
+            echo "Unknown option passed as argument: $1"
+            break ;;
+    esac
+done
+
+
+$CMAKE $SHARED $OTHER_FLAGS || exit 1
 make -j 4 || exit 1
 make install || exit 1

--- a/scripts/build_host_protoc.sh
+++ b/scripts/build_host_protoc.sh
@@ -6,6 +6,8 @@
 # for any cross-compilation as we will need to convert the protobuf source
 # files to cc files.
 #
+# --other-flags accepts flags that should be passed to cmake. Optional.
+#
 # After the execution of the file, one should be able to find the host protoc
 # binary at build_host_protoc/bin/protoc.
 

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -16,7 +16,8 @@ echo "Build Caffe2 ios into: $BUILD_ROOT"
 
 # Build protobuf from third_party so we have a host protoc binary.
 echo "Building protoc"
-$CAFFE2_ROOT/scripts/build_host_protoc.sh || exit 1
+BITCODE_FLAGS="-DCMAKE_C_FLAGS=-fembed-bitcode -DCMAKE_CXX_FLAGS=-fembed-bitcode "
+$CAFFE2_ROOT/scripts/build_host_protoc.sh --other-flags $BITCODE_FLAGS || exit 1
 
 # Now, actually build the iOS target.
 echo "Building caffe2"
@@ -36,6 +37,8 @@ cmake .. \
     -DUSE_CUDA=OFF \
     -DBUILD_TEST=OFF \
     -DBUILD_BINARY=OFF \
+    -DCMAKE_C_FLAGS=-fembed-bitcode \
+    -DCMAKE_CXX_FLAGS=-fembed-bitcode \
     -DUSE_LMDB=OFF \
     -DUSE_LEVELDB=OFF \
     -DBUILD_PYTHON=OFF \


### PR DESCRIPTION
build_ios.sh now have `-fembed-bitcode` flags for cmake and passes these flags to build_host_protoc.sh (which now accepts optional argument `--other-flags`). That allows to use output libs (libCaffe2_CPU.a, libCAFFE2_NNPACK.a, libCAFFE2_PTHREADPOOL.a and libprotobuf-lite.a, libprotobuf.a respectively) in Xcode projects with bitcode enabled.

Bitcode is enabled by default in all projects since Xcode7, is crucial for slicing and is mandatory for watchOS targets. Enabling bitcode for target requires bitcode to be enabled for all dependencies also, so Caffe2 built without bitcode forces developers to switch off bitcode for the whole app.