### PR TITLE
fp16: add test for FC

### DIFF
--- a/caffe2/python/operator_test/fc_operator_test.py
+++ b/caffe2/python/operator_test/fc_operator_test.py
@@ -3,8 +3,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from caffe2.proto import caffe2_pb2
 from caffe2.python import core
-from hypothesis import given
+from hypothesis import assume, given, settings
 import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
 import numpy as np
@@ -12,17 +13,34 @@ import numpy as np
 
 class TestFcOperator(hu.HypothesisTestCase):
 
-    @given(n=st.integers(1, 5), m=st.integers(0, 5),
+    @settings(max_examples=50)
+    @given(n=st.integers(1, 5),
+           m=st.integers(0, 5),
            k=st.integers(1, 5),
            multi_dim=st.sampled_from([True, False]),
+           dtype=st.sampled_from([np.float32, np.float16]),
+           engine=st.sampled_from(['', 'TENSORCORE']),
            **hu.gcs)
-    def test_fc(self, n, m, k, multi_dim, gc, dc):
-        X = np.random.rand(m, k).astype(np.float32) - 0.5
+    def test_fc(self, n, m, k, multi_dim, dtype, engine, gc, dc):
+        if dtype == np.float16:
+            # fp16 only supported with CUDA
+            assume(gc.device_type == caffe2_pb2.CUDA)
+            dc = [d for d in dc if d.device_type == caffe2_pb2.CUDA]
+
+        if engine == 'TENSORCORE':
+            # TensorCore only makes sense with CUDA
+            assume(gc.device_type == caffe2_pb2.CUDA)
+            # ensures TensorCore kernels can be called
+            m *= 8
+            k *= 8
+            n *= 8
+
+        X = np.random.rand(m, k).astype(dtype) - 0.5
         if multi_dim:
-            W = np.random.rand(n, k, 1, 1).astype(np.float32) - 0.5
+            W = np.random.rand(n, k, 1, 1).astype(dtype) - 0.5
         else:
-            W = np.random.rand(n, k).astype(np.float32) - 0.5
-        b = np.random.rand(n).astype(np.float32) - 0.5
+            W = np.random.rand(n, k).astype(dtype) - 0.5
+        b = np.random.rand(n).astype(dtype) - 0.5
 
         def fc_op(X, W, b):
             return [np.dot(X, W.reshape(n, k).transpose()) + b.reshape(n)]
@@ -30,7 +48,8 @@ class TestFcOperator(hu.HypothesisTestCase):
         op = core.CreateOperator(
             'FC',
             ['X', 'W', 'b'],
-            'out'
+            'out',
+            engine=engine,
         )
 
         # Check against numpy reference
@@ -42,12 +61,16 @@ class TestFcOperator(hu.HypothesisTestCase):
         )
         # Check over multiple devices
         self.assertDeviceChecks(dc, op, [X, W, b], [0])
-        # Gradient check wrt X
-        self.assertGradientChecks(gc, op, [X, W, b], 0, [0])
-        # Gradient check wrt W
-        self.assertGradientChecks(gc, op, [X, W, b], 1, [0])
-        # Gradient check wrt b
-        self.assertGradientChecks(gc, op, [X, W, b], 2, [0])
+
+        # Gradient checks
+        threshold = 0.5 if dtype == np.float16 else 0.005
+        stepsize = 0.5 if dtype == np.float16 else 0.05
+        self.assertGradientChecks(gc, op, [X, W, b], 0, [0],
+                                  threshold=threshold, stepsize=stepsize)
+        self.assertGradientChecks(gc, op, [X, W, b], 1, [0],
+                                  threshold=threshold, stepsize=stepsize)
+        self.assertGradientChecks(gc, op, [X, W, b], 2, [0],
+                                  threshold=threshold, stepsize=stepsize)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fp16 and TensorCore support was already added to the op in https://github.com/caffe2/caffe2/pull/1056. This adds a test.