### PR TITLE
Fix more MKL build issues

### DIFF
--- a/caffe2/contrib/nnpack/nnpack_ops.cc
+++ b/caffe2/contrib/nnpack/nnpack_ops.cc
@@ -1,6 +1,9 @@
+#include "caffe2/core/common.h"
+
 #ifdef CAFFE2_USE_MKL
 #include <mkl.h>
 #endif
+
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"

--- a/caffe2/core/init_omp.cc
+++ b/caffe2/core/init_omp.cc
@@ -1,5 +1,7 @@
 #include <stdlib.h>
 
+#include "caffe2/core/common.h"
+
 #ifdef _OPENMP
 #include "caffe2/core/common_omp.h"
 #endif  // _OPENMP

--- a/caffe2/mkl/mkl_utils.h
+++ b/caffe2/mkl/mkl_utils.h
@@ -1,5 +1,8 @@
 #ifndef CAFFE2_UTILS_MKL_UTILS_H_
 #define CAFFE2_UTILS_MKL_UTILS_H_
+
+#include "caffe2/core/macros.h"  // For caffe2 macros.
+
 #ifdef CAFFE2_USE_MKL
 
 #include "caffe2/mkl/utils/mkl_version_check.h"

--- a/caffe2/utils/cblas.h
+++ b/caffe2/utils/cblas.h
@@ -1,6 +1,8 @@
 // This is the exact cblas.h header file, placed here purely in order to get
 // the enums.
 
+#include "caffe2/core/macros.h"
+
 #ifndef CBLAS_H
 #ifdef CAFFE2_USE_MKL
 #include <mkl_cblas.h>

--- a/caffe2/utils/math_cpu.cc
+++ b/caffe2/utils/math_cpu.cc
@@ -17,15 +17,15 @@
 #include <random>
 #include <unordered_set>
 
-#ifdef CAFFE2_USE_MKL
-#include <mkl.h>
-#endif  // CAFFE2_USE_MKL
-
 #include "caffe2/utils/math.h"
 #include "caffe2/utils/cpu_neon.h"
 #include "caffe2/core/context.h"
 #include "Eigen/Core"
 #include "Eigen/Dense"
+
+#ifdef CAFFE2_USE_MKL
+#include <mkl.h>
+#endif  // CAFFE2_USE_MKL
 
 #if defined(_MSC_VER)
 #include <process.h>


### PR DESCRIPTION
Turns out that due to the cmake improvement by @lukeyeager , we now no longer rely on compiler flags but on the macros.h file to obtain CAFFE2_USE_MKL. This requires some minor changes in the MKL implementation to properly capture the macro before testing it.