### PR TITLE
Update centos.md

### DIFF
--- a/_docs/getting-started/centos.md
+++ b/_docs/getting-started/centos.md
@@ -63,7 +63,7 @@ make -j 8 && sudo make install && cd ../.. && \
 git clone https://github.com/google/glog && \
 cd glog && \
 mkdir build && cd build && \
-cmake3 -DCMAKE_CXX_FLAGS='-fPIC' .. && \
+cmake3 -DBUILD_SHARED_LIBS=ON -DCMAKE_CXX_FLAGS='-fPIC' .. && \
 make -j 8 && sudo make install && cd ../..
 ```
 
@@ -207,6 +207,7 @@ ssh -N -f -L localhost:8888:localhost:8889 -i "your-public-cert.pem" ec2-user@su
 
 caffe2.python not found | You may have some PATH or PYTHONPATH issues. Add `/home/ec2-user/caffe2/build` to your path and that can take care of those problems.
 error while loading shared libraries: libCaffe2_CPU.so: cannot open shared object file: No such file or directory | Try updating your LD_LIBRARY_PATH with `export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH`
+undefined reference to \`ncclReduceScatter' | This does not occur on Caffe2 building, but on linking with "libCaffe2_GPU.so" in some external projects. To solve this, you may install NCCL from its source bundled with Caffe2: (under the Caffe2 project directory) `cd third_party/nccl && make -j 8 && sudo make install`
 
 {{ outro | markdownify }}
 


### PR DESCRIPTION
Add solution for trouble linking with "libCaffe2_GPU.so" due to "undefined reference to `ncclReduceScatter'".
Add "-DBUILD_SHARED_LIBS=ON" to glog building.