### PR TITLE
tests: use assertRaises, not expectedFail

### DIFF
--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -433,7 +433,7 @@ class IR(object):
         for op in operators:
             if op.type == 'StopGradient':
                 if op.output[0] not in self.input_usages:
-                    raise Exception("""StopGradient's output '{}' is orphan.
+                    raise ValueError("""StopGradient's output '{}' is orphan.
 You typically want to specify same input and output for
 StopGradient. Op:\n\n{}""".format(op.output[0], str(op)))
 

--- a/caffe2/python/core_gradients_test.py
+++ b/caffe2/python/core_gradients_test.py
@@ -493,20 +493,16 @@ class TestGradientCalculation(test_util.TestCase):
             operators, {'out': 'out_grad'})
         self.assertEqual(gradients, desired_grad_operators)
 
-    @unittest.expectedFailure
     def testStopGradientOrphan(self):
         operators = [
             CreateOperator('Direct', 'in', 'hidden'),
             CreateOperator('StopGradient', 'hidden', 'auto_blobx'),
             CreateOperator('Direct', 'hidden', 'out'),
         ]
-        try:
+        with self.assertRaises(ValueError):
             # This should complain about incorrect use of StopGradient
             gradients, _ = GradientRegistry.GetBackwardPass(
                 operators, {'out': 'out_grad'})
-        except Exception as e:
-            print(e)
-            raise e
 
     def testStopGradientInplace(self):
         operators = [

--- a/caffe2/python/data_parallel_model_test.py
+++ b/caffe2/python/data_parallel_model_test.py
@@ -328,10 +328,10 @@ class DataParallelModelTest(TestCase):
                 device_option=None,
                 tmpdir=tmpdir)
 
-    @unittest.expectedFailure
     def test_device_scope_check(self):
-        with core.DeviceScope(core.DeviceOption(caffe2_pb2.CUDA, 0)):
-            data_parallel_model.Parallelize_GPU(None, None, None)
+        with self.assertRaises(AssertionError):
+            with core.DeviceScope(core.DeviceOption(caffe2_pb2.CUDA, 0)):
+                data_parallel_model.Parallelize_GPU(None, None, None)
 
 
 @unittest.skipIf(not workspace.has_gpu_support, "No gpu support.")


### PR DESCRIPTION
I would expect that tests marked "expected failure" mean that there is a known issue in the code which will be fixed later. Both of these tests are simply verifying proper error-checking - nothing needs fixing.

Before (looks like something is wrong):
```
======================================= 2 xfailed in 0.27 seconds =======================================
```
After:
```
======================================= 2 passed in 0.28 seconds ========================================
```
/cc @akyrola @gsethi523 