### PR TITLE
Include Caffe2 headers before anything else

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,12 +116,17 @@ if (CAFFE2_CPU_FLAGS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CAFFE2_CPU_FLAGS}")
 endif()
 
-# ---[ Include path needed for proto
-include_directories(BEFORE ${PROJECT_BINARY_DIR})
+# Prefix path to Caffe2 headers.
+# If a directory containing installed Caffe2 headers was inadvertently
+# added to the list of include directories, prefixing
+# PROJECT_SOURCE_DIR means this source tree always takes precedence.
+include_directories(BEFORE ${PROJECT_SOURCE_DIR})
+include_directories(BEFORE ${PROJECT_SOURCE_DIR}/build_host_protoc/include)
 
-# ---[ Third party builds.
-include_directories(${PROJECT_SOURCE_DIR})
-include_directories(${PROJECT_SOURCE_DIR}/build_host_protoc/include)
+# Prefix path to generated Caffe2 headers.
+# These need to take precedence over their empty counterparts located
+# in PROJECT_SOURCE_DIR.
+include_directories(BEFORE ${PROJECT_BINARY_DIR})
 
 # ---[ Old caffe protobuf.
 add_subdirectory(caffe/proto)


### PR DESCRIPTION
This was a tricky one to debug. After pulling from master, my build
was complaining that certain identifiers in updated source files were
undefined. After building with VERBOSE=1, extracting the compilation
commands, and adding -M, I saw that CMake had included the Caffe2
installation directory as include path. Worse yet, this path had
precedence over the path to the actual source code. The compiler
included older headers when compiling newer source files.

This change forces the path to the Caffe2 source code to take
precedence over all other include paths. The only path that takes
precedence over *that* path is PROJECT_BINARY_DIR, which holds the
headers that are generated at compile time.