### PR TITLE
Skip Python tests which require opencv or lmdb

### DIFF
--- a/caffe2/python/operator_test/image_input_op_test.py
+++ b/caffe2/python/operator_test/image_input_op_test.py
@@ -3,8 +3,13 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import unittest
+try:
+    import cv2
+except ImportError:
+    raise unittest.SkipTest('python-opencv is not installed')
+
 from PIL import Image
-import cv2
 import numpy as np
 import lmdb
 import shutil

--- a/caffe2/python/operator_test/video_input_op_test.py
+++ b/caffe2/python/operator_test/video_input_op_test.py
@@ -3,11 +3,15 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import unittest
+try:
+    import lmdb
+except ImportError:
+    raise unittest.SkipTest('python-lmdb is not installed')
+
 import sys
 import os
 import shutil
-import lmdb
-import unittest
 import tempfile
 
 from caffe2.proto import caffe2_pb2


### PR DESCRIPTION
Neither dependency is required by the core Python modules.

OpenCV, in particular, is a pain to install (no pip package). Conditionally skipping this test will make TravisCI integration easier.