### PR TITLE
Skip fp16 initializer test for CPU-only builds

### DIFF
--- a/caffe2/python/modeling/initializers_test.py
+++ b/caffe2/python/modeling/initializers_test.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import unittest
-from caffe2.python import brew, model_helper
+from caffe2.python import brew, model_helper, workspace
 from caffe2.python.modeling.initializers import (
         Initializer, pFP16Initializer)
 
@@ -31,13 +31,19 @@ class InitializerTest(unittest.TestCase):
                       weight_init=("ConstantFill", {})
         )
 
+    @unittest.skipIf(not workspace.has_gpu_support, 'No GPU support')
+    def test_fc_fp16_initializer(self):
+        model = model_helper.ModelHelper(name="test")
+        data = model.net.AddExternalInput("data")
+        fc1 = brew.fc(model, data, "fc1", dim_in=1, dim_out=1)
+
         # default operator, pFP16Initializer
-        fc5 = brew.fc(model, fc4, "fc5", dim_in=1, dim_out=1,
+        fc2 = brew.fc(model, fc1, "fc2", dim_in=1, dim_out=1,
                       WeightInitializer=pFP16Initializer
         )
 
         # specified operator, pFP16Initializer
-        fc6 = brew.fc(model, fc4, "fc5", dim_in=1, dim_out=1,
+        fc3 = brew.fc(model, fc2, "fc3", dim_in=1, dim_out=1,
                       weight_init=("ConstantFill", {}),
                       WeightInitializer=pFP16Initializer
         )


### PR DESCRIPTION
Working towards https://github.com/caffe2/caffe2/pull/817.
```
E           AttributeError: Method FloatToHalf is not a registered operator. Did you mean: []
```
https://travis-ci.org/caffe2/caffe2/jobs/243867951

/cc @slayton58 