### PR TITLE
Avoid numpy VisibleDeprecationWarning in test

### DIFF
--- a/caffe2/python/operator_test/tile_op_test.py
+++ b/caffe2/python/operator_test/tile_op_test.py
@@ -97,7 +97,7 @@ class TestTile(hu.HypothesisTestCase):
 
         def tile_ref(X, tiles, axis):
             dims = [1, 1, 1]
-            dims[axis] = tiles
+            dims[axis[0]] = tiles
             tiled_data = np.tile(X, tuple(dims))
             return (tiled_data,)
 


### PR DESCRIPTION
This warning becomes an error with https://github.com/numpy/numpy/pull/6271 (`>=0.12.0`).

```
caffe2/python/operator_test/tile_op_test.py::TestTile::test_tilewinput
  /opt/caffe2/caffe2/python/operator_test/tile_op_test.py:100: VisibleDeprecationWarning: converting an array with ndim > 0 to an index will result in an error in the future
    dims[axis] = tiles
  /usr/lib/python2.7/dist-packages/numpy/lib/shape_base.py:873: VisibleDeprecationWarning: converting an array with ndim > 0 to an index will result in an error in the future
    return c.reshape(shape_out)
```