### PR TITLE
Skip TestInferDevice if no GPU support

### DIFF
--- a/caffe2/python/core_test.py
+++ b/caffe2/python/core_test.py
@@ -441,6 +441,7 @@ class TestOperatorTraceback(test_util.TestCase):
         self.assertEqual(net.Proto().op[0].name, '{}:{}'.format(filename, line))
 
 
+@unittest.skipIf(not workspace.has_gpu_support, 'No GPU support')
 class TestInferDevice(test_util.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Working towards https://github.com/caffe2/caffe2/pull/817.
```
E           AttributeError: Method CopyCPUToGPU is not a registered operator. Did you mean: []
```
https://travis-ci.org/caffe2/caffe2/jobs/243867951