### PR TITLE
Bump travis osx to 8.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,15 @@ matrix:
   include:
     - env: BUILD=osx
       os: osx
+      osx_image: xcode8.3
       compiler: clang
     - env: BUILD=osx-ios
       os: osx
-      osx_image: xcode8.1
+      osx_image: xcode8.3
       compiler: clang
     - env: BUILD=osx-android
       os: osx
-      osx_image: xcode8.1
+      osx_image: xcode8.3
       compiler: clang
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,11 @@ matrix:
       compiler: clang
     - env: BUILD=osx-ios
       os: osx
+      osx_image: xcode8.1
       compiler: clang
     - env: BUILD=osx-android
       os: osx
+      osx_image: xcode8.1
       compiler: clang
 
 cache:


### PR DESCRIPTION
This is needed for metal build.

Note that for older xcode (7.3), right now ios build fails due to not having metal headers. We will require xcode 8.0 onwards now.