### PR TITLE
data_parallel_model: NCCLBroadcast root fix

### DIFF
--- a/caffe2/python/data_parallel_model.py
+++ b/caffe2/python/data_parallel_model.py
@@ -671,10 +671,13 @@ def _Broadcast(devices, model, net, param, use_nccl=False):
         if _IsGPUBlob(model, param):
             master_device_opt = core.DeviceOption(model._device_type, master_dev)
             with core.DeviceScope(master_device_opt):
+                # Note that the root is the root _rank_ and not the root
+                # _device_. Thus we always use root=0, regardless of the
+                # devices used.
                 model.NCCLBroadcast(
                     model._device_grouped_blobs[param].values(),
                     model._device_grouped_blobs[param].values(),
-                    root=master_dev
+                    root=0,
                 )
                 return
 


### PR DESCRIPTION
The root is the root _rank_ and not the root _device_. Thus we always
use root=0, regardless of the devices used.

https://github.com/NVIDIA/nccl/blob/v1.3.0-1/src/broadcast.cu#L75

/cc @slayton58 