### PR TITLE
Conv frontend: checking engine and use_cudnn

### DIFF
--- a/caffe2/python/helpers/conv.py
+++ b/caffe2/python/helpers/conv.py
@@ -38,6 +38,17 @@ def _ConvBase(
     else:
         kernels = [kernel] * 2
 
+    requested_engine = kwargs.get('engine')
+    if requested_engine is not None:
+        if use_cudnn and requested_engine != 'CUDNN':
+            raise ValueError(
+                'When use_cudnn=True, the only engine you can specify is '
+                '"CUDNN"')
+        elif not use_cudnn and requested_engine == 'CUDNN':
+            raise ValueError(
+                'When use_cudnn=False, the only engine you can specify is '
+                '""')
+
     if use_cudnn:
         kwargs['engine'] = 'CUDNN'
         kwargs['exhaustive_search'] = cudnn_exhaustive_search


### PR DESCRIPTION
*Fixes https://github.com/caffe2/caffe2/issues/860*

Raise an exception when the user specifies conflicting values for `engine` and `use_cudnn` in the conv frontend.