### PR TITLE
README: TravisCI and Appveyor badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Caffe2
 
+[![TravisCI Build Status](https://travis-ci.org/caffe2/caffe2.svg?branch=master)](https://travis-ci.org/caffe2/caffe2)
+[![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/github/caffe2/caffe2?svg=true)](https://ci.appveyor.com/project/Yangqing/caffe2)
+
 Caffe2 is a lightweight, modular, and scalable deep learning framework. Building on the original [Caffe](http://caffe.berkeleyvision.org), Caffe2 is designed with expression, speed, and modularity in mind.
 
 ## Events
@@ -21,17 +24,6 @@ Please participate in our survey (https://www.surveymonkey.com/r/caffe2). We wil
 ## License and Citation
 
 Caffe2 is released under the [BSD 2-Clause license](https://github.com/Yangqing/caffe2/blob/master/LICENSE).
-
-### Build Status
-
-[![Travis Build Status](https://travis-ci.org/caffe2/caffe2.svg?branch=master)](https://travis-ci.org/caffe2/caffe2)
-
-| Target      | Status |
-|-------------|----|
-| Linux       | [![Build Linux](https://travis-matrix-badges.herokuapp.com/repos/caffe2/caffe2/branches/master/1)](https://travis-ci.org/caffe2/caffe2) |
-| Android     | [![Build Android](https://travis-matrix-badges.herokuapp.com/repos/caffe2/caffe2/branches/master/3)](https://travis-ci.org/caffe2/caffe2) |
-| iOS         | [![Build iOS](https://travis-matrix-badges.herokuapp.com/repos/caffe2/caffe2/branches/master/5)](https://travis-ci.org/caffe2/caffe2) |
-| Linux + MKL | [![Build LinuxMKL](https://travis-matrix-badges.herokuapp.com/repos/caffe2/caffe2/branches/master/6)](https://travis-ci.org/caffe2/caffe2) |
 
 ### Further Resources on [Caffe2.ai](http://caffe2.ai)
 


### PR DESCRIPTION
The existing per-branch TravisCI badges don't work, and will be out-dated when https://github.com/caffe2/caffe2/pull/735 is merged.

I also added an Appveyor badge.