### PR TITLE
TravisCI: fix OSX builds

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -137,7 +137,6 @@ elif [ "$TRAVIS_OS_NAME" = 'osx' ]; then
     pip uninstall -y numpy  # use brew version (opencv dependency)
     brew tap homebrew/science  # for OpenCV
     brew install \
-        automake \
         ccache \
         glog \
         leveldb \
@@ -169,7 +168,7 @@ if [ "$BUILD_ANDROID" = 'true' ]; then
         $APT_INSTALL_CMD autotools-dev autoconf
         wget -O "$_ndk_zip" https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip
     elif [ "$TRAVIS_OS_NAME" = 'osx' ]; then
-        brew install automake libtool
+        brew install libtool
         wget -O "$_ndk_zip" https://dl.google.com/android/repository/android-ndk-r13b-darwin-x86_64.zip
     else
         echo "OS \"$TRAVIS_OS_NAME\" is unknown"


### PR DESCRIPTION
Apparently, `brew install` fails if the package is already installed?
```
Error: automake 1.15 is already installed
```
https://travis-ci.org/caffe2/caffe2/jobs/245226634

Maybe TravisCI made some unannounced updates to their OSX images at around the same time [they updated their trusty images](https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch). Something changed on their side two days ago, and the OSX builds have been failing ever since.