### PR TITLE
Fix LRN schema for cuDNN op

### DIFF
--- a/caffe2/operators/local_response_normalization_op.cc
+++ b/caffe2/operators/local_response_normalization_op.cc
@@ -231,16 +231,23 @@ namespace {
 REGISTER_CPU_OPERATOR(LRN, LRNOp<float, CPUContext>);
 REGISTER_CPU_OPERATOR(LRNGradient, LRNGradientOp<float, CPUContext>);
 
-OPERATOR_SCHEMA(LRN).NumInputs(1).NumOutputs(2);
-OPERATOR_SCHEMA(LRNGradient).NumInputs(4).NumOutputs(1);
+OPERATOR_SCHEMA(LRN).NumInputs(1).NumOutputs(1,2);
+OPERATOR_SCHEMA(LRNGradient).NumInputs(3,4).NumOutputs(1);
 
 class GetLRNGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;
   vector<OperatorDef> GetGradientDefs() override {
-    return SingleGradientDef(
-        "LRNGradient", "",
-        vector<string>{I(0), O(0), O(1), GO(0)},
-        vector<string>{GI(0)});
+    if (def_.output_size() == 2) {
+      return SingleGradientDef(
+          "LRNGradient", "",
+          vector<string>{I(0), O(0), O(1), GO(0)},
+          vector<string>{GI(0)});
+    } else {
+      return SingleGradientDef(
+          "LRNGradient", "",
+          vector<string>{I(0), O(0), GO(0)},
+          vector<string>{GI(0)});
+    }
   }
 };
 REGISTER_GRADIENT(LRN, GetLRNGradient);

--- a/caffe2/python/helpers/normalization.py
+++ b/caffe2/python/helpers/normalization.py
@@ -5,12 +5,15 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from caffe2.python import core
+from caffe2.python import core, scope
 
 
 def lrn(model, blob_in, blob_out, order="NCHW", use_cudnn=False, **kwargs):
     """LRN"""
-    if use_cudnn:
+    dev = kwargs['device_option'] if 'device_option' in kwargs \
+        else scope.CurrentDeviceScope()
+    is_cpu = dev is None or dev.device_type == caffe2_pb2.CPU
+    if use_cudnn and (not is_cpu):
         kwargs['engine'] = 'CUDNN'
         blobs_out = blob_out
     else:
@@ -22,7 +25,7 @@ def lrn(model, blob_in, blob_out, order="NCHW", use_cudnn=False, **kwargs):
         **kwargs
     )
 
-    if use_cudnn:
+    if use_cudnn and (not is_cpu):
         return lrn
     else:
         return lrn[0]

--- a/caffe2/python/helpers/normalization.py
+++ b/caffe2/python/helpers/normalization.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from caffe2.python import core, scope
+from caffe2.proto import caffe2_pb2
 
 
 def lrn(model, blob_in, blob_out, order="NCHW", use_cudnn=False, **kwargs):


### PR DESCRIPTION
Correct schema generation was previously broken leading to invalid gradient op creation.

Also exhibited in model_device_helper, where invalid schema were being created on the CPU when kwargs['engine'] == 'CUDNN'