### PR TITLE
Fix flaky test in dataset_ops_test.py

### DIFF
--- a/caffe2/python/operator_test/dataset_ops_test.py
+++ b/caffe2/python/operator_test/dataset_ops_test.py
@@ -638,7 +638,7 @@ class TestDatasetOps(TestCase):
         )
         print('Sample histogram: {}'.format(hist))
 
-        self.assertTrue(all(hist > 0.7 * (num_to_collect / 10)))
+        self.assertTrue(all(hist > 0.6 * (num_to_collect / 10)))
         for i in range(1, len(blobs)):
             result = workspace.FetchBlob(bconcated_map[blobs[i]])
             self.assertEqual(reference_result.tolist(), result.tolist())


### PR DESCRIPTION
```
while pytest caffe2/python/operator_test/dataset_ops_test.py::TestDatasetOps::test_collect_tensor_ops; do sleep 0.1; done
```
Run this long enough and you'll see an error like this:
```
Sample histogram: [ 92 109  65 103  99 104  99 125 100 104]
...
>       self.assertTrue(all(hist > 0.7 * (num_to_collect / 10)))
E       AssertionError: False is not true
```
I've seen values like 65, 68, 69, 70. Setting the cutoff at 60 instead of 70 seems safe enough.

/cc @Yangqing (or whoever authored https://github.com/caffe2/caffe2/commit/a56b881c4a4fd8a4e7554d0b31e6e0326d26e718).