### PR TITLE
Tests: fix dpm test when only 1 GPU present

### DIFF
--- a/caffe2/python/data_parallel_model_test.py
+++ b/caffe2/python/data_parallel_model_test.py
@@ -81,7 +81,8 @@ class DataParallelModelTest(TestCase):
         total batchsize, independent of number of GPUs.
         '''
         for gpu in [True, False]:
-            if gpu and not workspace.has_gpu_support:
+            if gpu and (not workspace.has_gpu_support or
+                        workspace.NumCudaDevices() < 2):
                 continue
             result_2gpus = self.run_model([0, 1], gpu=gpu)
             result_1gpus = self.run_model([0], gpu=gpu)


### PR DESCRIPTION
https://github.com/caffe2/caffe2/commit/b33894e95da4a7db0b038b9735714f7e8108a58f removed this line:
```py
@unittest.skipIf(workspace.NumCudaDevices() < 2, "Need at least 2 GPUs.")
```
but forgot to add it back later.
```
_________________________________ DataParallelModelTest.test_equiv __________________________________
...
            if p2p_access_pattern is not None and not p2p_access_pattern[
>               devices[0], peer
            ]:
E           IndexError: index 1 is out of bounds for axis 1 with size 1
...
WARNING:data_parallel_model:** Only 1 GPUs available, GPUs [0, 1] requested
```

/cc @akyrola 