### PR TITLE
Test smaller tensors in segment_ops_test

### DIFF
--- a/caffe2/python/operator_test/segment_ops_test.py
+++ b/caffe2/python/operator_test/segment_ops_test.py
@@ -312,7 +312,7 @@ class TestSegmentOps(hu.HypothesisTestCase):
             hu.lengths_tensor(
                 dtype=np.float32,
                 min_value=1,
-                max_value=10,
+                max_value=5,
                 allow_empty=True
             ),
             REFERENCES_ALL
@@ -324,7 +324,7 @@ class TestSegmentOps(hu.HypothesisTestCase):
             hu.sparse_lengths_tensor(
                 dtype=np.float32,
                 min_value=1,
-                max_value=10,
+                max_value=5,
                 allow_empty=True
             ),
             REFERENCES_ALL


### PR DESCRIPTION
It's causing problems inside docker containers:

`InvalidArgument: Insufficient bytes of entropy to draw requested array.  shape=(5, 9, 10, 5), dtype=float32.  Can you reduce the size or dimensions of the array?  What about using a smaller dtype? If slow test runs and minimisation are acceptable, you  could increase settings().buffer_size from 8192 to at least 18432000.`