### PR TITLE
Some adjustments for Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ include_directories(BEFORE ${PROJECT_BINARY_DIR})
 
 # ---[ Third party builds.
 include_directories(${PROJECT_SOURCE_DIR})
+include_directories(${PROJECT_SOURCE_DIR}/build_host_protoc/include)
 
 # ---[ Old caffe protobuf.
 add_subdirectory(caffe/proto)

--- a/scripts/build_host_protoc.bat
+++ b/scripts/build_host_protoc.bat
@@ -8,13 +8,17 @@
 :: After the execution of the file, one should be able to find the host protoc
 :: binary at build_host_protoc/bin/protoc.exe.
 
-@echo on
+@echo off
 
 SET ORIGINAL_DIR=%cd%
 SET CAFFE2_ROOT=%~dp0%..
+
+if NOT DEFINED CMAKE_BUILD_TYPE (
+  set CMAKE_BUILD_TYPE=Release
+)
+
 if not exist %CAFFE2_ROOT%\build_host_protoc mkdir %CAFFE2_ROOT%\build_host_protoc
 echo "Created %CAFFE2_ROOT%\build_host_protoc"
-
 cd %CAFFE2_ROOT%\build_host_protoc
 
 if NOT DEFINED CMAKE_GENERATOR (
@@ -30,18 +34,31 @@ if NOT DEFINED CMAKE_GENERATOR (
     )
   ) else (
   	:: In default we use win64 VS 2017.
-  	set CMAKE_GENERATOR="Visual Studio 15 2017 Win64"
+  	set CMAKE_GENERATOR="Visual Studio 14 2015 Win64"
   )
 )
 
+echo CAFFE2_ROOT=%CAFFE2_ROOT%
+echo CMAKE_GENERATOR=%CMAKE_GENERATOR%
+echo CMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%
+
+echo "Generating cmake"
 cmake ..\third_party\protobuf\cmake ^
   -G%CMAKE_GENERATOR% ^
   -DCMAKE_INSTALL_PREFIX=. ^
   -Dprotobuf_BUILD_TESTS=OFF ^
-  -DCMAKE_BUILD_TYPE=Debug ^
-  || exit /b
+  -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^
+  || goto :label_error
 
 :: Actually run the build
-msbuild INSTALL.vcxproj
+echo "Building protobuf"
+cmake --build . --config %CMAKE_BUILD_TYPE% --target INSTALL || goto :label_error
 
+echo "protobuf built successfully"
 cd %ORIGINAL_DIR%
+exit /b 0
+
+:label_error
+echo "protobuf building failed"
+cd %ORIGINAL_DIR%
+exit /b 1

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -4,14 +4,14 @@
 
 :: This script shows how one can build a Caffe2 binary for windows.
 
-@echo on
+@echo off
 
 SET ORIGINAL_DIR=%cd%
 SET CAFFE2_ROOT=%~dp0%..
-if not exist %CAFFE2_ROOT%\build_host_protoc\bin\protoc.exe call %CAFFE2_ROOT%\scripts\build_host_protoc.bat
 
-if not exist %CAFFE2_ROOT%\build mkdir %CAFFE2_ROOT%\build
-cd %CAFFE2_ROOT%\build
+if NOT DEFINED CMAKE_BUILD_TYPE (
+  set CMAKE_BUILD_TYPE=Release
+)
 
 if NOT DEFINED USE_CUDA (
   set USE_CUDA=OFF
@@ -34,9 +34,20 @@ if NOT DEFINED CMAKE_GENERATOR (
     )
   ) else (
     :: In default we use win64 VS 2017.
-    set CMAKE_GENERATOR="Visual Studio 15 2017 Win64"
+    set CMAKE_GENERATOR="Visual Studio 14 2015 Win64"
   )
 )
+
+if not exist %CAFFE2_ROOT%\build_host_protoc\bin\protoc.exe call %CAFFE2_ROOT%\scripts\build_host_protoc.bat || goto :label_error
+
+echo CAFFE2_ROOT=%CAFFE2_ROOT%
+echo CMAKE_GENERATOR=%CMAKE_GENERATOR%
+echo CMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%
+
+if not exist %CAFFE2_ROOT%\build mkdir %CAFFE2_ROOT%\build
+cd %CAFFE2_ROOT%\build
+
+SET Protobuf_DIR=%CAFFE2_ROOT%\build_host_protoc\cmake
 
 :: Set up cmake. We will skip building the test files right now.
 :: TODO: enable cuda support.
@@ -47,10 +58,26 @@ cmake .. ^
   -DBUILD_SHARED_LIBS=OFF ^
   -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^
   -DUSE_CUDA=%USE_CUDA% ^
+  -DUSE_NNPACK=OFF ^
+  -DUSE_GLOG=OFF ^
+  -DUSE_GFLAGS=OFF ^
+  -DUSE_LMDB=OFF ^
+  -DUSE_LEVELDB=OFF ^
+  -DUSE_ROCKSDB=OFF ^
+  -DUSE_OPENCV=OFF ^
+  -DBUILD_SHARED_LIBS=OFF ^
+  -DBUILD_PYTHON=OFF^
   -DPROTOBUF_PROTOC_EXECUTABLE=%CAFFE2_ROOT%\build_host_protoc\bin\protoc.exe ^
-  || exit /b
+  || goto :label_error
 
 :: Actually run the build
-cmake --build . --config %CMAKE_BUILD_TYPE% || exit /b
+cmake --build . --config %CMAKE_BUILD_TYPE% || goto :label_error
 
+echo "Caffe2 built successfully"
 cd %ORIGINAL_DIR%
+exit /b 0
+
+:label_error
+echo "Caffe2 building failed"
+cd %ORIGINAL_DIR%
+exit /b 1


### PR DESCRIPTION
1. switch the protoc building system from msbuild to cmake
2. set default CMAKE_GENERATE to VS2015
3. set default CMAKE_BUILD_TYPE to Release
4. improve error handling
5. add the generated protobuf include path
6. exclude many optional dependencies from build_windows.bat