### PR TITLE
Bugfix for concat frontend

### DIFF
--- a/caffe2/python/helpers/array_helpers.py
+++ b/caffe2/python/helpers/array_helpers.py
@@ -9,7 +9,8 @@ from __future__ import unicode_literals
 def concat(model, blobs_in, blob_out, **kwargs):
     """Depth Concat."""
     if kwargs.get('order') and kwargs.get('axis'):
-        raise ValueError("Don't set both order and axis")
+        # The backend throws an error if both are given
+        kwargs.pop('order')
 
     return model.net.Concat(
         blobs_in,


### PR DESCRIPTION
When breaking out @pooyadavoodi's change to `brew.concat` from https://github.com/caffe2/caffe2/pull/1151 to https://github.com/caffe2/caffe2/pull/1184, I made it throw an error instead of silently changing removing `order`. But `order` is always present because of [this](https://github.com/caffe2/caffe2/blob/v0.8.1/caffe2/python/model_helper.py#L118), so the frontend can never be used to set `axis`. That's bad. This PR changes the behavior back to Pooya's original implementation.