### PR TITLE
Additional fix for LRN: unitialized variable.

### DIFF
--- a/caffe2/operators/local_response_normalization_op.h
+++ b/caffe2/operators/local_response_normalization_op.h
@@ -66,7 +66,7 @@ class LRNOp final : public LRNOpBase<T, Context> {
  protected:
   // Input: X; Output: Y, scale.
   OUTPUT_TAGS(OUTPUT, SCALE);
-  Tensor<Context>* scale_;
+  Tensor<Context>* scale_ = nullptr;
   Tensor<Context> local_scale_tensor_;
 };
 
@@ -83,7 +83,7 @@ class LRNGradientOp final : public LRNOpBase<T, Context> {
  protected:
   // Input: X, Y, scale, dY; Output: dX
   INPUT_TAGS(INPUT, OUTPUT, SCALE, OUTPUT_GRAD);
-  Tensor<Context>* scale_;
+  Tensor<Context>* scale_ = nullptr;
   Tensor<Context> local_scale_tensor_;
 };
 


### PR DESCRIPTION
It is interesting that under facebook fbcode this was not an issue -
but definitely causing issue on oss.