### PR TITLE
Third fix for KeepOnShrink tests

### DIFF
--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -359,7 +359,10 @@ TYPED_TEST(TensorCPUTest, KeepOnShrink) {
   tensor.Resize(3, 4, 6);
   TypeParam* larger_ptr = tensor.mutable_data<TypeParam>();
   EXPECT_TRUE(larger_ptr != nullptr);
-  EXPECT_NE(ptr, larger_ptr);
+
+  // This check can fail when malloc() returns the same recently freed address
+  //EXPECT_NE(ptr, larger_ptr);
+
   // Shrinking - will not reallocate
   tensor.Resize(1, 2, 4);
   TypeParam* smaller_ptr = tensor.mutable_data<TypeParam>();


### PR DESCRIPTION
See https://github.com/caffe2/caffe2/pull/723, https://github.com/caffe2/caffe2/pull/551, https://github.com/caffe2/caffe2/issues/417
```
[ RUN      ] TensorCPUTest/1.KeepOnShrink
/opt/caffe2/caffe2/core/blob_test.cc:362: Failure
Expected: (ptr) != (larger_ptr), actual: 0x24f7640 vs 0x24f7640
[  FAILED  ] TensorCPUTest/1.KeepOnShrink, where TypeParam = int (0 ms)
```
I haven't been able to reproduce locally or on TravisCI - only in our own test infrastructure. The fix is conceptually the same as https://github.com/caffe2/caffe2/pull/723. After reading through the code, I can't see any other checks which should fail this way.