### PR TITLE
Create Gloo common world through MPI rendezvous

### DIFF
--- a/caffe2/contrib/gloo/common.h
+++ b/caffe2/contrib/gloo/common.h
@@ -4,6 +4,7 @@
 
 #include "caffe2/core/blob.h"
 
+#include <gloo/config.h>
 #include <gloo/transport/device.h>
 
 namespace caffe2 {
@@ -22,6 +23,11 @@ struct createDeviceAttr {
 
 std::shared_ptr<::gloo::transport::Device> createDevice(
     const createDeviceAttr attr);
+
+#if defined(GLOO_USE_MPI) && GLOO_USE_MPI
+void mpiInitialize();
+void mpiFinalize();
+#endif
 
 } // namespace gloo
 } // namespace caffe2

--- a/caffe2/python/data_parallel_model.py
+++ b/caffe2/python/data_parallel_model.py
@@ -1515,8 +1515,11 @@ def _CreateOrCloneCommonWorld(
             kwargs['transport'] = rendezvous['transport']
         if 'interface' in rendezvous:
             kwargs['interface'] = rendezvous['interface']
+        if 'mpi_rendezvous' in rendezvous:
+            kwargs['mpi_rendezvous'] = rendezvous['mpi_rendezvous']
+
         comm_world = net.CreateCommonWorld(
-            [rendezvous['kv_handler']],
+            rendezvous['kv_handler'] or [],
             common_world_blob,
             name=name,
             size=rendezvous['num_shards'],
@@ -1544,14 +1547,18 @@ def _RunComparison(model, blob_name, device=None):
 
         comparison_net = core.Net("allcompare_net")
 
+        kwargs=dict()
+        if 'mpi_rendezvous' in rendezvous:
+            kwargs['mpi_rendezvous'] = rendezvous['mpi_rendezvous']
         comm_world = comparison_net.CreateCommonWorld(
-            rendezvous['kv_handler'],
+            rendezvous['kv_handler'] or [],
             "initial_sync",
             name=model.net.Proto().name + ".cw_master_select",
             size=rendezvous['num_shards'],
             rank=rendezvous['shard_id'],
             engine=rendezvous['engine'],
             status_blob="cw_master_select",
+            **kwargs
         )
 
         blob_name_checksum = blob_name + "_checksum"


### PR DESCRIPTION
Before this change there were two ways for machines to rendezvous for a
distributed run: shared file system or Redis. If you're using an MPI
cluster it is much more convenient to simply execute mpirun and expect
the "right thing (tm)" to happen. This change adds the "mpi_rendezvous"
option to the CreateCommonWorld operator. If this is set, the common
world size and rank will be pulled from the MPI context and Gloo
rendezvous takes place using MPI. Note that this does NOT mean the MPI
BTL is used; MPI is only used for rendezvous.