### PR TITLE
Change basename for proto tensor naming to avoid name collision

### DIFF
--- a/caffe2/python/caffe_translator.py
+++ b/caffe2/python/caffe_translator.py
@@ -234,7 +234,7 @@ def _TranslateStridePadKernelHelper(param, caffe_op):
 def TranslateConvNd(layer, pretrained_blobs, is_test):
     param = layer.convolution3d_param
     caffe_op = BaseTranslate(layer, "Conv")
-    output = caffe_op.output[0]
+    output = layer.name
     caffe_op.input.append(output + '_w')
 
     AddArgument(
@@ -269,7 +269,7 @@ def TranslateConvNd(layer, pretrained_blobs, is_test):
 def TranslateConv(layer, pretrained_blobs, is_test):
     param = layer.convolution_param
     caffe_op = BaseTranslate(layer, "Conv")
-    output = caffe_op.output[0]
+    output = layer.name
     caffe_op.input.append(output + '_w')
     _TranslateStridePadKernelHelper(param, caffe_op)
     # weight
@@ -303,7 +303,7 @@ def TranslateDeconv(layer, pretrained_blobs, is_test):
             "Translator currently does not support group deconvolution."
         )
     caffe_op = BaseTranslate(layer, "ConvTranspose")
-    output = caffe_op.output[0]
+    output = layer.name
     _TranslateStridePadKernelHelper(param, caffe_op)
     caffe_op.input.extend([output + '_w', output + '_b'])
     AddArgument(caffe_op, "order", "NCHW")
@@ -407,7 +407,7 @@ def TranslateInnerProduct(layer, pretrained_blobs, is_test):
         # and transpose arguments, so we will silently pass.
         pass
     caffe_op = BaseTranslate(layer, "FC")
-    output = caffe_op.output[0]
+    output = layer.name
     caffe_op.input.extend([output + '_w', output + '_b'])
     # To provide the old-style 4-dimensional blob (1, 1, dim_output, dim_input)
     # case, we always explicitly reshape the pretrained blob.
@@ -486,7 +486,7 @@ def TranslateTanH(layer, pretrained_blobs, is_test):
 @TranslatorRegistry.Register("InstanceNorm")
 def TranslateInstanceNorm(layer, pretrained_blobs, is_test):
     caffe_op = BaseTranslate(layer, "InstanceNorm")
-    output = caffe_op.output[0]
+    output = layer.name
     weight = utils.NumpyArrayToCaffe2Tensor(
         pretrained_blobs[0].flatten(), output + '_w')
     bias = utils.NumpyArrayToCaffe2Tensor(
@@ -499,7 +499,7 @@ def TranslateInstanceNorm(layer, pretrained_blobs, is_test):
 @TranslatorRegistry.Register("BatchNorm")
 def TranslateBatchNorm(layer, pretrained_blobs, is_test):
     caffe_op = BaseTranslate(layer, "SpatialBN")
-    output = caffe_op.output[0]
+    output = layer.name
     param = layer.batch_norm_param
     AddArgument(caffe_op, "is_test", is_test)
     AddArgument(caffe_op, "epsilon", param.eps)
@@ -561,7 +561,7 @@ def TranslateScale(layer, pretrained_blobs, is_test):
         if scale_param.num_axes != 1:
             raise RuntimeError("This path has not been verified yet.")
 
-        output = mul_op.output[0]
+        output = layer.name
         mul_op_param = output + '_w'
         mul_op.input.append(mul_op_param)
         weights = []
@@ -660,7 +660,7 @@ def TranslateROIPooling(layer, pretrained_blobs, is_test):
 @TranslatorRegistry.Register("PReLU")
 def TranslatePRelu(layer, pretrained_blobs, is_test):
     caffe_op = BaseTranslate(layer, "PRelu")
-    output = caffe_op.output[0]
+    output = layer.name
     caffe_op.input.extend([output + '_Slope'])
     slope = utils.NumpyArrayToCaffe2Tensor(pretrained_blobs[0], output + '_Slope')
 


### PR DESCRIPTION
In `caffe_translator.py`, changed the base string used to name parameter tensors to avoid name clashing. This would happen with in-place operators. The script originally used as the base name the layer's output, this strategy caused all layers that had the same output name (which happens for in-place operators) to have the same base parameter name, which in some cases caused name collisions.

More discussion on this issue [here](https://github.com/caffe2/caffe2/issues/468).