### PR TITLE
Update windows.md (python 64 bits)

### DIFF
--- a/_docs/getting-started/windows.md
+++ b/_docs/getting-started/windows.md
@@ -22,7 +22,7 @@ The first thing you want to do is to assess whether or not you're going to use G
 2. [NVIDIA CUDA/cuDNN](https://developer.nvidia.com/cuda-downloads): if you have GPU(s) then go ahead and install
     * [CUDA](https://developer.nvidia.com/cuda-downloads)
     * [cuDNN](https://developer.nvidia.com/cudnn) (registration required; it is a zip file, not installer, so you need to copy the contents of the zip file to the cuda folder which is `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v8.0` by default)
-3. Python 2.7.6 to [Python 2.7.13](https://www.python.org/download/releases/python-2713/). Python version 3+ is not yet supported. You can use regular Python or Anaconda Python. Just note that you many have issues with package location and versioning with Anaconda. Some Anaconda notes are provided below the Regular Python notes.
+3. Python 2.7.6 to [Python 2.7.13](https://www.python.org/download/releases/python-2713/). Python version 3+ is not yet supported. You can use regular Python or Anaconda Python. Just note that you many have issues with package location and versioning with Anaconda. Some Anaconda notes are provided below the Regular Python notes. Take care to install the 64 bits version of Python, since we will be going to compile for 64 bits.
 4. Install a C++ compiler such as [Visual Studio Community Edition 2017](https://www.visualstudio.com/vs/community/)
     * When installing VS 2017, install Desktop Development with C++ (on the right check: C++/CLI support)
 5. Install [Cmake](http://cmake.org)
@@ -33,7 +33,7 @@ The first thing you want to do is to assess whether or not you're going to use G
 
 ### Regular Python Install
 
-Install [Python 2.7.13](https://www.python.org/download/releases/python-2713/) and [Microsoft Visual C++ Compiler for Python 2.7](http://aka.ms/vcpython27).
+Install [Python 2.7.13 (x86-64)](https://www.python.org/download/releases/python-2713/) and [Microsoft Visual C++ Compiler for Python 2.7](http://aka.ms/vcpython27).
 
 Assuming you have already added `C:\Python27` and `C:\Python27\scripts` to your Path environment variable, you can go ahead and use pip to install the Python dependencies.
 


### PR DESCRIPTION
Added notice to download the 64 bits version of Python since the windows build scripts build for 64 bits and the python module cannot be linked to the 32 bits python library.