### PR TITLE
Fix for protobuf with unicode_literals

### DIFF
--- a/caffe2/python/core_gradients_test.py
+++ b/caffe2/python/core_gradients_test.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from future.utils import bytes_to_native_str
 from hypothesis import given
 import hypothesis.strategies as st
 import unittest
@@ -88,7 +89,7 @@ class TestGradientCalculation(test_util.TestCase):
         if isinstance(op_list1, list) and isinstance(op_list2, list):
             for op in op_list1 + op_list2:
                 if isinstance(op, caffe2_pb2.OperatorDef):
-                    op.ClearField('uuid')
+                    op.ClearField(bytes_to_native_str(b'uuid'))
         return super(TestGradientCalculation, self).assertEqual(
             op_list1, op_list2)
 

--- a/caffe2/python/core_test.py
+++ b/caffe2/python/core_test.py
@@ -1,17 +1,21 @@
+from __future__ import unicode_literals
+
+from inspect import currentframe, getframeinfo
+import unittest
+
+from future.utils import bytes_to_native_str
+import numpy as np
+
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace, test_util
-
-import unittest
-import numpy as np
-from inspect import currentframe, getframeinfo
 
 
 def _remove_uuid(proto):
     if isinstance(proto, caffe2_pb2.NetDef):
         for op in proto.op:
-            op.ClearField('uuid')
+            op.ClearField(bytes_to_native_str(b'uuid'))
     elif isinstance(proto, caffe2_pb2.OperatorDef):
-        proto.ClearField('uuid')
+        proto.ClearField(bytes_to_native_str(b'uuid'))
     return proto
 
 class TestScopes(test_util.TestCase):


### PR DESCRIPTION
Python 2.7, Protobuf 2.6

    >                   op.ClearField('uuid')
    E                   TypeError: field name must be a string

Fix: http://python-future.org/imports.html#should-i-import-unicode-literals

/cc @salexspb @tomdz 