### PR TITLE
Fix bug on def of gpu_single_thread::Task::ops_

### DIFF
--- a/caffe2/core/net_gpu.h
+++ b/caffe2/core/net_gpu.h
@@ -50,7 +50,7 @@ class AsyncDAGNet : public DAGNetBase {
 namespace gpu_single_thread {
 
 struct Task {
-  std::vector<std::unique_ptr<OperatorBase>>* ops_;
+  std::vector<std::unique_ptr<Operator<CUDAContext>>>* ops_;
   std::condition_variable* cv_;
   std::mutex* mtx_;
   int stream_id_;


### PR DESCRIPTION
I think it's needed to use Operator<CUDAContext> instead of OperatorBase as the base type of ops_.