### PR TITLE
Partially fix memonger with networkx 2.0

### DIFF
--- a/caffe2/python/memonger.py
+++ b/caffe2/python/memonger.py
@@ -293,7 +293,7 @@ def _find_target_nodes(g):
     ''' Return nodes without successors '''
     ret = []
     for cn in g:
-        cur_succ = g.successors(cn)
+        cur_succ = list(g.successors(cn))
         if not cur_succ:
             ret.append(cn)
     return ret
@@ -381,7 +381,7 @@ def _compute_tree_height(g, root):
         Height of leaves are 0
     '''
     def _get_height(root):
-        children = g.successors(root)
+        children = list(g.successors(root))
         height = 0
         if children:
             child_heights = [_get_height(x) for x in children]
@@ -400,7 +400,7 @@ def _sort_tree_leaves(g, root):
         return g.node[root]["height"]
 
     def _get_sorted_leaves(root):
-        children = g.successors(root)
+        children = list(g.successors(root))
         if not children:
             return [root]
         child_heights = [_get_height(x) for x in children]

--- a/caffe2/python/memonger_test.py
+++ b/caffe2/python/memonger_test.py
@@ -516,7 +516,7 @@ class MemongerTest(hu.HypothesisTestCase):
         m.Copy("b1", "b1")
         m.Copy("b1", "b1")
         g = memonger.compute_interference_graph(m.net.Proto().op)
-        self.assertEqual(g.edges(), [(0, 1), (0, 2), (1, 2)])
+        self.assertEqual(list(g.edges()), [(0, 1), (0, 2), (1, 2)])
 
     def test_topological_sort_longest_path(self):
         m = model_helper.ModelHelper()

--- a/caffe2/python/memonger_test.py
+++ b/caffe2/python/memonger_test.py
@@ -538,7 +538,7 @@ class MemongerTest(hu.HypothesisTestCase):
         orders = memonger.topological_sort_traversal_longest_path(g)
         # longer path is in front of the shorter one
         orders_gt = [0, 1, 2, 3]
-        self.assertEqual(orders_gt, orders)
+        self.assertEqual(orders_gt, list(orders))
 
     def test_topological_sort_longest_path_multi_target(self):
         # two outputs: conv2 and data4
@@ -560,12 +560,12 @@ class MemongerTest(hu.HypothesisTestCase):
 
         orders_org = memonger.topological_sort_traversal(g)
         orders_gt_org = [4, 5, 2, 0, 1, 3]
-        self.assertEqual(orders_gt_org, orders_org)
+        self.assertEqual(orders_gt_org, list(orders_org))
 
         orders = memonger.topological_sort_traversal_longest_path(g)
         # longer path is in front of the shorter one
         orders_gt = [0, 1, 2, 3, 4, 5]
-        self.assertEqual(orders_gt, orders)
+        self.assertEqual(orders_gt, list(orders))
 
     def test_topological_sort_longest_path_single_node(self):
         # single node
@@ -577,12 +577,12 @@ class MemongerTest(hu.HypothesisTestCase):
 
         orders_org = memonger.topological_sort_traversal(g)
         orders_gt_org = [0]
-        self.assertEqual(orders_gt_org, orders_org)
+        self.assertEqual(orders_gt_org, list(orders_org))
 
         orders = memonger.topological_sort_traversal_longest_path(g)
         # longer path is in front of the shorter one
         orders_gt = [0]
-        self.assertEqual(orders_gt, orders)
+        self.assertEqual(orders_gt, list(orders))
 
     def test_compute_assignments_greedy(self):
         LiveRange = memonger.LiveRange
@@ -755,3 +755,7 @@ class MemongerTest(hu.HypothesisTestCase):
                     self.assertFalse(outp in found_frees)
 
         self.assertEqual(expect_frees, found_frees)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This fixes the apparent discrepancy (list vs iterator). After this, there are still 3 failures regarding topological sort but that seems a bit involved. Someone shall look deeper.