### PR TITLE
Fix multi-precision SGD outputs

### DIFF
--- a/caffe2/python/optimizer.py
+++ b/caffe2/python/optimizer.py
@@ -232,7 +232,7 @@ class MultiPrecisionSgdOptimizer(SgdOptimizer):
         # update (fused) in fp32
         net.MomentumSGDUpdate(
             [grad_fp32, momentum_data, lr, param_fp32],
-            [grad, momentum_data, param_fp32],
+            [grad_fp32, momentum_data, param_fp32],
             momentum=self.momentum,
             nesterov=self.nesterov)
 


### PR DESCRIPTION
@salexspb This fixes a major perf issue (40% boost on alexnet end-to-end perf) in the multi-precision SGD optimizer - it was causing repeated cudaMalloc / cudaFree calls during training iterations due to the changing size of the `grad` blob as it moved from fp16 <-> fp32.

