### PR TITLE
Hide loud warning when using third_party eigen

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -198,7 +198,7 @@ endif()
 
 # ---[ EIGEN
 add_definitions(-DEIGEN_MPL2_ONLY)
-find_package(Eigen3)
+find_package(Eigen3 QUIET)
 if(EIGEN3_FOUND)
   include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS})
 else()


### PR DESCRIPTION
This is a little excessive:
```
CMake Warning at cmake/Dependencies.cmake:201 (find_package):
  By not providing "FindEigen3.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Eigen3", but
  CMake did not find one.

  Could not find a package configuration file provided by "Eigen3" with any
  of the following names:

    Eigen3Config.cmake
    eigen3-config.cmake

  Add the installation prefix of "Eigen3" to CMAKE_PREFIX_PATH or set
  "Eigen3_DIR" to a directory containing one of the above files.  If "Eigen3"
  provides a separate development package or SDK, be sure it has been
  installed.
Call Stack (most recent call first):
  CMakeLists.txt:72 (include)
```