### PR TITLE
Tidy up CMake for NCCL

### DIFF
--- a/cmake/External/nccl.cmake
+++ b/cmake/External/nccl.cmake
@@ -30,7 +30,6 @@ if (NOT __NCCL_INCLUDED)
     set(NCCL_FOUND TRUE)
     set(NCCL_INCLUDE_DIRS ${nccl_PREFIX}/build/include)
     set(NCCL_LIBRARIES ${nccl_PREFIX}/build/lib/libnccl_static.a)
-    set(NCCL_LIBRARY_DIRS ${nccl_PREFIX}/build/lib)
     set(NCCL_EXTERNAL TRUE)
 
     list(APPEND Caffe2_EXTERNAL_DEPENDENCIES nccl_external)

--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -7,28 +7,29 @@
 #  NCCL_FOUND
 #  NCCL_INCLUDE_DIRS
 #  NCCL_LIBRARIES
-#  NCCL_LIBRARYRARY_DIRS
 
-include(FindPackageHandleStandardArgs)
-
-# TODO(slayton): Do this properly
-# set(NCCL_ROOT_DIR "/home/slayton/git/nccl/build" CACHE PATH "Folder contains NVIDIA NCCL")
 set(NCCL_ROOT_DIR "" CACHE PATH "Folder contains NVIDIA NCCL")
 
-find_path(NCCL_INCLUDE_DIR nccl.h
-    PATHS ${NCCL_ROOT_DIR}
-    PATH_SUFFIXES include)
+find_path(NCCL_INCLUDE_DIR
+  NAMES nccl.h
+  HINTS
+  ${NCCL_ROOT_DIR}
+  ${NCCL_ROOT_DIR}/include)
 
-find_library(NCCL_LIBRARY nccl
-    PATHS ${NCCL_ROOT_DIR}
-    PATH_SUFFIXES lib lib64)
+find_library(NCCL_LIBRARY
+  NAMES nccl
+  HINTS
+  ${NCCL_ROOT_DIR}
+  ${NCCL_ROOT_DIR}/lib
+  ${NCCL_ROOT_DIR}/lib/x86_64-linux-gnu
+  ${NCCL_ROOT_DIR}/lib64)
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(NCCL DEFAULT_MSG NCCL_INCLUDE_DIR NCCL_LIBRARY)
 
 if(NCCL_FOUND)
   set(NCCL_INCLUDE_DIRS ${NCCL_INCLUDE_DIR})
   set(NCCL_LIBRARIES ${NCCL_LIBRARY})
-  message(STATUS "Found NCCL    (include: ${NCCL_INCLUDE_DIR}, library: ${NCCL_LIBRARY})")
-  mark_as_advanced(NCCL_ROOT_DIR NCCL_LIBRARY_RELEASE NCCL_LIBRARY_DEBUG
-                                 NCCL_LIBRARY NCCL_INCLUDE_DIR)
+  message(STATUS "Found NCCL (include: ${NCCL_INCLUDE_DIRS}, library: ${NCCL_LIBRARIES})")
+  mark_as_advanced(NCCL_ROOT_DIR NCCL_INCLUDE_DIRS NCCL_LIBRARIES)
 endif()


### PR DESCRIPTION
Use HINTS instead of PATHS for find_library so that you can specify
-DNCCL_ROOT_DIR and it will use this NCCL installation regardless of
what else is installed on your system. Also add a path hint to include
the default base path for NCCL 2 libraries.