### PR TITLE
Add a new operator mocks numpy.flip

### DIFF
--- a/caffe2/operators/flip_op.cc
+++ b/caffe2/operators/flip_op.cc
@@ -1,0 +1,94 @@
+#include "caffe2/operators/flip_op.h"
+
+namespace caffe2 {
+
+  template <>
+  template <typename T>
+  bool FlipOp<CPUContext>::DoRunWithType() {
+    const auto& input = Input(0);
+    auto* output = Output(0);
+    size_t count = input.size();
+    int num_axes = axes_.size();
+    CAFFE_ENFORCE(OperatorBase::HasArgument("axes"), "argument axes is missing");
+    const T* from_data = input.template data<T>();
+    T* to_data = output->template mutable_data<T>();
+    auto in_dims = input.dims();
+
+    // Measure amount of contiguous data we can copy at once
+    // Suppose input.dims()=(N,C,H,W),
+    //   if axes=(1,) or (0,1) then blocksize = H * W
+    //   if axes=(2,) or (1,2) or (0,1,2) then blocksize = W
+    //   if axes=(3,) or (2,3) or (1,2,3) or (0,1,2,3) then blocksize = 1
+    // Calculate stride
+    //   if axes=(1,) or (1,2) or (1,2,3) then stride = C or C * H or C * H * W
+    //   if axes=(2,) or (2,3) then stride = H or H * W
+    //   if axes=(3,) then stride = W
+    TIndex blocksize = 1;
+    TIndex stride = 1;
+    for (int i = input.ndim() - 1; i >= 0; --i) {
+      if (axes_[num_axes - 1] < i) {
+        blocksize *= in_dims[i];
+      }
+      else if (axes_[0] <= i) {
+        stride *= in_dims[i];
+      }
+      else {
+        break;
+      }
+    }
+
+    // Now, for every stride, reverse data in blocksize
+    // Branch here to avoid branching within the loop
+    if (blocksize > 1) {
+      for (size_t index = 0; index < (count / blocksize); index += stride) {
+        for (size_t i = 0; i < stride; i++) {
+          memcpy(
+            to_data + blocksize * (index + i),
+            from_data + blocksize * (index + stride - 1 - i),
+            blocksize * sizeof(T));
+        }
+      }
+    }
+    else {
+      for (size_t index = 0; index < count; index += stride) {
+        for (size_t i = 0; i < stride; i++) {
+          *(to_data + index + i) = *(from_data + index + stride - 1 - i);
+        }
+      }
+    }
+
+    return true;
+  }
+
+  namespace {
+    REGISTER_CPU_OPERATOR(Flip, FlipOp<CPUContext>);
+
+    OPERATOR_SCHEMA(Flip)
+      .NumInputs(1)
+      .NumOutputs(1)
+      .IdenticalTypeAndShapeOfInput(0)
+      .SetDoc(R"DOC(
+Flip the input tensor similar to numpy.flip. For example, when axes=(3,), 
+given an input tensor M of shape (N, C, H, W), the output will be 
+similar as numpy.flip(M, 3). And when axes=(2,), the output will be
+similar as numpy.flip(M, 2).
+)DOC")
+      .Arg(
+        "axes",
+        "A list of integers. Mandatory."
+        "Flip the axes according to the values given.")
+      .Input(0, "data", "An input tensor.")
+      .Output(0, "flipped", "Flipped output tensor.");
+
+    class GetFlipGradient : public GradientMakerBase {
+      using GradientMakerBase::GradientMakerBase;
+      vector<OperatorDef> GetGradientDefs() override {
+        auto ops = SingleGradientDef(
+          "Flip", "", vector<string>{GO(0)}, vector<string>{GI(0)});
+        ops[0].mutable_arg()->CopyFrom(Def().arg());
+        return ops;
+      }
+    };
+    REGISTER_GRADIENT(Flip, GetFlipGradient);
+  } // namespace
+} // namespace caffe2

--- a/caffe2/operators/flip_op.h
+++ b/caffe2/operators/flip_op.h
@@ -1,0 +1,49 @@
+#ifndef CAFFE2_OPERATORS_FLIP_OP_H_
+#define CAFFE2_OPERATORS_FLIP_OP_H_
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/operator.h"
+
+namespace caffe2 {
+
+  template <class Context>
+  class FlipOp final : public Operator<Context> {
+  public:
+    USE_OPERATOR_CONTEXT_FUNCTIONS;
+    USE_DISPATCH_HELPER;
+    FlipOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws),
+      axes_(OperatorBase::GetRepeatedArgument<int>("axes")) {
+      // We will check the legality of axes_: it should be continuous and
+      // monotonous increasing between 0 and X.ndim().
+      // legal: (1,), (2,3) and (0,1,2)
+      // illegal: (-1,0,1), (1,3) and (4,) when only 4 dimension
+      CAFFE_ENFORCE(OperatorBase::HasArgument("axes"), "Argument `axes` is missing");
+      CAFFE_ENFORCE(axes_.size() > 0, "Argument `axes` is missing");
+      CAFFE_ENFORCE(axes_[0] >= 0, "Argument `axes` has invalid dimension:", axes_[0]);
+      for (int i = 1; i < axes_.size(); ++i) {
+        CAFFE_ENFORCE(axes_[i] == axes_[0] + i, "Argument `axes` has invalid dimension:", axes_[i]);
+      }
+      //CAFFE_ENFORCE(axes_[axes_.size()-1] < X.ndim(), "Argument `axes` has invalid dimension:", axes_[axes_.size()-1]);
+    }
+    ~FlipOp() {}
+
+    bool RunOnDevice() override {
+      const auto& X = Input(0);
+      auto* Y = Output(0);
+      Y->ResizeLike(X);
+      // Do the actual flip, which is implemented in DoRunWithType().
+      return DispatchHelper<TensorTypes<float, double, int, long>>::call(
+        this, Input(0));
+    }
+
+  protected:
+    template <typename T>
+    bool DoRunWithType();
+
+    std::vector<int> axes_;
+  };
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_FLIP_OP_H_

--- a/caffe2/python/operator_test/flip_op_test.py
+++ b/caffe2/python/operator_test/flip_op_test.py
@@ -1,0 +1,106 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from caffe2.python import core
+from hypothesis import given
+import hypothesis.strategies as st
+import caffe2.python.hypothesis_test_util as hu
+import numpy as np
+from caffe2.proto import caffe2_pb2
+
+import unittest
+
+
+class TestFlip(hu.HypothesisTestCase):
+
+    @given(N=st.sampled_from([2,3]),
+           C=st.sampled_from([3,5]),
+           H=st.sampled_from([5,8]),
+           W=st.sampled_from([8,13]),
+           engine=st.sampled_from([None]), # CPU only by now
+           **hu.gcs)
+    def test_flip(self, N, C, H, W, engine, gc, dc):
+        X = np.random.rand(N, C, H, W).astype(np.float32)
+
+        op = core.CreateOperator("Flip", ["X"], ["Y"], axes=(3,), engine=engine)
+        
+        def ref_fliplr(X):
+            return [np.flip(X, 3)]
+
+        self.assertReferenceChecks(
+            device_option=core.DeviceOption(caffe2_pb2.CPU, 0), # CPU only by now
+            op=op,
+            inputs=[X],
+            reference=ref_fliplr,
+        )
+
+    @given(N=st.sampled_from([2,3]),
+           C=st.sampled_from([3,5]),
+           H=st.sampled_from([5,8]),
+           W=st.sampled_from([8,13]),
+           engine=st.sampled_from([None]), # CPU only by now
+           **hu.gcs)
+    def test_flip2(self, N, C, H, W, engine, gc, dc):
+        X = np.random.rand(N, C, H, W).astype(np.float32)
+
+        op = core.CreateOperator("Flip", ["X"], ["Y"], axes=(2,), engine=engine)
+
+
+        def ref_flipud(X):
+            return [np.flip(X, 2)]
+
+        self.assertReferenceChecks(
+            device_option=core.DeviceOption(caffe2_pb2.CPU, 0), # CPU only by now
+            op=op,
+            inputs=[X],
+            reference=ref_flipud,
+        )
+
+    @given(N=st.sampled_from([2,3]),
+           C=st.sampled_from([3,5]),
+           H=st.sampled_from([5,8]),
+           W=st.sampled_from([8,13]),
+           engine=st.sampled_from([None]), # CPU only by now
+           **hu.gcs)
+    def test_flip3(self, N, C, H, W, engine, gc, dc):
+        X = np.random.rand(N, C, H, W).astype(np.float32)
+
+        op = core.CreateOperator("Flip", ["X"], ["Y"], axes=(2,3), engine=engine)
+
+
+        def ref_flipud(X):
+            return [np.flip(np.flip(X, 3), 2)]
+
+        self.assertReferenceChecks(
+            device_option=core.DeviceOption(caffe2_pb2.CPU, 0), # CPU only by now
+            op=op,
+            inputs=[X],
+            reference=ref_flipud,
+        )
+
+    @given(N=st.sampled_from([2,3]),
+           C=st.sampled_from([3,5]),
+           H=st.sampled_from([5,8]),
+           W=st.sampled_from([8,13]),
+           engine=st.sampled_from([None]), # CPU only by now
+           **hu.gcs)
+    def test_flip4(self, N, C, H, W, engine, gc, dc):
+        X = np.random.rand(N, C, H, W).astype(np.float32)
+
+        op = core.CreateOperator("Flip", ["X"], ["Y"], axes=(0,1,2), engine=engine)
+
+
+        def ref_flipud(X):
+            return [np.flip(np.flip(np.flip(X, 2), 1), 0)]
+
+        self.assertReferenceChecks(
+            device_option=core.DeviceOption(caffe2_pb2.CPU, 0), # CPU only by now
+            op=op,
+            inputs=[X],
+            reference=ref_flipud,
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Flip the input tensor similar to numpy.flip. For example, when axes=(3,), 
given an input tensor M of shape (N, C, H, W), the output will be 
similar as numpy.flip(M, 3). And when axes=(2,), the output will be
similar as numpy.flip(M, 2).