### PR TITLE
Don't require pydot for Python tests

### DIFF
--- a/caffe2/python/gradient_check_test.py
+++ b/caffe2/python/gradient_check_test.py
@@ -335,7 +335,6 @@ class TestNetGradientChecker(test_util.TestCase):
             [net1, net2], [[x], [y]], [0],
             inputs_with_grads=[a, b, c, d],
             input_values=input_values,
-            print_net_images=True,
         )
 
 if __name__ == '__main__':

--- a/caffe2/python/operator_test/rnn_cell_test.py
+++ b/caffe2/python/operator_test/rnn_cell_test.py
@@ -495,7 +495,6 @@ class RNNCellTest(hu.HypothesisTestCase):
             gradient_checker.NetGradientChecker.CompareNets(
                 nets, outputs, outputs_with_grad_ids=outputs_with_grad,
                 inputs_with_grads=[input_blob],
-                print_net_images=True,
             )
 
     @given(
@@ -532,7 +531,6 @@ class RNNCellTest(hu.HypothesisTestCase):
         gradient_checker.NetGradientChecker.CompareNets(
             nets, outputs, outputs_with_grads,
             inputs_with_grads=inputs[0],
-            print_net_images=True,
         )
 
     @given(


### PR DESCRIPTION
Working towards https://github.com/caffe2/caffe2/pull/817.
```
>       graph = pydot.Dot(name, rankdir=rankdir)
E       AttributeError: 'NoneType' object has no attribute 'Dot'
```
https://travis-ci.org/caffe2/caffe2/jobs/243867951