### PR TITLE
Disable smart_tensor_printer_test on OSX

### DIFF
--- a/caffe2/utils/smart_tensor_printer_test.cc
+++ b/caffe2/utils/smart_tensor_printer_test.cc
@@ -37,9 +37,13 @@ void printTensorAndCheck(const std::vector<T>& values) {
   expect_stderr_contains(values);
 }
 
+#if !(__APPLE__) // TODO(janusz): thread_local does not work under mac.
+
 TEST(SmartTensorPrinterTest, SimpleTest) {
   printTensorAndCheck(std::vector<int>{1, 2, 3, 4, 5});
   printTensorAndCheck(std::vector<std::string>{"bob", "alice", "facebook"});
 }
+
+#endif // !(__APPLE__)
 
 } // namespace caffe2


### PR DESCRIPTION
TravisCI failure: https://travis-ci.org/lukeyeager/caffe2/jobs/240947529

Copies solution from https://github.com/caffe2/caffe2/commit/ef688490c483d111c73222d49decf25337fee0eb