### PR TITLE
Tests: fix test_convolution_sync()

### DIFF
--- a/caffe2/python/operator_test/conv_test.py
+++ b/caffe2/python/operator_test/conv_test.py
@@ -418,6 +418,8 @@ class TestConvolution(hu.HypothesisTestCase):
         w = 5
         workspace.ResetWorkspace()
 
+        use_cudnn = (engine == 'CUDNN')
+
         np.random.seed(1701)
         # Build a binary tree of conv layers, summing at each node.
         for i in reversed(range(depth)):
@@ -438,6 +440,7 @@ class TestConvolution(hu.HypothesisTestCase):
                     stride=1,
                     pad=1,
                     deterministic=1,
+                    use_cudnn=use_cudnn,
                     engine=engine)
                 brew.conv(
                     m, bottom_2, mid_2,
@@ -449,6 +452,7 @@ class TestConvolution(hu.HypothesisTestCase):
                     bias_init=('ConstantFill', dict(value=b2)),
                     deterministic=1,
                     cudnn_state=np.random.randint(0, 3),
+                    use_cudnn=use_cudnn,
                     engine=engine)
                 m.net.Sum([mid_1, mid_2], top)
 


### PR DESCRIPTION
This bug in the test was exposed by https://github.com/caffe2/caffe2/pull/861 (previously, the test was always using the cuDNN engine, regardless of the value of `engine`). This bug is now blocking https://github.com/caffe2/caffe2/pull/817.
```
____________________ TestConvolution.test_convolution_sync _____________________
...
            if use_cudnn and requested_engine != 'CUDNN':
                raise ValueError(
>                   'When use_cudnn=True, the only engine you can specify is '
E                   ValueError: When use_cudnn=True, the only engine you can specify is "CUDNN"
```
https://travis-ci.org/caffe2/caffe2/jobs/247605579