### PR TITLE
Fixes for NCCLReduce with non-zero root

### DIFF
--- a/caffe2/contrib/nccl/cuda_nccl_gpu.cc
+++ b/caffe2/contrib/nccl/cuda_nccl_gpu.cc
@@ -78,6 +78,9 @@ std::unordered_map<std::string, std::unique_ptr<NCCLContext>>& gContexts() {
 
 std::string ncclKey(const NCCLExecution& ex) {
   std::string result;
+  int curr_device;
+  CUDA_CHECK(cudaGetDevice(&curr_device));
+  result += to_string(curr_device) + ":";
   for (const auto& el : ex.elements) {
     result += to_string(el.device) + ",";
   }

--- a/caffe2/contrib/nccl/cuda_nccl_op_gpu.cc
+++ b/caffe2/contrib/nccl/cuda_nccl_op_gpu.cc
@@ -199,7 +199,7 @@ OPERATOR_SCHEMA(NCCLReduce)
     .InputsCanCrossDevices()
     .AllowInplace([](int in, int out) -> bool {
       return (out == 0);
-    });
+    })
     .DeviceInferenceFunction(ncclOpDevInfer);
 SHOULD_NOT_DO_GRADIENT(NCCLReduce);
 

--- a/caffe2/contrib/nccl/cuda_nccl_op_gpu.cc
+++ b/caffe2/contrib/nccl/cuda_nccl_op_gpu.cc
@@ -18,7 +18,13 @@ nccl::NCCLExecution getNCCLElements(
   for (auto i = 0; i < op->InputSize(); ++i) {
     auto& el = ex.elements[i];
     el.src = &(op->Input<TensorCUDA>(i));
-    if (i < op->OutputSize()) {
+
+    if (op->OutputSize() == 1) {
+      // Reduce op
+      if (i == ex.root) {
+        el.dst = op->Output<TensorCUDA>(0);
+      }
+    } else if (i < op->OutputSize()) {
       el.dst = op->Output<TensorCUDA>(i);
     }
     // TODO - expensive (>1ms) - cache these.
@@ -95,8 +101,6 @@ class NCCLReduceOp final : public Operator<CUDAContext> {
     if (InputSize() == 1)
       return true;
     const auto& ex = getNCCLElements(this, context_);
-    CAFFE_ENFORCE_EQ(
-        ex.root, 0, "NCCLReduce has spurious deadlocks for non-zero root");
 
     if (AllInputsAre<float>(this)) {
       nccl::NCCL<float>::Reduce(ex);
@@ -193,7 +197,9 @@ OPERATOR_SCHEMA(NCCLReduce)
     .NumOutputs(1)
     .IdenticalTypeAndShapeOfInput(0)
     .InputsCanCrossDevices()
-    .AllowInplace({{0, 0}})
+    .AllowInplace([](int in, int out) -> bool {
+      return (out == 0);
+    });
     .DeviceInferenceFunction(ncclOpDevInfer);
 SHOULD_NOT_DO_GRADIENT(NCCLReduce);
 


### PR DESCRIPTION
All other NCCL ops expect paired src, dst pointers for each
GPU. Reduce doesn't, and the old logic would always set dst for
rank = 0 regardless of whether that was the root or not.
This change takes into account that Reduce only has one output, and it
should assign dst only for the root rank. Also changes the schema to
allow inplace for any input and Output(0).