### PR TITLE
fix #790 so model.init_params = False takes effect

### DIFF
--- a/caffe2/python/helpers/conv.py
+++ b/caffe2/python/helpers/conv.py
@@ -55,10 +55,10 @@ def _ConvBase(
         weight_shape.extend(kernels)
         weight_shape.append(int(dim_in / group))
 
-    weight_initializer = initializers.update_initializer(
+    WeightInitializer = initializers.update_initializer(
         WeightInitializer, weight_init, ("XavierFill", {})
     )
-    bias_initializer = initializers.update_initializer(
+    BiasInitializer = initializers.update_initializer(
         BiasInitializer, bias_init, ("ConstantFill", {})
     )
     if not model.init_params:
@@ -68,14 +68,14 @@ def _ConvBase(
     weight = model.create_param(
         param_name=blob_out + '_w',
         shape=weight_shape,
-        initializer=weight_initializer,
+        initializer=WeightInitializer,
         tags=ParameterTags.WEIGHT
     )
     if use_bias:
         bias = model.create_param(
             param_name=blob_out + '_b',
             shape=[dim_out, ],
-            initializer=bias_initializer,
+            initializer=BiasInitializer,
             tags=ParameterTags.BIAS
         )
 


### PR DESCRIPTION
Given the parameter init_params=False, Weight Blob(*_w) and Bias Blob (*_b) should be suppressed in model.param_init_net. Without this fix, the init_params=False doesn't take effect in brew.conv as it does in brew.fc or other ops. This issue is the root cause of #790 [https://github.com/caffe2/caffe2/pull/790].