### PR TITLE
updated downloader to use s3 url without a redirect via the vanity url

### DIFF
--- a/caffe2/python/models/download.py
+++ b/caffe2/python/models/download.py
@@ -21,7 +21,8 @@ except ImportError:
     HTTPError = urllib.HTTPError
     URLError = urllib.URLError
 
-DOWNLOAD_BASE_URL = "https://s3.amazonaws.com/caffe2/models/"
+# urllib requires more work to deal with a redirect, so not using vanity url
+DOWNLOAD_BASE_URL = "https://s3.amazonaws.com/download.caffe2.ai/models/"
 DOWNLOAD_COLUMNS = 70
 
 


### PR DESCRIPTION
Model downloader was broken after the move on s3 to the vanity url, download.caffe2.ai. Using this as the url base hits a redirect, and will result in the script throwing a 403 error.  Rather than upgrading to urllib2 or putting in a bunch of code to handle a redirect on urllib, we can just use the non-vanity base url.