### PR TITLE
Fixes in tests to support numpy >= 0.12

### DIFF
--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -1907,8 +1907,8 @@ class TestOperators(hu.HypothesisTestCase):
         X = np.random.randn(
             n * block_size * block_size,
             c,
-            (h + 2 * pad) / block_size,
-            (w + 2 * pad) / block_size).astype(np.float32)
+            (h + 2 * pad) // block_size,
+            (w + 2 * pad) // block_size).astype(np.float32)
         op = core.CreateOperator("BatchToSpace", ["X"], ["Y"],
                                  pad=pad, block_size=block_size)
         self.assertDeviceChecks(dc, op, [X], [0])

--- a/caffe2/python/operator_test/tile_op_test.py
+++ b/caffe2/python/operator_test/tile_op_test.py
@@ -30,9 +30,9 @@ class TestTile(hu.HypothesisTestCase):
         )
 
         def tile_ref(X, tiles, axis):
-            dims = [1, 1, 1]
+            dims = np.asarray([1, 1, 1], dtype=np.int)
             dims[axis] = tiles
-            tiled_data = np.tile(X, tuple(dims))
+            tiled_data = np.tile(X, dims)
             return (tiled_data,)
 
         # Check against numpy reference
@@ -59,9 +59,9 @@ class TestTile(hu.HypothesisTestCase):
         )
 
         def tile_ref(X, tiles, axis):
-            dims = [1, 1]
+            dims = np.asarray([1, 1], dtype=np.int)
             dims[axis] = tiles
-            tiled_data = np.tile(X, tuple(dims))
+            tiled_data = np.tile(X, dims)
             return (tiled_data,)
 
         # Check against numpy reference
@@ -96,9 +96,9 @@ class TestTile(hu.HypothesisTestCase):
         )
 
         def tile_ref(X, tiles, axis):
-            dims = [1, 1, 1]
+            dims = np.asarray([1, 1, 1], dtype=np.int)
             dims[axis] = tiles
-            tiled_data = np.tile(X, tuple(dims))
+            tiled_data = np.tile(X, dims)
             return (tiled_data,)
 
         # Check against numpy reference

--- a/caffe2/python/operator_test/tile_op_test.py
+++ b/caffe2/python/operator_test/tile_op_test.py
@@ -97,7 +97,7 @@ class TestTile(hu.HypothesisTestCase):
 
         def tile_ref(X, tiles, axis):
             dims = [1, 1, 1]
-            dims[axis[0]] = tiles
+            dims[axis] = tiles
             tiled_data = np.tile(X, tuple(dims))
             return (tiled_data,)
 


### PR DESCRIPTION
```
  File "/data/caffe2/install/caffe2/python/hypothesis_test.py", line 1911, in test_batch_to_space
    (w + 2 * pad) / block_size).astype(np.float32)
  File "mtrand.pyx", line 1404, in mtrand.RandomState.randn (numpy/random/mtrand/mtrand.c:19843)
  File "mtrand.pyx", line 1534, in mtrand.RandomState.standard_normal (numpy/random/mtrand/mtrand.c:20368)  
  File "mtrand.pyx", line 167, in mtrand.cont0_array (numpy/random/mtrand/mtrand.c:6127)
TypeError: 'float' object cannot be interpreted as an index
```
```
  File "/data/caffe2/install/caffe2/python/operator_test/tile_op_test.py", line 101, in tile_ref
    tiled_data = np.tile(X, tuple(dims))
  File "/data/caffe2/venv/local/lib/python2.7/site-packages/numpy/lib/shape_base.py", line 881, in tile
    return c.reshape(shape_out)
TypeError: only integer scalar arrays can be converted to a scalar index
```
I also tested to make sure this still works with 0.11.