### PR TITLE
Change repo from bwasti to caffe2.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/caffe2/caffe2.svg?branch=cmake)](https://travis-ci.org/caffe2/caffe2)
 
-    git clone https://github.com/bwasti/caffe2.git
+    git clone https://github.com/caffe2/caffe2.git
     cd caffe2
     
 #### OS X


### PR DESCRIPTION
I'm assuming the repo should be caffe2/caffe2.git and not bwasti/caffe2.git. Changed it accordingly.