### PR TITLE
Fix entropy error coming from utility_ops_test

### DIFF
--- a/caffe2/python/operator_test/utility_ops_test.py
+++ b/caffe2/python/operator_test/utility_ops_test.py
@@ -143,7 +143,7 @@ class TestUtilityOps(hu.HypothesisTestCase):
         )
 
     @given(
-        inputs=hu.lengths_tensor(max_value=30).flatmap(
+        inputs=hu.lengths_tensor().flatmap(
             lambda pair: st.tuples(
                 st.just(pair[0]),
                 st.just(pair[1]),


### PR DESCRIPTION
Working towards https://github.com/caffe2/caffe2/pull/817.

`E           InvalidArgument: Insufficient bytes of entropy to draw requested array.  shape=(20, 12, 22), dtype=float32.  Can you reduce the size or dimensions of the array?  What about using a smaller dtype?  If slow test runs and minimisation are acceptable, you  could increase settings().buffer_size from 8192 to at least 43253760.`

https://travis-ci.org/caffe2/caffe2/jobs/243867951

/cc @kittipatv 