### PR TITLE
Fix SparseAdagrad for indices.ndim>1

### DIFF
--- a/caffe2/python/operator_test/adam_test.py
+++ b/caffe2/python/operator_test/adam_test.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import functools
 
+import hypothesis
 from hypothesis import given
 import hypothesis.strategies as st
 import numpy as np
@@ -70,17 +71,28 @@ class TestAdam(hu.HypothesisTestCase):
                            allow_nan=False, allow_infinity=False),
            epsilon=st.floats(min_value=0.01, max_value=0.99,
                              allow_nan=False, allow_infinity=False),
+           data_strategy=st.data(),
            **hu.gcs)
     def test_sparse_adam(self, inputs, ITER, LR, beta1, beta2, epsilon,
-                         gc, dc):
+                         data_strategy, gc, dc):
         param, mom1, mom2, grad = inputs
         mom1 = np.absolute(mom1)
         mom2 = np.absolute(mom2)
         ITER = np.array([ITER], dtype=np.int64)
         LR = np.array([LR], dtype=np.float32)
 
-        indices = np.arange(grad.shape[0])
-        indices = indices[indices % 2 == 0]
+        # Create an indexing array containing values which index into grad
+        indices = data_strategy.draw(
+            hu.tensor(dtype=np.int64,
+                      elements=st.sampled_from(np.arange(grad.shape[0]))),
+        )
+        hypothesis.note('indices.shape: %s' % str(indices.shape))
+
+        # For now, the indices must be unique
+        hypothesis.assume(np.array_equal(np.unique(indices.flatten()),
+                                         np.sort(indices.flatten())))
+
+        # Sparsify grad
         grad = grad[indices]
 
         op = core.CreateOperator(

--- a/caffe2/sgd/adagrad_op.h
+++ b/caffe2/sgd/adagrad_op.h
@@ -75,8 +75,6 @@ class SparseAdagradOp final : public Operator<Context> {
   template <typename SIndex>
   bool DoRunWithType() {
     const auto* lr = Input(LR).template data<T>();
-    auto n = Input(GRAD).dim(0);
-
     const auto* indices = Input(INDICES).template data<SIndex>();
     const auto* gradIn = Input(GRAD).template data<T>();
     const auto* paramIn = Input(PARAM).template data<T>();
@@ -84,11 +82,12 @@ class SparseAdagradOp final : public Operator<Context> {
     auto* paramOut = Output(OUTPUT_PARAM)->template mutable_data<T>();
     auto* momentOut = Output(OUTPUT_MOMENT_1)->template mutable_data<T>();
 
+    auto n = Input(INDICES).size();
     if (n == 0) {
       return true;
     }
 
-    auto block_size = Input(GRAD).size_from_dim(1);
+    auto block_size = Input(GRAD).size() / n;
     for (auto i = 0; i < n; ++i) {
       auto idx = indices[i];
       if (block_size == 1) {


### PR DESCRIPTION
Same fix as https://github.com/caffe2/caffe2/pull/249, but for SparseAdagrad.

Also update the tests for both ops to test this functionality.

