### PR TITLE
Add stack traces on fatal signals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,10 @@ else()
   endif()
 endif()
 
+if(NOT APPLE AND UNIX)
+  list(APPEND Caffe2_DEPENDENCY_LIBS dl)
+endif()
+
 if (CAFFE2_CPU_FLAGS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CAFFE2_CPU_FLAGS}")
 endif()

--- a/caffe2/utils/CMakeLists.txt
+++ b/caffe2/utils/CMakeLists.txt
@@ -42,3 +42,6 @@ set(Caffe2_CPU_SRCS ${Caffe2_CPU_SRCS} PARENT_SCOPE)
 set(Caffe2_GPU_SRCS ${Caffe2_GPU_SRCS} PARENT_SCOPE)
 set(Caffe2_CPU_TEST_SRCS ${Caffe2_CPU_TEST_SRCS} PARENT_SCOPE)
 set(Caffe2_GPU_TEST_SRCS ${Caffe2_GPU_TEST_SRCS} PARENT_SCOPE)
+
+# ---[ Printing stack traces requires dladdr
+

--- a/caffe2/utils/fatal_signal_test.cc
+++ b/caffe2/utils/fatal_signal_test.cc
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+#include <pthread.h>
+#include <unistd.h>
+
+#include <functional>
+#include <iostream>
+
+#include "caffe2/core/common.h"
+#include "caffe2/utils/signal_handler.h"
+
+namespace {
+void* dummy_thread(void*) {
+  while (1) {
+  }
+}
+
+bool forkAndPipe(
+    std::string& stderrBuffer,
+    std::function<void(void)> callback) {
+  std::array<int, 2> stderrPipe;
+  if (pipe(stderrPipe.data()) != 0) {
+    perror("STDERR pipe");
+    return false;
+  }
+  pid_t child = fork();
+  if (child == 0) {
+    // Replace this process' stderr so we can read it.
+    if (dup2(stderrPipe[1], STDERR_FILENO) < 0) {
+      close(stderrPipe[0]);
+      close(stderrPipe[1]);
+      perror("dup2 STDERR");
+      exit(1);
+    }
+
+    // This is for the parent to work with.
+    close(stderrPipe[0]);
+    close(stderrPipe[1]);
+
+    // Install our handlers because gtest installs their own it seems.
+    int argc = 0;
+    char** argv = nullptr;
+    if (!caffe2::internal::Caffe2InitFatalSignalHandler(&argc, &argv)) {
+      write(STDERR_FILENO, "WAT\n", 4);
+      exit(1);
+    }
+    callback();
+    exit(1);
+  } else if (child > 0) {
+    const int bufferSize = 128;
+    std::array<char, bufferSize> buffer;
+
+    // We want to close the writing end of the pipe right away so our
+    // read actually gets an EOF.
+    close(stderrPipe[1]);
+
+    // wait for child to finish crashing.
+    int statloc;
+    if (wait(&statloc) < 0) {
+      close(stderrPipe[0]);
+      perror("wait");
+      return false;
+    }
+
+    // The child should have exited due to signal.
+    if (!WIFSIGNALED(statloc)) {
+      fprintf(stderr, "Child didn't exit because it received a signal\n");
+      return false;
+    }
+
+    ssize_t bytesRead;
+    while ((bytesRead = read(stderrPipe[0], buffer.data(), bufferSize)) > 0) {
+      const std::string tmp(buffer.data(), bytesRead);
+      std::cout << tmp;
+      stderrBuffer += tmp;
+    }
+    if (bytesRead < 0) {
+      perror("read");
+      return false;
+    }
+    close(stderrPipe[0]);
+    return true;
+  } else {
+    perror("fork");
+    return false;
+  }
+}
+
+#define TEST_FATAL_SIGNAL(signum, name, threadCount)                         \
+  do {                                                                       \
+    std::string stderrBuffer;                                                \
+    ASSERT_TRUE(forkAndPipe(stderrBuffer, [=]() {                            \
+      pthread_t pt;                                                          \
+      for (int i = 0; i < threadCount; i++) {                                \
+        if (pthread_create(&pt, nullptr, ::dummy_thread, nullptr)) {         \
+          perror("pthread_create");                                          \
+        }                                                                    \
+      }                                                                      \
+      raise(signum);                                                         \
+    }));                                                                     \
+    int keyPhraseCount = 0;                                                  \
+    std::string keyPhrase =                                                  \
+        std::string(name) + "(" + caffe2::to_string(signum) + "), Thread";   \
+    size_t loc = 0;                                                          \
+    while ((loc = stderrBuffer.find(keyPhrase, loc)) != std::string::npos) { \
+      keyPhraseCount += 1;                                                   \
+      loc += 1;                                                              \
+    }                                                                        \
+    EXPECT_EQ(keyPhraseCount, threadCount + 1);                              \
+  } while (0)
+}
+
+TEST(fatalSignalTest, SIGABRT8) {
+  TEST_FATAL_SIGNAL(SIGABRT, "SIGABRT", 8);
+}
+
+TEST(fatalSignalTest, SIGINT8) {
+  TEST_FATAL_SIGNAL(SIGINT, "SIGINT", 8);
+}
+
+TEST(fatalSignalTest, SIGILL8) {
+  TEST_FATAL_SIGNAL(SIGILL, "SIGILL", 8);
+}
+
+TEST(fatalSignalTest, SIGFPE8) {
+  TEST_FATAL_SIGNAL(SIGFPE, "SIGFPE", 8);
+}
+
+TEST(fatalSignalTest, SIGBUS8) {
+  TEST_FATAL_SIGNAL(SIGBUS, "SIGBUS", 8);
+}
+
+TEST(fatalSignalTest, SIGSEGV8) {
+  TEST_FATAL_SIGNAL(SIGSEGV, "SIGSEGV", 8);
+}

--- a/caffe2/utils/fatal_signal_test.cc
+++ b/caffe2/utils/fatal_signal_test.cc
@@ -1,3 +1,4 @@
+#if defined(__linux__)
 #include <gtest/gtest.h>
 #include <pthread.h>
 #include <unistd.h>
@@ -132,3 +133,4 @@ TEST(fatalSignalTest, SIGBUS8) {
 TEST(fatalSignalTest, SIGSEGV8) {
   TEST_FATAL_SIGNAL(SIGSEGV, "SIGSEGV", 8);
 }
+#endif // defined(__linux__)

--- a/caffe2/utils/signal_handler.cc
+++ b/caffe2/utils/signal_handler.cc
@@ -3,8 +3,8 @@
 
 #if defined(_MSC_VER)
 
-// Currently we do not support signal handling in Windows yet - below is a
-// minimal implementation that makes things compile.
+// TODO: Currently we do not support signal handling in Windows yet - below is
+// a minimal implementation that makes things compile.
 namespace caffe2 {
 SignalHandler::SignalHandler(
     SignalHandler::Action SIGINT_action,
@@ -25,97 +25,289 @@ SignalHandler::Action SignalHandler::CheckForSignals() {
 
 // Normal signal handler implementation.
 
+#include <cxxabi.h>
+#include <dirent.h>
+#include <dlfcn.h>
+#include <execinfo.h>
+#include <pthread.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 #include <atomic>
-#include <signal.h>
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
 #include <unordered_set>
+
+#include "caffe2/core/init.h"
 
 namespace {
 
-  static struct sigaction previous_sighup;
-  static struct sigaction previous_sigint;
-  static volatile sig_atomic_t sigint_count = 0;
-  static volatile sig_atomic_t sighup_count = 0;
-  static std::atomic<int> hooked_up_count{0};
+struct sigaction previousSighup;
+struct sigaction previousSigint;
+std::atomic<int> sigintCount(0);
+std::atomic<int> sighupCount(0);
+std::atomic<int> hookedUpCount(0);
 
-  void handle_signal(int signal) {
-    switch (signal) {
+// We need to hold a reference to call the previous SIGUSR2 handler in case
+// we didn't signal it
+struct sigaction previousSigusr2;
+// Flag dictating whether the SIGUSR2 handler falls back to previous handlers
+// or is intercepted in order to print a stack trace.
+std::atomic<bool> fatalSignalReceived(false);
+// Global state set when a fatal signal is received so that backtracing threads
+// know why they're printing a stacktrace.
+const char* fatalSignalName("<UNKNOWN>");
+int fatalSignum(-1);
+// This wait condition is used to wait for other threads to finish writing
+// their stack trace when in fatal sig handler (we can't use pthread_join
+// because there's no way to convert from a tid to a pthread_t).
+pthread_cond_t writingCond = PTHREAD_COND_INITIALIZER;
+pthread_mutex_t writingMutex = PTHREAD_MUTEX_INITIALIZER;
+
+struct {
+  const char* name;
+  int signum;
+  struct sigaction previous;
+} kSignalHandlers[] = {
+  { "SIGABRT",  SIGABRT,  {} },
+  { "SIGINT",   SIGINT,   {} },
+  { "SIGILL",   SIGILL,   {} },
+  { "SIGFPE",   SIGFPE,   {} },
+  { "SIGBUS",   SIGBUS,   {} },
+  { "SIGSEGV",  SIGSEGV,  {} },
+  { nullptr,    0,        {} }
+};
+
+void handleSignal(int signal) {
+  switch (signal) {
+    // TODO: what if the previous handler uses sa_sigaction?
     case SIGHUP:
-      sighup_count += 1;
-      if (previous_sighup.sa_handler) {
-        previous_sighup.sa_handler(signal);
+      sighupCount += 1;
+      if (previousSighup.sa_handler) {
+        previousSighup.sa_handler(signal);
       }
       break;
     case SIGINT:
-      sigint_count += 1;
-      if (previous_sigint.sa_handler) {
-        previous_sigint.sa_handler(signal);
+      sigintCount += 1;
+      if (previousSigint.sa_handler) {
+        previousSigint.sa_handler(signal);
       }
       break;
+  }
+}
+
+void hookupHandler() {
+  if (hookedUpCount++) {
+    return;
+  }
+  struct sigaction sa;
+  // Setup the handler
+  sa.sa_handler = &handleSignal;
+  // Restart the system call, if at all possible
+  sa.sa_flags = SA_RESTART;
+  // Block every signal during the handler
+  sigfillset(&sa.sa_mask);
+  // Intercept SIGHUP and SIGINT
+  if (sigaction(SIGHUP, &sa, &previousSighup) == -1) {
+    LOG(FATAL) << "Cannot install SIGHUP handler.";
+  }
+  if (sigaction(SIGINT, &sa, &previousSigint) == -1) {
+    LOG(FATAL) << "Cannot install SIGINT handler.";
+  }
+}
+
+// Set the signal handlers to the default.
+void unhookHandler() {
+  if (--hookedUpCount > 0) {
+    return;
+  }
+  struct sigaction sa;
+  // Setup the sighub handler
+  sa.sa_handler = SIG_DFL;
+  // Restart the system call, if at all possible
+  sa.sa_flags = SA_RESTART;
+  // Block every signal during the handler
+  sigfillset(&sa.sa_mask);
+  // Intercept SIGHUP and SIGINT
+  if (sigaction(SIGHUP, &previousSighup, nullptr) == -1) {
+    LOG(FATAL) << "Cannot uninstall SIGHUP handler.";
+  }
+  if (sigaction(SIGINT, &previousSigint, nullptr) == -1) {
+    LOG(FATAL) << "Cannot uninstall SIGINT handler.";
+  }
+}
+
+struct sigaction* getPreviousSigaction(int signum) {
+  for (auto handler = kSignalHandlers; handler->name != nullptr; handler++) {
+    if (handler->signum == signum) {
+      return &handler->previous;
     }
   }
+  return nullptr;
+}
 
-  void HookupHandler() {
-    if (hooked_up_count++) {
-      return;
-    }
-    struct sigaction sa;
-    // Setup the handler
-    sa.sa_handler = &handle_signal;
-    // Restart the system call, if at all possible
-    sa.sa_flags = SA_RESTART;
-    // Block every signal during the handler
-    sigfillset(&sa.sa_mask);
-    // Intercept SIGHUP and SIGINT
-    if (sigaction(SIGHUP, &sa, nullptr) == -1) {
-      LOG(FATAL) << "Cannot install SIGHUP handler.";
-    }
-    if (sigaction(SIGINT, &sa, nullptr) == -1) {
-      LOG(FATAL) << "Cannot install SIGINT handler.";
+const char* getSignalName(int signum) {
+  for (auto handler = kSignalHandlers; handler->name != nullptr; handler++) {
+    if (handler->signum == signum) {
+      return handler->name;
     }
   }
+  return nullptr;
+}
 
-  // Set the signal handlers to the default.
-  void UnhookHandler() {
-    if (--hooked_up_count > 0) {
-      return;
+void printStacktrace() {
+  constexpr const unsigned maxFrames = 256;
+  std::array<void*, maxFrames> frames;
+  Dl_info info;
+  int numberOfFrames = backtrace(frames.data(), maxFrames);
+  for (int i = 0; i < numberOfFrames; i++) {
+    const void* pc = frames[i];
+    const char* path = nullptr;
+    const char* name = "???";
+    char* demangled = nullptr;
+    int offset = -1;
+
+    std::cerr << "[" << i << "] ";
+    if (dladdr(pc, &info)) {
+      path = info.dli_fname;
+      name = info.dli_sname ?: "???";
+      offset = reinterpret_cast<uintptr_t>(pc) -
+          reinterpret_cast<uintptr_t>(info.dli_saddr);
+
+      int status;
+      demangled = abi::__cxa_demangle(name, nullptr, nullptr, &status);
+      if (status == 0) {
+        name = demangled;
+      }
     }
-    struct sigaction sa;
-    // Setup the sighub handler
-    sa.sa_handler = SIG_DFL;
-    // Restart the system call, if at all possible
-    sa.sa_flags = SA_RESTART;
-    // Block every signal during the handler
-    sigfillset(&sa.sa_mask);
-    // Intercept SIGHUP and SIGINT
-    if (sigaction(SIGHUP, &sa, &previous_sighup) == -1) {
-      LOG(FATAL) << "Cannot uninstall SIGHUP handler.";
+    std::cerr << name;
+    if (offset >= 0) {
+      std::cerr << "+" << reinterpret_cast<void*>(offset);
     }
-    if (sigaction(SIGINT, &sa, &previous_sigint) == -1) {
-      LOG(FATAL) << "Cannot uninstall SIGINT handler.";
+    std::cerr << "(" << pc << ")";
+    if (path) {
+      std::cerr << " in " << path;
+    }
+    std::cerr << std::endl;
+    if (demangled) {
+      free(demangled);
     }
   }
+}
 
-}  // namespace
+void callPreviousSignalHandler(
+    struct sigaction* action,
+    int signum,
+    siginfo_t* info,
+    void* ctx) {
+  if (!action->sa_handler) {
+    return;
+  }
+  if ((action->sa_flags & SA_SIGINFO) == SA_SIGINFO) {
+    action->sa_sigaction(signum, info, ctx);
+  } else {
+    action->sa_handler(signum);
+  }
+}
+
+// needsLock signals whether we need to lock our writing mutex.
+void stacktraceSignalHandler(bool needsLock) {
+  if (needsLock) {
+    pthread_mutex_lock(&writingMutex);
+  }
+  pid_t tid = syscall(SYS_gettid);
+  std::cerr << fatalSignalName << "(" << fatalSignum << "), Thread " << tid
+            << ": " << std::endl;
+  printStacktrace();
+  std::cerr << std::endl;
+  if (needsLock) {
+    pthread_mutex_unlock(&writingMutex);
+    pthread_cond_signal(&writingCond);
+  }
+}
+
+// Our fatal signal entry point
+void fatalSignalHandler(int signum) {
+  // Check if this is a proper signal that we declared above.
+  const char* name = getSignalName(signum);
+  if (!name) {
+    return;
+  }
+  if (fatalSignalReceived) {
+    return;
+  }
+  // Set the flag so that our SIGUSR2 handler knows that we're aborting and
+  // that it should intercept any SIGUSR2 signal.
+  fatalSignalReceived = true;
+  // Set state for other threads.
+  fatalSignum = signum;
+  fatalSignalName = name;
+  // Linux doesn't have a nice userland API for enumerating threads so we
+  // need to use the proc pseudo-filesystem.
+  DIR* procDir = opendir("/proc/self/task");
+  if (procDir) {
+    pid_t pid = getpid();
+    pid_t currentTid = syscall(SYS_gettid);
+    struct dirent* entry;
+    pthread_mutex_lock(&writingMutex);
+    while ((entry = readdir(procDir)) != nullptr) {
+      if (entry->d_name[0] == '.') {
+        continue;
+      }
+      pid_t tid = atoi(entry->d_name);
+      // If we've found the current thread then we'll jump into the SIGUSR2
+      // handler before calling pthread_cond_wait thus deadlocking, so branch
+      // our directly to the backtrace handler instead of signaling it.
+      if (tid != currentTid) {
+        syscall(SYS_tgkill, pid, tid, SIGUSR2);
+        pthread_cond_wait(&writingCond, &writingMutex);
+      } else {
+        stacktraceSignalHandler(false);
+      }
+    }
+    pthread_mutex_unlock(&writingMutex);
+  } else {
+    perror("Failed to open /proc/self/task");
+  }
+  sigaction(signum, getPreviousSigaction(signum), nullptr);
+  raise(signum);
+}
+
+// Our SIGUSR2 entry point
+void stacktraceSignalHandler(int signum, siginfo_t* info, void* ctx) {
+  if (fatalSignalReceived) {
+    stacktraceSignalHandler(true);
+  } else {
+    // We don't want to actually change the signal handler as we want to
+    // remain the signal handler so that we may get the usr2 signal later.
+    callPreviousSignalHandler(&previousSigusr2, signum, info, ctx);
+  }
+}
+
+} // namespace
 
 namespace caffe2 {
 
-SignalHandler::SignalHandler(SignalHandler::Action SIGINT_action,
-                             SignalHandler::Action SIGHUP_action):
-  SIGINT_action_(SIGINT_action),
-  SIGHUP_action_(SIGHUP_action),
-  my_sigint_count_(sigint_count),
-  my_sighup_count_(sighup_count) {
-  HookupHandler();
+SignalHandler::SignalHandler(
+    SignalHandler::Action SIGINT_action,
+    SignalHandler::Action SIGHUP_action)
+    : SIGINT_action_(SIGINT_action),
+      SIGHUP_action_(SIGHUP_action),
+      my_sigint_count_(sigintCount),
+      my_sighup_count_(sighupCount) {
+  hookupHandler();
 }
 
 SignalHandler::~SignalHandler() {
-  UnhookHandler();
+  unhookHandler();
 }
 
 // Return true iff a SIGINT has been received since the last time this
 // function was called.
 bool SignalHandler::GotSIGINT() {
-  uint64_t count = sigint_count;
+  uint64_t count = sigintCount;
   bool result = (count != my_sigint_count_);
   my_sigint_count_ = count;
   return result;
@@ -124,7 +316,7 @@ bool SignalHandler::GotSIGINT() {
 // Return true iff a SIGHUP has been received since the last time this
 // function was called.
 bool SignalHandler::GotSIGHUP() {
-  uint64_t count = sighup_count;
+  uint64_t count = sighupCount;
   bool result = (count != my_sighup_count_);
   my_sighup_count_ = count;
   return result;
@@ -140,6 +332,45 @@ SignalHandler::Action SignalHandler::CheckForSignals() {
   }
   return SignalHandler::Action::NONE;
 }
+
+namespace internal {
+
+// Installs SIGABRT signal handler so that we get stack traces
+// from every thread on SIGABRT caused exit. Also installs SIGUSR2 handler
+// so that threads can communicate with each other (be sure if you use SIGUSR2)
+// to install your handler before initing caffe2 (we properly fall back to
+// the previous handler if we didn't initiate the SIGUSR2).
+bool Caffe2InitFatalSignalHandler(int*, char***) {
+  struct sigaction sa;
+  sigemptyset(&sa.sa_mask);
+  // Since we'll be in an exiting situation it's possible there's memory
+  // corruption, so make our own stack just in case.
+  sa.sa_flags = SA_ONSTACK | SA_SIGINFO;
+  sa.sa_handler = ::fatalSignalHandler;
+  for (auto* handler = kSignalHandlers; handler->name != nullptr; handler++) {
+    if (sigaction(handler->signum, &sa, &handler->previous)) {
+      std::string str("Failed to add ");
+      str += handler->name;
+      str += " handler!";
+      perror(str.c_str());
+      return false;
+    }
+  }
+  sa.sa_sigaction = ::stacktraceSignalHandler;
+  if (sigaction(SIGUSR2, &sa, &::previousSigusr2)) {
+    perror("Failed to add SIGUSR2 handler");
+    return false;
+  }
+  return true;
+}
+
+REGISTER_CAFFE2_EARLY_INIT_FUNCTION(
+    Caffe2InitFatalSignalHandler,
+    &Caffe2InitFatalSignalHandler,
+    "Inits signal handlers for fatal signals so we can see what"
+    " went wrong");
+
+} // namepsace internal
 
 }  // namespace caffe2
 

--- a/caffe2/utils/signal_handler.h
+++ b/caffe2/utils/signal_handler.h
@@ -25,7 +25,7 @@ class SignalHandler {
   unsigned long my_sighup_count_;
 };
 
-#if !defined(_MSC_VER)
+#if defined(__linux__)
 
 namespace internal {
 

--- a/caffe2/utils/signal_handler.h
+++ b/caffe2/utils/signal_handler.h
@@ -25,4 +25,14 @@ class SignalHandler {
   unsigned long my_sighup_count_;
 };
 
+#if !defined(_MSC_VER)
+
+namespace internal {
+
+bool Caffe2InitFatalSignalHandler(int* pargc, char*** pargv);
+
+} // namespace internal
+
+#endif // !defined(_MSC_VER)
+
 }  // namespace caffe2


### PR DESCRIPTION
When a fatal signal is fired to a task that links against caffe2 this PR adds stacktraces from every thread that's currently running. Only linux is supported currently. The signals that are currently supported are SIGABRT, SIGINT, SIGILL, SIGFPE, SIGBUS and SIGSEGV (more signals can easily be added, but for now this seemed like the major signals that might be fired - see signal_handler.cc:138 for the table of signals).

I've added tests that verify that each of those signals indeed output the expected number of stacktraces.

We need to add linking against libdl since on linux apparently it's not implicitly always linked in (I'm coming from macOS where I believe it is).

Example output can be found [here](https://gist.github.com/danzimm/814faa1229d9c54f359d23ba038344a6) - note that the signal name changes depending on the signal that was sent (as well as the number in parenthesis that corresponds to the specified signal).