### PR TITLE
fix build error in workersthread.h

### DIFF
--- a/caffe2/utils/threadpool/WorkersPool.h
+++ b/caffe2/utils/threadpool/WorkersPool.h
@@ -361,7 +361,7 @@ class WorkersPool {
     assert(workers_count <= workers_.size());
     counter_to_decrement_when_ready_.Reset(workers_count);
     int n = 0;
-    std::for_each(++tasks.begin(), tasks.end(), [this, &n](auto& task) {
+    std::for_each(++tasks.begin(), tasks.end(), [this, &n](const std::shared_ptr<Task>& task) {
       workers_[n++]->StartWork(task.get());
     });
     // Execute the remaining workload immediately on the current thread.


### PR DESCRIPTION
    According #1135, fix error in C++11, because using auto as a parameter of lambda is supported by c++14. In order to build in c++11, it should declare with type.