### PR TITLE
Easier compilation with python3 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ option(USE_TRANSFORMS "Use Graph Transforms" OFF)
 option(BUILD_SHARED_LIBS "Build libcaffe2.so" ON)
 option(USE_OPENMP "Use OpenMP for parallel code" ON)
 option(BUILD_PYTHON "Build Python binaries" ON)
+option(PYTHON "Python to use" "")
 option(BUILD_BINARY "Build C++ binaries" ON)
 
 # External projects

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,13 @@
 version: '{build}'
 clone_folder: c:\projects\caffe2
 environment:
-  PYTHON: python3
   matrix:
   
     - USE_CUDA: OFF
+      PYTHON: python3
       CMAKE_BUILD_TYPE: Release
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       
-    
-
     # Building CUDA with Visual Studio 2017 is yet to be supported by
     # NVidia, so we canot enable it right now.
     #- USE_CUDA: ON

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,12 @@ environment:
     - USE_CUDA: OFF
       CMAKE_BUILD_TYPE: Release
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      
+    # python3
+    - USE_CUDA: OFF
+      PYTHON: python3
+      CMAKE_BUILD_TYPE: Release
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     # Building CUDA with Visual Studio 2017 is yet to be supported by
     # NVidia, so we canot enable it right now.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,20 @@
 version: '{build}'
 clone_folder: c:\projects\caffe2
 environment:
-  - PYTHON: python3
   matrix:
+  
+    - TEST: HELLOWORLD
+    
+    - USE_CUDA: OFF
+      PYTHON: python3
+      CMAKE_BUILD_TYPE: Release
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  
     - USE_CUDA: OFF
       CMAKE_BUILD_TYPE: Release
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      
+    
 
     # Building CUDA with Visual Studio 2017 is yet to be supported by
     # NVidia, so we canot enable it right now.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,9 @@
 version: '{build}'
 clone_folder: c:\projects\caffe2
 environment:
+  - PYTHON: python3
   matrix:
     - USE_CUDA: OFF
-      CMAKE_BUILD_TYPE: Release
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      
-    # python3
-    - USE_CUDA: OFF
-      PYTHON: python3
       CMAKE_BUILD_TYPE: Release
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,8 @@
 version: '{build}'
 clone_folder: c:\projects\caffe2
 environment:
+  PYTHON: python3
   matrix:
-  
-    - TEST: HELLOWORLD
-    
-    - USE_CUDA: OFF
-      PYTHON: python3
-      CMAKE_BUILD_TYPE: Release
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
   
     - USE_CUDA: OFF
       CMAKE_BUILD_TYPE: Release

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -209,18 +209,29 @@ endif()
 # ---[ Python + Numpy
 
 if(BUILD_PYTHON)
-  if (NOT DEFINED PYTHON)
-    set(PYTHON "python")
-  endif()
-  # Get the full path to executable
-  execute_process(
+  set(found OFF)
+  if (DEFINED PYTHON)
+    # Get the full path to executable
+    execute_process(
     COMMAND  
-    ${PYTHON} -c "import sys; print(sys.executable)"
-    OUTPUT_VARIABLE PYTHON_EXECUTABLE
-    RESULT_VARIABLE result
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
+      ${PYTHON} -c "import sys; print(sys.executable)"
+      OUTPUT_VARIABLE PYTHON_EXECUTABLE
+      RESULT_VARIABLE result
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  else()
+    execute_process(
+    COMMAND  
+      ${PYTHON_EXECUTABLE} --version
+      RESULT_VARIABLE result
+    )
+  endif()
   if(${result} MATCHES "0")
+    set(found ON)
+  else()
+    set(found OFF)
+  endif()
+  if(found)
     # Get version major
     execute_process(
     COMMAND  

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -218,12 +218,14 @@ if(BUILD_PYTHON)
       RESULT_VARIABLE result
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-  else()
+  elseif(DEFINED PYTHON_EXECUTABLE)
     execute_process(
     COMMAND  
       ${PYTHON_EXECUTABLE} --version
       RESULT_VARIABLE result
     )
+  else()
+    message(FATAL_ERROR "PYTHON_EXECUTABLE not set!")
   endif()
   if(${result} MATCHES "0")
     set(found ON)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -207,10 +207,9 @@ else()
 endif()
 
 # ---[ Python + Numpy
-
 if(BUILD_PYTHON)
   set(found OFF)
-  if (DEFINED PYTHON)
+  if (DEFINED PYTHON AND NOT "${PYTHON}" STREQUAL "")
     # Get the full path to executable
     execute_process(
     COMMAND  
@@ -260,7 +259,7 @@ if(BUILD_PYTHON)
       set(BUILD_PYTHON OFF)
     endif()
   else()
-    message(FATAL_ERROR "Specified PYTHON not found: ${PYTHON}")
+    message(FATAL_ERROR "Specified PYTHON not found: [${PYTHON}]")
     set(BUILD_PYTHON OFF)
   endif()
   

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -47,6 +47,7 @@ cmake .. ^
   -DBUILD_SHARED_LIBS=OFF ^
   -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^
   -DUSE_CUDA=%USE_CUDA% ^
+  -DPYTHON=%PYTHON% ^
   -DPROTOBUF_PROTOC_EXECUTABLE=%CAFFE2_ROOT%\build_host_protoc\bin\protoc.exe ^
   || exit /b
 


### PR DESCRIPTION
Currently, in order to use python3, you have to pass in the location of the executable and the library. While these locations are easily found, they are platform and version specific. For example, on Ubuntu Linux:
cmake .. 
-DPYTHON_EXECUTABLE=usr/bin/python3 
-DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.5m.so

This PR adds the option of specifying just the python command:
cmake .. -DPYTHON=python3
or 
cmake .. -DPYTHON=python3.5

This means that this command is platform dependent, and the former is version independent (it will point to the prefered python3 version, usually the latest version installed).

The basic premise is to use the provided interpreter to get the executable and version. Providing cmake with the exact version ensures that python3 is not substituted for python2 simply because it is a later version.

Tested on Ubuntu 16.04
Should work on Windows and Mac as well.
