### PR TITLE
Removed CNMEM git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "third_party/nccl"]
 	path = third_party/nccl
 	url = https://github.com/nvidia/nccl.git
-[submodule "third_party/cnmem"]
-	path = third_party/cnmem
-	url = https://github.com/nvidia/cnmem.git
 [submodule "third_party/cub"]
 	path = third_party/cub
 	url = https://github.com/NVlabs/cub.git


### PR DESCRIPTION
CNMEM was deprecated by commit c59f291 and is not used anymore by
Caffe2. It was superseded by CUB.

The git submodule can now be removed.