### PR TITLE
Fix gradient checking for softplus op

### DIFF
--- a/caffe2/python/operator_test/softplus_op_test.py
+++ b/caffe2/python/operator_test/softplus_op_test.py
@@ -17,7 +17,7 @@ class TestSoftplus(hu.HypothesisTestCase):
     def test_softplus(self, X, gc, dc):
         op = core.CreateOperator("Softplus", ["X"], ["Y"])
         self.assertDeviceChecks(dc, op, [X], [0])
-        self.assertGradientChecks(gc, op, [X], 0, [0], stepsize=0.0005)
+        self.assertGradientChecks(gc, op, [X], 0, [0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@kmatzen why did you set the stepsize in https://github.com/caffe2/caffe2/commit/ff84e7dea6e118710859d62a7207c06b87ae992e?

The test is flaky before this change. Solid afterwards.