### PR TITLE
Execute submodule init command in srcdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,10 @@ project(Caffe2 CXX C)
 # one is building from a git checkout.
 find_package(Git)
 if (GIT_FOUND)
-  execute_process(COMMAND git submodule update --init)
+  execute_process(
+    COMMAND git submodule update --init
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  )
 endif()
 
 # Useful functions.


### PR DESCRIPTION
Having this submodule git command in the cmake script is questionable. If you are having it, at least ensure it works correctly for out-of-tree builds (which are the norm when using cmake).
