### PR TITLE
Python3 compilation

### DIFF
--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -16,6 +16,16 @@
 #include "caffe2/utils/windows_cpu_supports.h"
 #endif
 
+#if PY_MAJOR_VERSION >= 3
+  #define PyString_Check PyUnicode_Check
+  #if PY_VERSION_HEX < 0x03030000
+    #error "Python 3.0 - 3.2 are not supported."
+  #else
+  #define PyString_AsString(ob) \
+    (PyUnicode_Check(ob)? PyUnicode_AsUTF8(ob): PyBytes_AsString(ob))
+  #endif
+#endif
+
 namespace caffe2 {
 namespace python {
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -182,7 +182,6 @@ add_definitions(-DEIGEN_MPL2_ONLY)
 
 # ---[ Python + Numpy
 if (BUILD_PYTHON)
-  set(Python_ADDITIONAL_VERSIONS 2.8 2.7 2.6)
   find_package(PythonInterp 2.7)
   find_package(PythonLibs 2.7)
   find_package(NumPy REQUIRED)


### PR DESCRIPTION
This PR does two things:

1. It allows compilation of caffe2 using python3 libraries.
2. It reverts https://github.com/caffe2/caffe2/commit/6cd340ec67d5b4a7efe92f5017b903e50359def8 (PR: https://github.com/caffe2/caffe2/pull/361) as this is not a proper fix for forcing a certain python version (in addition, it doesn't work).

Also note that this PR only enables compilation of python3 bindings. The mnist tutorial seems to mostly run, however some python tools in caffe2 need to be updated to be python2/3 compatible. I will hopefully work on that soon, but this PR can be viewed as a start on python3 compatibility.

EDIT: I'll guard the use of PyUnicode so that it is only used on python3 later today (I thought it was python2/3 compatible but apparently it isn't).