### PR TITLE
Bugfix for data_parallel_model - add Copy ops

### DIFF
--- a/caffe2/python/data_parallel_model.py
+++ b/caffe2/python/data_parallel_model.py
@@ -513,10 +513,10 @@ def _AllReduce(devices, model, net, param, use_nccl=False, control_input=None):
         d2 = model._devices[d2i]
         device_opt = core.DeviceOption(caffe2_pb2.CUDA, d1)
         with core.DeviceScope(device_opt):
-            net.Sum(
-                [blobs_group[d1], blobs_group[d2]], [blobs_group[d1]],
-                name="dpm",
-            )
+            # Copy from d2 to d1
+            d2_copy = 'gpu_{}/{}_copy'.format(d1, param)
+            model.Copy(blobs_group[d2], d2_copy)
+            net.Sum([blobs_group[d1], d2_copy], [blobs_group[d1]])
     if len(devices) == 8:
         # Special tree reduction for 8 gpus, TODO generalize like in muji.py
         for j in range(4):
@@ -531,7 +531,7 @@ def _AllReduce(devices, model, net, param, use_nccl=False, control_input=None):
         sum2(0, 2)
         _Broadcast(devices, model, net, param)
     else:
-        net.Sum(blobs_group, blobs_group[0], name="dpm")
+        sum2(0, 1)
         _Broadcast(devices, model, net, param)
 
 
@@ -829,8 +829,6 @@ def _AnalyzeOperators(model):
     '''
     for op in model.Proto().op:
         if "NCCL" in op.type or "Copy" in op.type or "Concat" in op.type:
-            continue
-        if "Sum" == op.type and op.name == "dpm":
             continue
         if "Allreduce" in op.type and "GLOO" in op.engine:
             continue

--- a/caffe2/python/data_parallel_model.py
+++ b/caffe2/python/data_parallel_model.py
@@ -515,8 +515,8 @@ def _AllReduce(devices, model, net, param, use_nccl=False, control_input=None):
         with core.DeviceScope(device_opt):
             # Copy from d2 to d1
             d2_copy = 'gpu_{}/{}_copy'.format(d1, param)
-            model.Copy(blobs_group[d2], d2_copy)
-            net.Sum([blobs_group[d1], d2_copy], [blobs_group[d1]])
+            model.Copy(blobs_group[d2i], d2_copy)
+            net.Sum([blobs_group[d1i], d2_copy], [blobs_group[d1i]])
     if len(devices) == 8:
         # Special tree reduction for 8 gpus, TODO generalize like in muji.py
         for j in range(4):


### PR DESCRIPTION
Bug was exposed by this test:
```
caffe2/python/data_parallel_model_test.py::GPUDataParallelModelTest::test_equiv
```
Fixes this error:
```
========= Invalid __global__ read of size 4
=========     at 0x000000a0 in caffe2::math::_Kernel_float_Add(int, float const *, float const *, float*)
E0522 10:33:44.497241 18450 context_gpu.h:126] Encountered CUDA error: unspecified launch failure
F0522 10:33:44.497547 18450 operator.h:200] Computation on device returned error in operator
input: "gpu_0/fc_b_grad" input: "gpu_1/fc_b_grad" output: "gpu_0/fc_b_grad" name: "dpm" type: "Sum" device_option { device_type: 1 cuda_gpu_id: 0 }
```