### PR TITLE
Fix observer_test

### DIFF
--- a/caffe2/core/observer_test.cc
+++ b/caffe2/core/observer_test.cc
@@ -129,7 +129,6 @@ TEST(ObserverTest, TestNotifyAfterDetach) {
       make_unique<DummyObserver<SimpleNet>>(
           *(caffe2::dynamic_cast_if_rtti<SimpleNet*>(net.get())));
   net_ob.get()->Deactivate();
-  counter = 0;
   net.get()->Run();
   auto count_after = counter.load();
   EXPECT_EQ(0, count_after - count_before);

--- a/caffe2/core/observer_test.cc
+++ b/caffe2/core/observer_test.cc
@@ -105,6 +105,7 @@ unique_ptr<NetBase> CreateNetTestHelper(
 }
 
 TEST(ObserverTest, TestNotify) {
+  auto count_before = counter.load();
   Workspace ws;
   ws.CreateBlob("in");
   NetDef net_def;
@@ -114,10 +115,12 @@ TEST(ObserverTest, TestNotify) {
       make_unique<DummyObserver<SimpleNet>>(
           *(caffe2::dynamic_cast_if_rtti<SimpleNet*>(net.get())));
   net.get()->Run();
-  EXPECT_EQ(1212, counter.load());
+  auto count_after = counter.load();
+  EXPECT_EQ(1212, count_after - count_before);
 }
 
 TEST(ObserverTest, TestNotifyAfterDetach) {
+  auto count_before = counter.load();
   Workspace ws;
   ws.CreateBlob("in");
   NetDef net_def;
@@ -128,6 +131,7 @@ TEST(ObserverTest, TestNotifyAfterDetach) {
   net_ob.get()->Deactivate();
   counter = 0;
   net.get()->Run();
-  EXPECT_EQ(0, counter.load());
+  auto count_after = counter.load();
+  EXPECT_EQ(0, count_after - count_before);
 }
 }


### PR DESCRIPTION
Fixes bug in tests introduced with https://github.com/caffe2/caffe2/commit/52dafaa7db9e974b25df665eb18d2dbb80b85edc.
```
[ RUN      ] ObserverTest.TestNotifyAfterDetach
/data/caffe2/caffe2/core/observer_test.cc:130: Failure
      Expected: 0
To be equal to: counter.load()
      Which is: 1212
```
Bug disovered with TravisCI builds at https://github.com/caffe2/caffe2/pull/735, but can also be seen in the existing builds at https://travis-ci.org/caffe2/caffe2/jobs/239913458.