### PR TITLE
Tests: handle missing python-lmdb gracefully

### DIFF
--- a/caffe2/python/operator_test/image_input_op_test.py
+++ b/caffe2/python/operator_test/image_input_op_test.py
@@ -6,12 +6,12 @@ from __future__ import unicode_literals
 import unittest
 try:
     import cv2
+    import lmdb
 except ImportError:
     pass  # Handled below
 
 from PIL import Image
 import numpy as np
-import lmdb
 import shutil
 try:
     import StringIO
@@ -199,6 +199,7 @@ def create_test(output_dir, width, height, default_bound,
 
 
 @unittest.skipIf('cv2' not in sys.modules, 'python-opencv is not installed')
+@unittest.skipIf('lmdb' not in sys.modules, 'python-lmdb is not installed')
 class TestImport(hu.HypothesisTestCase):
     @given(size_tuple=st.tuples(
         st.integers(min_value=8, max_value=4096),


### PR DESCRIPTION
Fix issue mentioned here: https://github.com/caffe2/caffe2/commit/875a9850c15f7bbc4466aec6054f25f327793bcd#commitcomment-22773221

Unblocks https://github.com/caffe2/caffe2/pull/817

/cc @tomdz 