### PR TITLE
Avoid compiler warning about unreachable code

### DIFF
--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -273,7 +273,7 @@ class OpSchema {
       };
   CostInferenceFunctionType cost_inference_function_ =
       [](const OperatorDef& def, const vector<TensorShape>&) {
-        CAFFE_THROW("No cost inference function registered.");
+        LOG(FATAL) << "No cost inference function registered.";
         return Cost();
       };
   DeviceInferenceFunctionType device_inference_function_ =


### PR DESCRIPTION
Fix https://github.com/caffe2/caffe2/issues/764

I don't think we care much about the behavior, exactly, as long as it's a loud clear crash - right?