### PR TITLE
tests: don't test SparseLengthsSum with fp16+CUDA

### DIFF
--- a/caffe2/python/operator_test/specialized_segment_ops_test.py
+++ b/caffe2/python/operator_test/specialized_segment_ops_test.py
@@ -11,6 +11,9 @@ import numpy as np
 import unittest
 import random
 
+from hypothesis import assume
+from caffe2.proto import caffe2_pb2
+
 
 class TestSpecializedSegmentOps(hu.HypothesisTestCase):
     @given(nseg=st.integers(1, 20),
@@ -19,6 +22,8 @@ class TestSpecializedSegmentOps(hu.HypothesisTestCase):
            bs=st.sampled_from([8, 17, 32, 64, 85, 96, 128, 163]), **hu.gcs)
     def test_sparse_lengths_sum_cpu_fp32(
             self, nseg, fptype, fp16asint, bs, gc, dc):
+        # the CUDA op does not currently support fp16
+        assume(not gc.device_type == caffe2_pb2.CUDA and fptype == np.float16)
 
         tblsize = 300
         if fptype == np.float32:


### PR DESCRIPTION
Fixes issue reported here: https://github.com/caffe2/caffe2/commit/8cbea8d3cae011467978d18e0a667cf53eb6319c#commitcomment-23958756

/cc @dzhulgakov