### PR TITLE
Restore compatibility with protobuf2

### DIFF
--- a/caffe2/python/recurrent.py
+++ b/caffe2/python/recurrent.py
@@ -236,7 +236,9 @@ def recurrent_net(
         proto = backward_cell_net.Proto()
         operators = []
         while len(proto.op) > 0:
-            operators.append(proto.op.pop())
+            op = proto.op[-1]
+            proto.op.remove(op)
+            operators.append(op)
         for op in operators[::-1]:
             proto.op.extend([op])
             for j, output_blob in enumerate(op.output):


### PR DESCRIPTION
Addresses an issue with https://github.com/caffe2/caffe2/commit/417f74509e265d89511c740bcb0ff03d78d97fd0.
```
>               operators.append(proto.op.pop())
E               AttributeError: 'RepeatedCompositeFieldContainer' object has no attribute 'pop'
```
/cc @jhcross 