### PR TITLE
Enable c++11 support through CMake functions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 project(Caffe2 CXX C)
 
@@ -100,9 +100,14 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "binaries")
 
 # ---[ Build flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED on)
 if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
+  # Enable C++11 support
+  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD_REQUIRED on)
+
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing")
 else()
   if (NOT ${BUILD_SHARED_LIBS})

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -1,6 +1,7 @@
 INCLUDE(CheckCXXSourceCompiles)
 
-set(CMAKE_REQUIRED_FLAGS "-std=c++11")
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 # ---[ Check if the data type long and int32_t/int64_t overlap. 
 CHECK_CXX_SOURCE_COMPILES(


### PR DESCRIPTION
This PR enables C++11 support using CMake variables (`CMAKE_CXX_STANDARD` for choosing the standard and `CMAKE_CXX_STANDARD_REQUIRED` for disabling CMake's default functionality of "decaying" to c++98 if c++11 is not available).

These variables are added since CMake 3.1.13 so a bump of the minimum required cmake version was necessary.