### PR TITLE
Always use assertAlmostEqual for floats when crossing python and C boundaries

### DIFF
--- a/caffe2/python/optimizer_test.py
+++ b/caffe2/python/optimizer_test.py
@@ -244,7 +244,7 @@ class TestOptimizerContext(TestCase):
                 for arg in op.arg:
                     if arg.name == 'base_lr':
                         val = arg.f
-                self.assertEqual(
+                self.assertAlmostEqual(
                     val,
                     expected_learning_rate[op.output[0]]
                 )


### PR DESCRIPTION
This fixes travis numerical issue.