### PR TITLE
Another fix for KeepOnShrink tests

### DIFF
--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -347,8 +347,10 @@ TYPED_TEST(TensorCPUTest, NoLongerSharesAfterResize) {
 }
 
 TYPED_TEST(TensorCPUTest, KeepOnShrink) {
+  // Set flags (defaults)
   FLAGS_caffe2_keep_on_shrink = true;
   FLAGS_caffe2_max_keep_on_shrink_memory = LLONG_MAX;
+
   vector<int> dims{2, 3, 5};
   TensorCPU tensor(dims);
   TypeParam* ptr = tensor.mutable_data<TypeParam>();
@@ -373,9 +375,10 @@ TYPED_TEST(TensorCPUTest, KeepOnShrink) {
 }
 
 TYPED_TEST(TensorCPUTest, MaxKeepOnShrink) {
+  // Set flags
   FLAGS_caffe2_keep_on_shrink = true;
-  // Remember that this tests for int, float and char
-  FLAGS_caffe2_max_keep_on_shrink_memory = 40;
+  FLAGS_caffe2_max_keep_on_shrink_memory = 8 * 4 * sizeof(TypeParam);
+
   vector<int> dims{1, 8, 8};
   TensorCPU tensor(dims);
   TypeParam* ptr = tensor.mutable_data<TypeParam>();
@@ -389,7 +392,12 @@ TYPED_TEST(TensorCPUTest, MaxKeepOnShrink) {
   tensor.Resize(1, 1, 8);
   TypeParam* new_ptr = tensor.mutable_data<TypeParam>();
   EXPECT_TRUE(new_ptr != nullptr);
-  EXPECT_NE(ptr, new_ptr);
+
+  // This check can fail when malloc() returns the same recently freed address
+  //EXPECT_NE(ptr, new_ptr);
+
+  // Restore default flags
+  FLAGS_caffe2_max_keep_on_shrink_memory = LLONG_MAX;
 }
 
 TYPED_TEST(TensorCPUDeathTest, CannotAccessRawDataWhenEmpty) {


### PR DESCRIPTION
*Fix #417 again (#551 was insufficient)*

Even after a reallocation, the data address can still be the same if malloc returns the same newly freed address.

* Be very explicit and careful about how we set these flags so they don't interfere with other tests
* Disable the failing check

This somewhat takes the teeth out of this test, since it no longer verifies that the reallocation actually occurs.

Test with:
```
blob_test --gtest_filter=TensorCPUTest*Shrink* \
    --gtest_shuffle --gtest_repeat=100 --gtest_throw_on_failure
```
/cc @sunwael 