### PR TITLE
Formatting fix for verbose net logging

### DIFF
--- a/caffe2/core/net_dag.cc
+++ b/caffe2/core/net_dag.cc
@@ -277,7 +277,7 @@ DAGNetBase::DAGNetBase(
   // Initialize the operators
   for (int idx = 0; idx < net_def->op_size(); ++idx) {
     const OperatorDef& op_def = net_def->op(idx);
-    VLOG(1) << "Creating operator #" << idx << ": " << op_def.name() << ":"
+    VLOG(1) << "Creating operator #" << idx << ": " << op_def.name() << ": "
             << op_def.type();
     if (!op_def.has_device_option() && net_def_has_device_option) {
       OperatorDef temp_def(op_def);

--- a/caffe2/core/net_simple.cc
+++ b/caffe2/core/net_simple.cc
@@ -22,7 +22,7 @@ SimpleNet::SimpleNet(
   // Initialize the operators
   for (int idx = 0; idx < net_def->op_size(); ++idx) {
     const auto& operator_def = net_def->op(idx);
-    VLOG(1) << "Creating operator " << operator_def.name() << ":"
+    VLOG(1) << "Creating operator " << operator_def.name() << ": "
             << operator_def.type();
     std::unique_ptr<OperatorBase> op{nullptr};
     if (!operator_def.has_device_option() && net_def_has_device_option) {

--- a/caffe2/core/net_simple_async.cc
+++ b/caffe2/core/net_simple_async.cc
@@ -22,7 +22,7 @@ AsyncSimpleNet::AsyncSimpleNet(
   // Initialize the operators
   for (int idx = 0; idx < net_def->op_size(); ++idx) {
     const auto& operator_def = net_def->op(idx);
-    VLOG(1) << "Creating operator " << operator_def.name() << ":"
+    VLOG(1) << "Creating operator " << operator_def.name() << ": "
             << operator_def.type();
     std::unique_ptr<OperatorBase> op{nullptr};
     if (!operator_def.has_device_option() && net_def_has_device_option) {


### PR DESCRIPTION
This doesn't look quite right:
`I0915 21:26:03.910737    19 net_simple.cc:24] Creating operator :ConstantFill`