### PR TITLE
[TravisCI] Add target for quick build+test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,18 @@ matrix:
           packages:
           - g++-5
       env: COMPILER=g++-5
+    # 10
+    - os: linux
+      compiler: gcc
+      env: QUICKTEST
+      install:
+        - ./.travis/quicktest-install.sh
+        - ./.travis/quicktest-build.sh
+      script:
+        - ./.travis/quicktest-test.sh
   allow_failures:
+    - env: COMPILER=g++
+    - env: COMPILER=clang++
     - env: COMPILER=g++-5
     - env: COMPILER=g++-4.9
     - env: COMPILER=g++-4.8
@@ -73,6 +84,8 @@ matrix:
 
 cache:
   apt: true
+  directories:
+    - $HOME/.ccache
 
 install:
   - ./.travis/install.sh

--- a/.travis/quicktest-build.sh
+++ b/.travis/quicktest-build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+set -x
+
+export CXX=/usr/lib/ccache/g++
+
+mkdir build
+cd build
+cmake .. \
+    -DCMAKE_VERBOSE_MAKEFILE=ON \
+    -DUSE_CUDA=OFF -DUSE_NCCL=OFF -DUSE_GLOO=OFF \
+    -DUSE_NNPACK=OFF
+make -j$(nproc)

--- a/.travis/quicktest-install.sh
+++ b/.travis/quicktest-install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+set -x
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+    libatlas-base-dev \
+    libgoogle-glog-dev \
+    libiomp-dev \
+    libleveldb-dev \
+    liblmdb-dev \
+    libopencv-dev \
+    libprotobuf-dev \
+    libpthread-stubs0-dev \
+    libsnappy-dev \
+    protobuf-compiler \
+    python-dev \
+    python-pip
+
+# Can't use deb packages because of TravisCI's virtualenv
+pip install numpy

--- a/.travis/quicktest-test.sh
+++ b/.travis/quicktest-test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+set -x
+
+cd build
+CTEST_OUTPUT_ON_FAILURE=1 make test -j$(nproc)


### PR DESCRIPTION
Once the build is cached, QUICKTEST takes less than 3 minutes to install+build+test (first build is ~13 minutes).

Future TravisCI improvements:
* Refactor other build targets so they're fast enough to build in under 45 mins
* Run tests for other build targets
* Run Python tests