### PR TITLE
net_drawer: --input is required

### DIFF
--- a/caffe2/python/net_drawer.py
+++ b/caffe2/python/net_drawer.py
@@ -340,7 +340,7 @@ def main():
     parser = argparse.ArgumentParser(description="Caffe2 net drawer.")
     parser.add_argument(
         "--input",
-        type=str,
+        type=str, required=True,
         help="The input protobuf file."
     )
     parser.add_argument(


### PR DESCRIPTION
Before:
```
$ python -m caffe2.python.net_drawer
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/data/caffe2/install/caffe2/python/net_drawer.py", line 403, in <module>
    main()
  File "/data/caffe2/install/caffe2/python/net_drawer.py", line 365, in main
    with open(args.input, 'r') as fid:
TypeError: coercing to Unicode: need string or buffer, NoneType found
```
After:
```
$ python -m caffe2.python.net_drawer
usage: net_drawer.py [-h] --input INPUT [--output_prefix OUTPUT_PREFIX]
                     [--minimal] [--minimal_dependency] [--append_output]
                     [--rankdir RANKDIR]
net_drawer.py: error: argument --input is required
```