### PR TITLE
Python3 compatibility (WIP)

### DIFF
--- a/caffe2/core/types.cc
+++ b/caffe2/core/types.cc
@@ -24,6 +24,7 @@ CAFFE_KNOWN_TYPE(std::unique_ptr<std::mutex>);
 CAFFE_KNOWN_TYPE(std::unique_ptr<std::atomic<bool>>);
 CAFFE_KNOWN_TYPE(std::vector<int64_t>);
 CAFFE_KNOWN_TYPE(std::vector<unsigned long>);
+CAFFE_KNOWN_TYPE(std::vector<uint8_t>);
 
 #ifdef CAFFE2_UNIQUE_LONG_TYPEMETA
 CAFFE_KNOWN_TYPE(long);

--- a/caffe2/experiments/python/SparseTransformer.py
+++ b/caffe2/experiments/python/SparseTransformer.py
@@ -61,7 +61,7 @@ def transFCRelu(cur, id2node, name2id, ops, model):
     """
     # 1. add trans before the start of this chain
     # assuming that cur is an FC_Prune, and it has only one input
-    pre = cur.prev.itervalues().next()
+    pre = next(cur.prev.itervalues())
     # Create an node /op and insert it.
     # TODO(wyiming): check whether it is correct here
     current_blob = model.Transpose(cur.op.input[0], cur.op.input[0] + "_trans")
@@ -106,13 +106,13 @@ def transFCRelu(cur, id2node, name2id, ops, model):
         cur.visited = True
         pre = cur
         flag = False
-        for _, temp in cur.ops.iteritems():
+        for _, temp in cur.ops.items():
             if temp.optype == "Relu" or temp.optype == "FC_Prune":
                 flag = True
                 cur = temp
         if not flag:
             # assume that there is only 1 output that is not PrintOP
-            cur = cur.ops.itervalues().next()
+            cur = next(cur.ops.itervalues())
             cur.deleteInput(pre)
             print("No FC/RElu children")
             print(cur.op.type)
@@ -134,7 +134,7 @@ def Prune2Sparse(cur, id2node, name2id, ops, model):
         transFCRelu(cur, id2node, name2id, ops, model)
 
     cur.visited = True
-    for name, n in cur.ops.iteritems():
+    for name, n in cur.ops.items():
         Prune2Sparse(n, id2node, name2id, ops, model)
 
 
@@ -145,13 +145,13 @@ def net2list(net_root):
     bfs_queue = []
     op_list = []
     cur = net_root
-    for _, n in cur.ops.iteritems():
+    for _, n in cur.ops.items():
         bfs_queue.append(n)
     while bfs_queue:
         node = bfs_queue[0]
         bfs_queue = bfs_queue[1:]
         op_list.append(node.op)
-        for _, n in node.ops.iteritems():
+        for _, n in node.ops.items():
             bfs_queue.append(n)
 
     return op_list

--- a/caffe2/proto/caffe2.proto
+++ b/caffe2/proto/caffe2.proto
@@ -98,10 +98,12 @@ message Argument {
   optional string name = 1;
   optional float f = 2;
   optional int64 i = 3;
-  optional bytes s = 4;
-  repeated float floats = 5;
-  repeated int64 ints = 6;
-  repeated bytes strings = 7;
+  optional string s = 4;
+  optional bytes b = 5;
+  repeated float floats = 6;
+  repeated int64 ints = 7;
+  repeated string strings = 8;
+  repeated bytes bytes = 9;
 }
 
 // DeviceType that Caffe2 currently supports.

--- a/caffe2/python/brew.py
+++ b/caffe2/python/brew.py
@@ -5,6 +5,13 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+# Python 2 and 3 compatibility: test if basestring exists
+try:
+    basestring  # NOQA
+except NameError:
+    # This is python3 so we define basestring.
+    basestring = str
+
 import sys
 import copy
 import inspect

--- a/caffe2/python/checkpoint_test.py
+++ b/caffe2/python/checkpoint_test.py
@@ -53,19 +53,19 @@ class TestCheckpoint(TestCase):
         session, checkpoint = builder()
         compiled_job = job.compile(LocalSession)
         num_epochs = JobRunner(compiled_job, checkpoint)(session)
-        self.assertEquals(num_epochs, len(EXPECTED_TOTALS))
-        self.assertEquals(fetch_total(session), EXPECTED_TOTALS[-1])
+        self.assertEqual(num_epochs, len(EXPECTED_TOTALS))
+        self.assertEqual(fetch_total(session), EXPECTED_TOTALS[-1])
 
         for initial_epoch in range(1, num_epochs + 1):
             session, checkpoint = builder()
             JobRunner(
                 compiled_job,
                 checkpoint, resume_from_epoch=initial_epoch)(session)
-            self.assertEquals(fetch_total(session), EXPECTED_TOTALS[-1])
+            self.assertEqual(fetch_total(session), EXPECTED_TOTALS[-1])
 
         for epoch in range(1, num_epochs + 1):
             session.run(checkpoint.load(epoch))
-            self.assertEquals(fetch_total(session), EXPECTED_TOTALS[epoch - 1])
+            self.assertEqual(fetch_total(session), EXPECTED_TOTALS[epoch - 1])
 
     def test_single_checkpoint(self):
         # test single node
@@ -106,14 +106,14 @@ class TestCheckpoint(TestCase):
                 compiled_job = job.compile(LocalSession)
                 job_runner = JobRunner(compiled_job, checkpoint)
                 num_epochs = job_runner(session)
-                self.assertEquals(num_epochs, len(EXPECTED_TOTALS))
+                self.assertEqual(num_epochs, len(EXPECTED_TOTALS))
 
                 # There are 16 blobs after finishing up the job runner.
-                self.assertEquals(len(ws.blobs), 16)
+                self.assertEqual(len(ws.blobs), 16)
 
             ws = workspace.C.Workspace()
             session = LocalSession(ws)
-            self.assertEquals(len(ws.blobs), 0)
+            self.assertEqual(len(ws.blobs), 0)
             model_blob_names = ['reader:1/task/GivenTensorInt64Fill:0',
                                 'reader:2/task/GivenTensorInt64Fill:0']
             checkpoint = MultiNodeCheckpointManager(tmpdir, 'minidb')
@@ -135,7 +135,7 @@ class TestCheckpoint(TestCase):
                 # Check that all the model blobs are loaded.
                 for blob_name in model_blob_names:
                     self.assertTrue(ws.has_blob(blob_name))
-                    self.assertEquals(ws.fetch_blob(blob_name),
+                    self.assertEqual(ws.fetch_blob(blob_name),
                                       np.array([EXPECTED_TOTALS[epoch - 1]]))
             self.assertFalse(
                 job_runner.load_blobs_from_checkpoints(

--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -2112,9 +2112,11 @@ def execution_step(default_name,
         step.AddNet(steps_or_nets)
     elif isinstance(steps_or_nets, list):
         if all(isinstance(x, Net) for x in steps_or_nets):
-            map(step.AddNet, steps_or_nets)
+            for n in steps_or_nets:
+                step.AddNet(n)
         else:
-            map(step.AddSubstep, map(to_execution_step, steps_or_nets))
+            for s in steps_or_nets:
+                step.AddSubstep(to_execution_step(s))
     elif steps_or_nets:
         raise ValueError(
             'steps_or_nets must be a step, a net, or a list of nets or steps.')

--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -236,7 +236,7 @@ def _RectifyInputOutput(blobs, net=None):
     elif type(blobs) is BlobReference:
         # If blob is a BlobReference, simply put it as a list.
         return [blobs]
-    elif type(blobs) in (list, tuple):
+    elif type(blobs) in (list, tuple, map):
         # If blob is a list, we go through it and type check.
         rectified = []
         for blob in blobs:

--- a/caffe2/python/data_workers.py
+++ b/caffe2/python/data_workers.py
@@ -5,6 +5,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from future import standard_library
+standard_library.install_aliases()
 
 '''
 This module provides a python-land multithreaded data input mechanism
@@ -59,7 +61,7 @@ for each GPU. Note that the 'coordinator' returned by the function is same
 each time.
 '''
 
-import Queue
+import queue
 import logging
 import threading
 import atexit
@@ -221,7 +223,7 @@ class DataInputCoordinator(object):
         while self.is_active():
             try:
                 return self._internal_queue.get(block=True, timeout=0.5)
-            except Queue.Empty:
+            except queue.Empty:
                 continue
         return None
 
@@ -240,7 +242,7 @@ class DataInputCoordinator(object):
                 self._internal_queue.put(chunk, block=True, timeout=0.5)
                 self._log_inputs_per_interval(chunk[0].shape[0])
                 return
-            except Queue.Full:
+            except queue.Full:
                 log.debug("Queue full: stalling fetchers...")
                 continue
 
@@ -298,7 +300,7 @@ class DataInputCoordinator(object):
                 cur_batch = trimmed_batch
                 try:
                     self._internal_queue.put(leftover, block=False)
-                except Queue.Full:
+                except queue.Full:
                     pass
 
                 assert cur_batch[0].shape[first_batch_col] == self._batch_size
@@ -428,7 +430,7 @@ class GlobalCoordinator(object):
     def get_queue(self, queue_name, max_buffered_batches):
         assert isinstance(max_buffered_batches, int)
         if queue_name not in self._queues:
-            self._queues[queue_name] = Queue.Queue(maxsize=max_buffered_batches)
+            self._queues[queue_name] = queue.Queue(maxsize=max_buffered_batches)
         return self._queues[queue_name]
 
     def start(self):

--- a/caffe2/python/dataio_test.py
+++ b/caffe2/python/dataio_test.py
@@ -41,7 +41,7 @@ class TestReaderWithLimit(TestCase):
         session.run(tg)
 
         self.assertFalse(ws.blobs[str(reader.data_finished())].fetch())
-        self.assertEquals(
+        self.assertEqual(
             sorted(ws.blobs[str(dst_ds.content().label())].fetch()), range(10))
 
         """ 3. Read with limit larger than size of dataset """
@@ -50,7 +50,7 @@ class TestReaderWithLimit(TestCase):
             reader = ReaderWithLimit(src_ds.reader(), num_iter=110)
             pipe(reader, dst_ds.writer(), num_threads=8)
         session.run(tg)
-        self.assertEquals(
+        self.assertEqual(
             sorted(ws.blobs[str(dst_ds.content().label())].fetch()), range(100))
         self.assertTrue(ws.blobs[str(reader.data_finished())].fetch())
 
@@ -60,6 +60,6 @@ class TestReaderWithLimit(TestCase):
             reader = ReaderWithLimit(src_ds.reader(), num_iter=None)
             pipe(reader, dst_ds.writer(), num_threads=8)
         session.run(tg)
-        self.assertEquals(
+        self.assertEqual(
             sorted(ws.blobs[str(dst_ds.content().label())].fetch()), range(100))
         self.assertTrue(ws.blobs[str(reader.data_finished())].fetch())

--- a/caffe2/python/db_test.py
+++ b/caffe2/python/db_test.py
@@ -34,7 +34,7 @@ class TestDB(unittest.TestCase):
         data = []
         while cursor.valid():
             data.append((cursor.key(), cursor.value()))
-            cursor.next()
+            next(cursor)
         del cursor
 
         db.close()  # test explicit db closer

--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 import numpy as np
 import copy
 from functools import partial, reduce
@@ -1263,7 +1265,7 @@ class TestOperators(hu.HypothesisTestCase):
           original matrices.
         """
         import threading
-        import Queue
+        import queue
         op = core.CreateOperator(
             "CreateBlobsQueue",
             [],
@@ -1275,7 +1277,7 @@ class TestOperators(hu.HypothesisTestCase):
 
         xs = [np.random.randn(num_elements, 5).astype(np.float32)
               for _ in range(num_blobs)]
-        q = Queue.Queue()
+        q = queue.Queue()
         for i in range(num_elements):
             q.put([x[i] for x in xs])
 
@@ -1293,7 +1295,7 @@ class TestOperators(hu.HypothesisTestCase):
                         self.ws.create_blob(feed_blob).feed(
                             elem, device_option=do)
                     self.ws.run(op)
-                except Queue.Empty:
+                except queue.Empty:
                     return
 
         # Create all blobs before racing on multiple threads

--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -6,7 +6,7 @@ from future import standard_library
 standard_library.install_aliases()
 import numpy as np
 import copy
-from functools import partial, reduce
+from functools import partial, reduce, cmp_to_key
 from hypothesis import assume, given, settings
 import hypothesis.strategies as st
 import unittest
@@ -958,7 +958,7 @@ class TestOperators(hu.HypothesisTestCase):
                 # we no longer have cmp function in python 3
                 pred_sorted = sorted([
                     [item, j] for j, item in enumerate(prediction[i])],
-                    cmp=lambda x, y: int(y[0] > x[0]) - int(y[0] < x[0]))
+                    key=cmp_to_key(lambda x, y: int(y[0] > x[0]) - int(y[0] < x[0])))
                 max_ids = [x[1] for x in pred_sorted[0:top_k]]
                 for m in max_ids:
                     if m == labels[i]:

--- a/caffe2/python/hypothesis_test_util.py
+++ b/caffe2/python/hypothesis_test_util.py
@@ -248,7 +248,7 @@ gcs_gpu_only = dict(gc=st.sampled_from([gpu_do]), dc=st.just([gpu_do]))
 
 
 @contextlib.contextmanager
-def temp_workspace(name=b"temp_ws"):
+def temp_workspace(name="temp_ws"):
     old_ws_name = workspace.CurrentWorkspace()
     workspace.SwitchWorkspace(name, True)
     yield

--- a/caffe2/python/mint/app.py
+++ b/caffe2/python/mint/app.py
@@ -47,7 +47,7 @@ def visualize_summary(filename):
         y_axis_format='.03g'
     )
     if args.sample < 0:
-        step = max(data.shape[0] / -args.sample, 1)
+        step = max(data.shape[0] // -args.sample, 1)
     else:
         step = args.sample
     xdata = np.arange(0, data.shape[0], step)
@@ -74,14 +74,14 @@ def visualize_print_log(filename):
         y_axis_format='.03g'
     )
     if args.sample < 0:
-        step = max(data.shape[0] / -args.sample, 1)
+        step = max(data.shape[0] // -args.sample, 1)
     else:
         step = args.sample
     xdata = np.arange(0, data.shape[0], step)
     # if there is only one curve, we also show the running min and max
     if data.shape[1] == 1:
         # We also print the running min and max for the steps.
-        trunc_size = data.shape[0] / step
+        trunc_size = data.shape[0] // step
         running_mat = data[:trunc_size * step].reshape((trunc_size, step))
         chart.add_serie(
             x=xdata[:trunc_size],

--- a/caffe2/python/models/download.py
+++ b/caffe2/python/models/download.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
 import argparse
 import os
 import sys
@@ -53,7 +55,7 @@ def progressBar(percentage):
 def downloadFromURLToFile(url, filename):
     try:
         print("Downloading from {url}".format(url=url))
-        response = urllib.urlopen(url)
+        response = urllib.request.urlopen(url)
         size = int(response.info().getheader('Content-Length').strip())
         downloaded_size = 0
         chunk = min(size, 8192)
@@ -107,6 +109,7 @@ def downloadModel(model, args):
             try:
                 response = raw_input(query)
             except NameError:
+                # python3 variant
                 response = input(query)
             if response.upper() == 'N' or not response:
                 print("Cancelling download...")

--- a/caffe2/python/models/seq2seq/train.py
+++ b/caffe2/python/models/seq2seq/train.py
@@ -14,7 +14,7 @@ import random
 import time
 import sys
 
-from itertools import izip
+
 
 import caffe2.proto.caffe2_pb2 as caffe2_pb2
 from caffe2.python import core, workspace, rnn_cell, data_parallel_model
@@ -582,7 +582,7 @@ class Seq2SeqModelCaffe2:
     ):
         if self.num_gpus < 1:
             batch_obj = prepare_batch(batch)
-            for batch_obj_name, batch_obj_value in izip(
+            for batch_obj_name, batch_obj_value in zip(
                 Batch._fields,
                 batch_obj,
             ):
@@ -591,7 +591,7 @@ class Seq2SeqModelCaffe2:
             for i in range(self.num_gpus):
                 gpu_batch = batch[i::self.num_gpus]
                 batch_obj = prepare_batch(gpu_batch)
-                for batch_obj_name, batch_obj_value in izip(
+                for batch_obj_name, batch_obj_value in zip(
                     Batch._fields,
                     batch_obj,
                 ):

--- a/caffe2/python/net_builder_test.py
+++ b/caffe2/python/net_builder_test.py
@@ -81,7 +81,7 @@ class TestNetBuilder(unittest.TestCase):
         ]
         for b, expected in expected:
             actual = ws.blobs[str(b)].fetch()
-            self.assertEquals(actual, expected)
+            self.assertEqual(actual, expected)
 
     def _expected_loop(self):
         total = 0
@@ -127,7 +127,7 @@ class TestNetBuilder(unittest.TestCase):
             expected = self._expected_loop()
             actual = [o.fetch() for o in out_actual]
             for e, a in zip(expected, actual):
-                self.assertEquals(e, a)
+                self.assertEqual(e, a)
 
     def test_setup(self):
         with Task() as task:
@@ -149,6 +149,6 @@ class TestNetBuilder(unittest.TestCase):
             o7_2 = final_output(seven_2)
         with LocalSession() as session:
             session.run(task)
-            self.assertEquals(o6.fetch(), 6)
-            self.assertEquals(o7_1.fetch(), 7)
-            self.assertEquals(o7_2.fetch(), 7)
+            self.assertEqual(o6.fetch(), 6)
+            self.assertEqual(o7_1.fetch(), 7)
+            self.assertEqual(o7_2.fetch(), 7)

--- a/caffe2/python/net_printer.py
+++ b/caffe2/python/net_printer.py
@@ -72,13 +72,16 @@ class Analyzer(Visitor):
 
 @Analyzer.register(OperatorDef)
 def analyze_op(analyzer, op):
-    map(analyzer.need_blob, op.input)
-    map(analyzer.define_blob, op.output)
+    for i in op.input:
+        analyzer.need_blob(i)
+    for o in op.output:
+        analyzer.define_blob(o)
 
 
 @Analyzer.register(Net)
 def analyze_net(analyzer, net):
-    map(analyzer, net.Proto().op)
+    for op in net.Proto().op:
+        analyzer(op)
 
 
 @Analyzer.register(ExecutionStep)
@@ -100,7 +103,8 @@ def analyze_step(analyzer, step):
                 'Error: Blobs created by multiple parallel steps: %s' % (
                     ', '.join(all_new_blobs & new_blobs)))
             all_new_blobs |= new_blobs
-    map(analyzer.define_blob, all_new_blobs)
+    for blob in all_new_blobs:
+        analyzer.define_blob(blob)
 
 
 @Analyzer.register(Task)

--- a/caffe2/python/operator_test/atomic_ops_test.py
+++ b/caffe2/python/operator_test/atomic_ops_test.py
@@ -43,7 +43,7 @@ class TestAtomicOps(TestCase):
         plan.AddStep(super_step)
         workspace.RunPlan(plan)
         # checksum = sum[i=1..20000](i) = 20000 * 20001 / 2 = 200010000
-        self.assertEquals(workspace.FetchBlob(checksum), 200010000)
+        self.assertEqual(workspace.FetchBlob(checksum), 200010000)
 
 if __name__ == "__main__":
     import unittest

--- a/caffe2/python/operator_test/dataset_ops_test.py
+++ b/caffe2/python/operator_test/dataset_ops_test.py
@@ -20,7 +20,7 @@ import hypothesis.strategies as st
 
 
 def _assert_arrays_equal(actual, ref, err_msg):
-    if ref.dtype.kind in ('S', 'O'):
+    if ref.dtype.kind in ('S', 'O', 'U'):
         np.testing.assert_array_equal(actual, ref, err_msg=err_msg)
     else:
         np.testing.assert_allclose(

--- a/caffe2/python/operator_test/dataset_ops_test.py
+++ b/caffe2/python/operator_test/dataset_ops_test.py
@@ -263,8 +263,8 @@ class TestDatasetOps(TestCase):
             expected_fields, schema.field_names(), schema.field_types()
         )
         for (ref_name, ref_type), name, dtype in zipped:
-            self.assertEquals(ref_name, name)
-            self.assertEquals(np.dtype(ref_type), dtype)
+            self.assertEqual(ref_name, name)
+            self.assertEqual(np.dtype(ref_type), dtype)
         """
         2. The contents of our dataset.
 
@@ -446,7 +446,7 @@ class TestDatasetOps(TestCase):
         """
         subschema = Struct(('top_level', schema.int_lists.values))
         int_list_contents = contents.int_lists.values.field_names()
-        self.assertEquals(len(subschema.field_names()), len(int_list_contents))
+        self.assertEqual(len(subschema.field_names()), len(int_list_contents))
         """
         7. Random Access a dataset
 

--- a/caffe2/python/operator_test/hsm_test.py
+++ b/caffe2/python/operator_test/hsm_test.py
@@ -224,7 +224,7 @@ class TestHsm(hu.HypothesisTestCase):
         workspace.RunOperatorOnce(op)
         huffmanTreeOutput = workspace.FetchBlob('huffman_tree')
         treeOutput = hsm_pb2.TreeProto()
-        treeOutput.ParseFromString(huffmanTreeOutput[0])
+        treeOutput.ParseFromString(huffmanTreeOutput[0].encode('utf-8'))
         treePathOutput = hsmu.create_hierarchy(treeOutput)
 
         label_to_path = {}

--- a/caffe2/python/operator_test/index_ops_test.py
+++ b/caffe2/python/operator_test/index_ops_test.py
@@ -56,7 +56,7 @@ class TestIndexOps(TestCase):
             ['index'],
             ['index_size']))
         size = workspace.FetchBlob('index_size')
-        self.assertEquals(size, 6)
+        self.assertEqual(size, 6)
 
         workspace.RunOperatorOnce(core.CreateOperator(
             'IndexStore',
@@ -83,7 +83,7 @@ class TestIndexOps(TestCase):
             ['index2'],
             ['index2_size']))
         index2_size = workspace.FetchBlob('index2_size')
-        self.assertEquals(index2_size, 5)
+        self.assertEqual(index2_size, 5)
 
         # test serde
         with tempfile.NamedTemporaryFile() as tmp:

--- a/caffe2/python/operator_test/instance_norm_test.py
+++ b/caffe2/python/operator_test/instance_norm_test.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import numpy as np
 from hypothesis import given, assume
 import hypothesis.strategies as st
-from itertools import izip
+
 
 from caffe2.python import core, model_helper, brew
 import caffe2.python.hypothesis_test_util as hu
@@ -46,7 +46,7 @@ class TestInstanceNorm(hu.HypothesisTestCase):
 
     def _feed_inputs(self, input_blobs, device_option):
         names = ['input', 'scale', 'bias']
-        for name, blob in izip(names, input_blobs):
+        for name, blob in zip(names, input_blobs):
             self.ws.create_blob(name).feed(blob, device_option=device_option)
 
     @given(gc=hu.gcs['gc'],

--- a/caffe2/python/operator_test/leaky_relu_test.py
+++ b/caffe2/python/operator_test/leaky_relu_test.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import numpy as np
 from hypothesis import given, assume
 import hypothesis.strategies as st
-from itertools import izip
+
 
 from caffe2.python import core, model_helper
 import caffe2.python.hypothesis_test_util as hu
@@ -39,7 +39,7 @@ class TestLeakyRelu(hu.HypothesisTestCase):
 
     def _feed_inputs(self, input_blobs, device_option):
         names = ['input', 'scale', 'bias']
-        for name, blob in izip(names, input_blobs):
+        for name, blob in zip(names, input_blobs):
             self.ws.create_blob(name).feed(blob, device_option=device_option)
 
     @given(gc=hu.gcs['gc'],

--- a/caffe2/python/operator_test/shape_inference_test.py
+++ b/caffe2/python/operator_test/shape_inference_test.py
@@ -23,13 +23,13 @@ class TestShapeInference(test_util.TestCase):
             {'data': [64, 96]}
         )
 
-        self.assertEquals(shapes['data'], [64, 96])
-        self.assertEquals(shapes['fc1_w'], [32, 96])
-        self.assertEquals(shapes['fc1_b'], [32])
-        self.assertEquals(shapes['fc1'], [64, 32])
-        self.assertEquals(shapes['fc2_w'], [55, 32])
-        self.assertEquals(shapes['fc2_b'], [55])
-        self.assertEquals(shapes['fc2'], [64, 55])
+        self.assertEqual(shapes['data'], [64, 96])
+        self.assertEqual(shapes['fc1_w'], [32, 96])
+        self.assertEqual(shapes['fc1_b'], [32])
+        self.assertEqual(shapes['fc1'], [64, 32])
+        self.assertEqual(shapes['fc2_w'], [55, 32])
+        self.assertEqual(shapes['fc2_b'], [55])
+        self.assertEqual(shapes['fc2'], [64, 55])
 
     def testShapeInferenceDistances(self):
         model = model_helper.ModelHelper(name="test_model")

--- a/caffe2/python/operator_test/text_file_reader_test.py
+++ b/caffe2/python/operator_test/text_file_reader_test.py
@@ -23,8 +23,8 @@ class TestTextFileReader(TestCase):
             ['l1f2', 'l2f2', 'l3f2', 'l4f2'],
             [0.456, 0.789, 0.10101, -24342.64],
         ]
-        row_data = zip(*col_data)
-        txt_file = tempfile.NamedTemporaryFile(delete=False)
+        row_data = list(zip(*col_data))
+        txt_file = tempfile.NamedTemporaryFile(delete=False, mode='w')
         txt_file.write(
             '\n'.join(['\t'.join(map(str, f)) for f in row_data]) + '\n')
         txt_file.close()

--- a/caffe2/python/pipeline.py
+++ b/caffe2/python/pipeline.py
@@ -164,11 +164,11 @@ def processor_name(processor):
     if hasattr(processor, 'name'):
         return processor.name
     if hasattr(processor, 'func_name'):
-        if processor.func_name == '<lambda>':
+        if processor.__name__ == '<lambda>':
             return processor.__module__
         if hasattr(processor, 'im_class'):
-            return '%s.%s' % (processor.im_class.__name__, processor.func_name)
-        return processor.func_name
+            return '%s.%s' % (processor.__self__.__class__.__name__, processor.__name__)
+        return processor.__name__
     return processor.__class__.__name__
 
 

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -818,7 +818,7 @@ void addGlobalMethods(py::module& m) {
         if (device_option != py::none()) {
           // If we have a device option passed in, read it.
           CAFFE_ENFORCE(ParseProtobufFromLargeString(
-              py::bytes(device_option).cast<std::string>(), &option));
+              py::bytes(device_option), &option));
         }
         auto* blob = gWorkspace->CreateBlob(name);
         if (PyArray_Check(arg.ptr())) { // numpy array

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -66,7 +66,8 @@ int CaffeToNumpyType(const TypeMeta& meta) {
       {TypeMeta::Id<int64_t>(), NPY_LONGLONG},
       {TypeMeta::Id<uint8_t>(), NPY_UINT8},
       {TypeMeta::Id<uint16_t>(), NPY_UINT16},
-      {TypeMeta::Id<std::string>(), NPY_OBJECT},
+      {TypeMeta::Id<std::vector<uint8_t>>(), NPY_OBJECT},
+      {TypeMeta::Id<std::string>(), NPY_UNICODE},
       // Note: Add more types here.
   };
   const auto it = numpy_type_map.find(meta.id());
@@ -89,7 +90,8 @@ const TypeMeta& NumpyTypeToCaffe(int numpy_type) {
       {NPY_LONGLONG, TypeMeta::Make<int64_t>()},
       {NPY_UINT8, TypeMeta::Make<uint8_t>()},
       {NPY_UINT16, TypeMeta::Make<uint16_t>()},
-      {NPY_OBJECT, TypeMeta::Make<std::string>()},
+      {NPY_OBJECT, TypeMeta::Make<std::vector<uint8_t>>()},
+      {NPY_UNICODE, TypeMeta::Make<std::string>()},
       // Note: Add more types here.
   };
   static TypeMeta unknown_type;

--- a/caffe2/python/pybind_state.h
+++ b/caffe2/python/pybind_state.h
@@ -86,7 +86,8 @@ class TensorFetcher : public BlobFetcherBase {
 
   bool NeedsCopy(const TypeMeta& meta) const {
     return !std::is_same<Context, CPUContext>::value ||
-        CaffeToNumpyType(meta) == NPY_OBJECT;
+        CaffeToNumpyType(meta) == NPY_OBJECT ||
+        CaffeToNumpyType(meta) == NPY_UNICODE;
   }
 
   FetchedBlob FetchTensor(const Tensor<Context>& tensor, bool force_copy) {
@@ -105,9 +106,17 @@ class TensorFetcher : public BlobFetcherBase {
     result.copied = force_copy || NeedsCopy(tensor.meta());
     void* outPtr;
     if (result.copied) {
-      result.obj = pybind11::object(
-          PyArray_SimpleNew(tensor.ndim(), npy_dims.data(), numpy_type),
+      if (numpy_type == NPY_UNICODE) {
+        PyObject* item = PyUnicode_FromString(tensor.template data<std::string>()->c_str());
+        PyArray_Descr* descr = PyArray_DescrFromScalar(item);
+        result.obj = pybind11::object(
+          PyArray_SimpleNewFromDescr(tensor.ndim(), npy_dims.data(), descr),
           /* borrowed */ false);
+      } else {
+        result.obj = pybind11::object(
+            PyArray_SimpleNew(tensor.ndim(), npy_dims.data(), numpy_type),
+            /* borrowed */ false);
+      }
       outPtr = static_cast<void*>(
           PyArray_DATA(reinterpret_cast<PyArrayObject*>(result.obj.ptr())));
     } else {
@@ -118,21 +127,39 @@ class TensorFetcher : public BlobFetcherBase {
           /* borrowed */ false);
     }
 
-    if (numpy_type == NPY_OBJECT) {
-      PyObject** outObj = reinterpret_cast<PyObject**>(outPtr);
-      auto* str = tensor.template data<std::string>();
-      for (int i = 0; i < tensor.size(); ++i) {
-        outObj[i] = PyBytes_FromStringAndSize(str->data(), str->size());
-        str++;
-        // cleanup on failure
-        if (outObj[i] == nullptr) {
-          for (int j = 0; j < i; ++j) {
-            Py_DECREF(outObj[j]);
-          }
-          CAFFE_THROW("Failed to allocate string for ndarray of strings.");
-        }
-      }
-      return result;
+    switch(numpy_type) {
+        case NPY_UNICODE: {
+            PyObject** outObj = reinterpret_cast<PyObject**>(outPtr);
+            auto* str = tensor.template data<std::string>();
+            for (int i = 0; i < tensor.size(); ++i) {
+                outObj[i] = PyUnicode_FromStringAndSize(str->data(), str->size());
+                str++;
+                // cleanup on failure
+                if (outObj[i] == nullptr) {
+                    for (int j = 0; j < i; ++j) {
+                        Py_DECREF(outObj[j]);
+                    }
+                    CAFFE_THROW("Failed to allocate string for ndarray of strings.");
+                }
+            }
+            return result;
+        } break;
+        case NPY_OBJECT: {
+            PyObject** outObj = reinterpret_cast<PyObject**>(outPtr);
+            auto* obj = tensor.template data<std::vector<uint8_t>>();
+            for (int i = 0; i < tensor.size(); ++i) {
+                outObj[i] = PyBytes_FromStringAndSize((const char *)obj->data(), obj->size());
+                obj++;
+                // cleanup on failure
+                if (outObj[i] == nullptr) {
+                    for (int j = 0; j < i; ++j) {
+                        Py_DECREF(outObj[j]);
+                    }
+                    CAFFE_THROW("Failed to allocate string for ndarray of strings.");
+                }
+            }
+            return result;
+        } break;
     }
 
     if (result.copied) {
@@ -175,16 +202,29 @@ class TensorFeeder : public BlobFeederBase {
 
     // Now, copy the data to the tensor.
     switch (npy_type) {
+      case NPY_UNICODE: {
+        auto* outPtr = tensor->template mutable_data<std::string>();
+
+        for (int i = 0; i < tensor->size(); ++i) {
+          PyObject* item = PyArray_GETITEM(array, (char *)PyArray_GETPTR1(array, i));
+          Py_ssize_t strSize;
+          char* str = PyUnicode_AsUTF8AndSize(item, &strSize);
+          CAFFE_ENFORCE(
+               str != NULL,
+              "Unsupported python object type passed into ndarray.");
+          outPtr[i] = std::string(str, strSize);
+        }
+      } break;
       case NPY_OBJECT: {
         PyObject** input = reinterpret_cast<PyObject**>(PyArray_DATA(array));
-        auto* outPtr = tensor->template mutable_data<std::string>();
+        auto* outPtr = tensor->template mutable_data<std::vector<uint8_t>>();
         for (int i = 0; i < tensor->size(); ++i) {
           char* str;
           Py_ssize_t strSize;
           CAFFE_ENFORCE(
               PyBytes_AsStringAndSize(input[i], &str, &strSize) != -1,
               "Unsupported python object type passed into ndarray.");
-          outPtr[i] = std::string(str, strSize);
+          outPtr[i] = std::vector<uint8_t>(str, str + strSize);
         }
       } break;
       default:

--- a/caffe2/python/schema_test.py
+++ b/caffe2/python/schema_test.py
@@ -24,7 +24,7 @@ class TestDB(unittest.TestCase):
 
     def testNormalizeField(self):
         s = schema.Struct(('field1', np.int32), ('field2', str))
-        self.assertEquals(
+        self.assertEqual(
             s,
             schema.Struct(
                 ('field1', schema.Scalar(dtype=np.int32)),
@@ -39,11 +39,11 @@ class TestDB(unittest.TestCase):
             ('field_1', schema.Scalar(dtype=np.str)),
             ('field_2', schema.Scalar(dtype=np.float32))
         )
-        self.assertEquals(s, s2)
-        self.assertEquals(s[0], schema.Scalar(dtype=np.int32))
-        self.assertEquals(s[1], schema.Scalar(dtype=np.str))
-        self.assertEquals(s[2], schema.Scalar(dtype=np.float32))
-        self.assertEquals(
+        self.assertEqual(s, s2)
+        self.assertEqual(s[0], schema.Scalar(dtype=np.int32))
+        self.assertEqual(s[1], schema.Scalar(dtype=np.str))
+        self.assertEqual(s[2], schema.Scalar(dtype=np.float32))
+        self.assertEqual(
             s[2, 0],
             schema.Struct(
                 ('field_2', schema.Scalar(dtype=np.float32)),
@@ -52,19 +52,19 @@ class TestDB(unittest.TestCase):
         )
         # test iterator behavior
         for i, (v1, v2) in enumerate(zip(s, s2)):
-            self.assertEquals(v1, v2)
-            self.assertEquals(s[i], v1)
-            self.assertEquals(s2[i], v1)
+            self.assertEqual(v1, v2)
+            self.assertEqual(s[i], v1)
+            self.assertEqual(s2[i], v1)
 
     def testRawTuple(self):
         s = schema.RawTuple(2)
-        self.assertEquals(
+        self.assertEqual(
             s, schema.Struct(
                 ('field_0', schema.Scalar()), ('field_1', schema.Scalar())
             )
         )
-        self.assertEquals(s[0], schema.Scalar())
-        self.assertEquals(s[1], schema.Scalar())
+        self.assertEqual(s[0], schema.Scalar())
+        self.assertEqual(s[1], schema.Scalar())
 
     def testStructIndexing(self):
         s = schema.Struct(
@@ -72,10 +72,10 @@ class TestDB(unittest.TestCase):
             ('field2', schema.List(schema.Scalar(dtype=str))),
             ('field3', schema.Struct()),
         )
-        self.assertEquals(s['field2'], s.field2)
-        self.assertEquals(s['field2'], schema.List(schema.Scalar(dtype=str)))
-        self.assertEquals(s['field3'], schema.Struct())
-        self.assertEquals(
+        self.assertEqual(s['field2'], s.field2)
+        self.assertEqual(s['field2'], schema.List(schema.Scalar(dtype=str)))
+        self.assertEqual(s['field3'], schema.Struct())
+        self.assertEqual(
             s['field2', 'field1'],
             schema.Struct(
                 ('field2', schema.List(schema.Scalar(dtype=str))),
@@ -89,8 +89,8 @@ class TestDB(unittest.TestCase):
             ('field1', schema.Scalar(dtype=np.int32)),
             ('field2', a)
         )
-        self.assertEquals(s['field2:lengths'], a.lengths)
-        self.assertEquals(s['field2:items'], a.items)
+        self.assertEqual(s['field2:lengths'], a.lengths)
+        self.assertEqual(s['field2:items'], a.items)
         with self.assertRaises(KeyError):
             s['fields2:items:non_existent']
         with self.assertRaises(KeyError):
@@ -105,8 +105,8 @@ class TestDB(unittest.TestCase):
             ('field1', schema.Scalar(dtype=np.int32)),
             ('field2', a)
         )
-        self.assertEquals(s['field2:keys'], a.keys)
-        self.assertEquals(s['field2:values'], a.values)
+        self.assertEqual(s['field2:keys'], a.keys)
+        self.assertEqual(s['field2:values'], a.values)
         with self.assertRaises(KeyError):
             s['fields2:keys:non_existent']
 

--- a/caffe2/python/scope_test.py
+++ b/caffe2/python/scope_test.py
@@ -15,68 +15,68 @@ SUCCESS_COUNT = 0
 
 def thread_runner(idx, testobj):
     global SUCCESS_COUNT
-    testobj.assertEquals(scope.CurrentNameScope(), "")
-    testobj.assertEquals(scope.CurrentDeviceScope(), None)
+    testobj.assertEqual(scope.CurrentNameScope(), "")
+    testobj.assertEqual(scope.CurrentDeviceScope(), None)
     namescope = "namescope_{}".format(idx)
     dsc = core.DeviceOption(caffe2_pb2.CUDA, idx)
     with scope.DeviceScope(dsc):
         with scope.NameScope(namescope):
-            testobj.assertEquals(scope.CurrentNameScope(), namescope + "/")
-            testobj.assertEquals(scope.CurrentDeviceScope(), dsc)
+            testobj.assertEqual(scope.CurrentNameScope(), namescope + "/")
+            testobj.assertEqual(scope.CurrentDeviceScope(), dsc)
 
             time.sleep(0.01 + idx * 0.01)
-            testobj.assertEquals(scope.CurrentNameScope(), namescope + "/")
-            testobj.assertEquals(scope.CurrentDeviceScope(), dsc)
+            testobj.assertEqual(scope.CurrentNameScope(), namescope + "/")
+            testobj.assertEqual(scope.CurrentDeviceScope(), dsc)
 
-    testobj.assertEquals(scope.CurrentNameScope(), "")
-    testobj.assertEquals(scope.CurrentDeviceScope(), None)
+    testobj.assertEqual(scope.CurrentNameScope(), "")
+    testobj.assertEqual(scope.CurrentDeviceScope(), None)
     SUCCESS_COUNT += 1
 
 
 class TestScope(unittest.TestCase):
 
     def testNamescopeBasic(self):
-        self.assertEquals(scope.CurrentNameScope(), "")
+        self.assertEqual(scope.CurrentNameScope(), "")
 
         with scope.NameScope("test_scope"):
-            self.assertEquals(scope.CurrentNameScope(), "test_scope/")
+            self.assertEqual(scope.CurrentNameScope(), "test_scope/")
 
-        self.assertEquals(scope.CurrentNameScope(), "")
+        self.assertEqual(scope.CurrentNameScope(), "")
 
     def testNamescopeAssertion(self):
-        self.assertEquals(scope.CurrentNameScope(), "")
+        self.assertEqual(scope.CurrentNameScope(), "")
 
         try:
             with scope.NameScope("test_scope"):
-                self.assertEquals(scope.CurrentNameScope(), "test_scope/")
+                self.assertEqual(scope.CurrentNameScope(), "test_scope/")
                 raise Exception()
         except Exception:
             pass
 
-        self.assertEquals(scope.CurrentNameScope(), "")
+        self.assertEqual(scope.CurrentNameScope(), "")
 
     def testDevicescopeBasic(self):
-        self.assertEquals(scope.CurrentDeviceScope(), None)
+        self.assertEqual(scope.CurrentDeviceScope(), None)
 
         dsc = core.DeviceOption(caffe2_pb2.CUDA, 9)
         with scope.DeviceScope(dsc):
-            self.assertEquals(scope.CurrentDeviceScope(), dsc)
+            self.assertEqual(scope.CurrentDeviceScope(), dsc)
 
-        self.assertEquals(scope.CurrentDeviceScope(), None)
+        self.assertEqual(scope.CurrentDeviceScope(), None)
 
     def testDevicescopeAssertion(self):
-        self.assertEquals(scope.CurrentDeviceScope(), None)
+        self.assertEqual(scope.CurrentDeviceScope(), None)
 
         dsc = core.DeviceOption(caffe2_pb2.CUDA, 9)
 
         try:
             with scope.DeviceScope(dsc):
-                self.assertEquals(scope.CurrentDeviceScope(), dsc)
+                self.assertEqual(scope.CurrentDeviceScope(), dsc)
                 raise Exception()
         except Exception:
             pass
 
-        self.assertEquals(scope.CurrentDeviceScope(), None)
+        self.assertEqual(scope.CurrentDeviceScope(), None)
 
     def testMultiThreaded(self):
         """
@@ -84,8 +84,8 @@ class TestScope(unittest.TestCase):
         and don't interfere
         """
         global SUCCESS_COUNT
-        self.assertEquals(scope.CurrentNameScope(), "")
-        self.assertEquals(scope.CurrentDeviceScope(), None)
+        self.assertEqual(scope.CurrentNameScope(), "")
+        self.assertEqual(scope.CurrentDeviceScope(), None)
 
         threads = []
         for i in range(4):
@@ -97,13 +97,13 @@ class TestScope(unittest.TestCase):
             t.start()
 
         with scope.NameScope("master"):
-            self.assertEquals(scope.CurrentDeviceScope(), None)
-            self.assertEquals(scope.CurrentNameScope(), "master/")
+            self.assertEqual(scope.CurrentDeviceScope(), None)
+            self.assertEqual(scope.CurrentNameScope(), "master/")
             for t in threads:
                 t.join()
 
-            self.assertEquals(scope.CurrentNameScope(), "master/")
-            self.assertEquals(scope.CurrentDeviceScope(), None)
+            self.assertEqual(scope.CurrentNameScope(), "master/")
+            self.assertEqual(scope.CurrentDeviceScope(), None)
 
         # Ensure all threads succeeded
-        self.assertEquals(SUCCESS_COUNT, 4)
+        self.assertEqual(SUCCESS_COUNT, 4)

--- a/caffe2/python/tutorials/helpers.py
+++ b/caffe2/python/tutorials/helpers.py
@@ -3,7 +3,6 @@
 import numpy as np
 import skimage.io
 import skimage.transform
-import urllib2
 
 def crop_center(img,cropx,cropy):
     y,x,c = img.shape
@@ -70,7 +69,7 @@ def parseResults(results):
             index = i
 
     # top 3 results
-    print "Raw top 3 results:", sorted(arr, key=lambda x: x[1], reverse=True)[:3]
+    print("Raw top 3 results:", sorted(arr, key=lambda x: x[1], reverse=True)[:3])
 
     # now we can grab the code list
     with open('inference_codes.txt', 'r') as f:

--- a/caffe2/python/utils.py
+++ b/caffe2/python/utils.py
@@ -213,7 +213,7 @@ class DebugMode(object):
                 'Entering interactive debugger. Type "bt" to print '
                 'the full stacktrace. Type "help" to see command listing.')
             print(sys.exc_info()[1])
-            print
+            print('')
 
             pdb.post_mortem()
             sys.exit(1)

--- a/caffe2/python/utils.py
+++ b/caffe2/python/utils.py
@@ -82,8 +82,9 @@ def MakeArgument(key, value):
         # int.
         argument.i = value
     elif isinstance(value, basestring):
-        argument.s = (value if type(value) is bytes
-                      else value.encode('utf-8'))
+        argument.s = value
+    elif isinstance(value, bytes):
+        argument.b = value
     elif isinstance(value, Message):
         argument.s = value.SerializeToString()
     elif iterable and all(type(v) in [float, np.float_] for v in value):
@@ -91,10 +92,11 @@ def MakeArgument(key, value):
     elif iterable and all(type(v) in [int, bool, long, np.int_] for v in value):
         argument.ints.extend(value)
     elif iterable and all(isinstance(v, basestring) for v in value):
-        argument.strings.extend([
-            (v if type(v) is bytes else v.encode('utf-8')) for v in value])
+        argument.strings.extend(value)
+    elif iterable and all(isinstance(v, bytes) for v in value):
+        argument.bytes.extend(value)
     elif iterable and all(isinstance(v, Message) for v in value):
-        argument.strings.extend([v.SerializeToString() for v in value])
+        argument.bytes.extend([v.SerializeToString() for v in value])
     else:
         raise ValueError(
             "Unknown argument type: key=%s value=%s, value type=%s" %

--- a/caffe2/python/visualize.py
+++ b/caffe2/python/visualize.py
@@ -85,7 +85,7 @@ class PatchVisualizer(object):
                 cmap = cm.gray
         image = np.ones(image_shape) * bg_func(patches)
         for pid in range(num_patches):
-            row = pid / ncols * patch_size_expand[0]
+            row = pid // ncols * patch_size_expand[0]
             col = pid % ncols * patch_size_expand[1]
             image[row:row+patches.shape[1], col:col+patches.shape[2]] = \
                 patches[pid]

--- a/caffe2/python/workspace_test.py
+++ b/caffe2/python/workspace_test.py
@@ -97,13 +97,13 @@ class TestWorkspace(unittest.TestCase):
         """ feed (copy) data into tensor """
         val = np.array([['abc', 'def'], ['ghi', 'jkl']], dtype=np.object)
         tensor.feed(val)
-        self.assertEquals(tensor.data[0, 0], 'abc')
+        self.assertEqual(tensor.data[0, 0], 'abc')
         np.testing.assert_array_equal(ws.blobs["tensor"].fetch(), val)
 
         val = np.array([1.1, 10.2])
         tensor.feed(val)
         val[0] = 5.2
-        self.assertEquals(tensor.data[0], 1.1)
+        self.assertEqual(tensor.data[0], 1.1)
 
         """ fetch (copy) data from tensor """
         val = np.array([1.1, 1.2])
@@ -112,7 +112,7 @@ class TestWorkspace(unittest.TestCase):
         tensor.data[0] = 5.2
         val3 = tensor.fetch()
         np.testing.assert_array_equal(val, val2)
-        self.assertEquals(val3[0], 5.2)
+        self.assertEqual(val3[0], 5.2)
 
     def testFetchFeedBlob(self):
         self.assertEqual(
@@ -207,8 +207,8 @@ class TestWorkspace(unittest.TestCase):
         workspace.FeedBlob('s1', s1)
         workspace.FeedBlob('s2', s2)
         fetch1, fetch2 = workspace.FetchBlobs(['s1', 's2'])
-        self.assertEquals(s1, fetch1)
-        self.assertEquals(s2, fetch2)
+        self.assertEqual(s1, fetch1)
+        self.assertEqual(s2, fetch2)
 
     def testFetchFeedViaBlobDict(self):
         self.assertEqual(

--- a/docs/process.py
+++ b/docs/process.py
@@ -31,11 +31,11 @@ for root, dirs, files in os.walk("."):
             print("filepath: " + filepath)
             directory = os.path.dirname(filepath)[2:]
             directory = directory.replace("/",".")
-            print "directory: " + directory
+            print("directory: " + directory)
             name = os.path.splitext(file)[0]
             first_line = "## @package " + name
             description = "\n# Module " + directory + "." + name + "\n"
-            print first_line,description
+            print(first_line,description)
             insert(filepath,first_line,description)
 
 if os.path.exists("doxygen/doxygen-python"):


### PR DESCRIPTION
This PR is a first draft to get python2/3 compatibility in caffe2. Most noticeable changes come from the difference in `str` for python2 vs python3. python2 defines `bytes` and `str` as the same thing but in python3 they are two very different types.

Specifically the changes in `pybind_state` require some attention by caffe2 devs, as these are the areas where I am uncertain about the changes made.

Note that this PR is not finished, not all tests are running successfully in python3 yet and I have to test python2 again as well before this can be merged. I hope to continue work on this in a week or so, but meanwhile I was hoping to get some feedback on the changes made thus far.

ps. this PR depends on https://github.com/caffe2/caffe2/pull/463