### PR TITLE
Trying to fix all networkx 2 issues.

### DIFF
--- a/caffe2/python/memonger.py
+++ b/caffe2/python/memonger.py
@@ -332,16 +332,16 @@ def _get_path(pred_list, dist_list):
 
     ret = []
     cur = target
-    # Hack to get networkx 2.0 happy: it uses list in pred.
-    # TODO(akyrola): are there cases with multiple predecessors?
-    if nx.__version__ < '2.0':
-        while cur is not None:
-            ret.append(cur)
-            cur = pred_list[cur]
-    else:
-        while cur is not None:
-            ret.append(cur)
+
+
+    while cur is not None:
+        ret.append(cur)
+        # Hack to get networkx 2.0 happy: it uses list in pred.
+        # TODO(tulloch): are there cases with multiple predecessors?
+        try:
             cur = pred_list[cur][0]
+        except TypeError:
+            cur = pred_list[cur]
 
     return list(reversed(ret))
 

--- a/caffe2/python/memonger.py
+++ b/caffe2/python/memonger.py
@@ -283,7 +283,7 @@ def _find_source_nodes(g):
     ''' Return nodes without predecessors '''
     ret = []
     for cn in g:
-        cur_pred = g.predecessors(cn)
+        cur_pred = list(g.predecessors(cn))
         if not cur_pred:
             ret.append(cn)
     return ret
@@ -332,9 +332,17 @@ def _get_path(pred_list, dist_list):
 
     ret = []
     cur = target
-    while cur is not None:
-        ret.append(cur)
-        cur = pred_list[cur]
+    # Hack to get networkx 2.0 happy: it uses list in pred.
+    # TODO(akyrola): are there cases with multiple predecessors?
+    if nx.__version__ < '2.0':
+        while cur is not None:
+            ret.append(cur)
+            cur = pred_list[cur]
+    else:
+        while cur is not None:
+            ret.append(cur)
+            cur = pred_list[cur][0]
+
     return list(reversed(ret))
 
 
@@ -436,13 +444,28 @@ def topological_sort_traversal_longest_path(g):
     sorted_sources = _sort_tree_leaves(tree, root)
     assert(sorted(sorted_sources) == sorted(source_nodes))
 
-    ret = nx.topological_sort(g, sorted_sources)
+    if nx.__version__ < '2.0':
+        ret = nx.topological_sort(g, sorted_sources)
+    else:
+        # Manually making a sorted descendent list
+        dependency_order = list(sorted_sources)
+        seen_nodes = set(sorted_sources)
+        for s in sorted_sources:
+            desc = nx.descendants(g, s)
+            for d in desc:
+                if d not in seen_nodes:
+                    seen_nodes.add(d)
+                    dependency_order.append(d)
+        sort_key = dict((v, len(dependency_order) - i) for i, v in enumerate(dependency_order))
+        ret = nx.algorithms.dag.lexicographical_topological_sort(
+            g, key=lambda x: sort_key[x])
+        ret = list(ret)
     assert(len(ret) == len(g.node))
     return ret
 
 
 def topological_sort_traversal(g):
-    return nx.topological_sort(g)
+    return list(nx.topological_sort(g))
 
 
 def compute_ranges(linearized_ops, blob_sizes=None):

--- a/caffe2/python/memonger_test.py
+++ b/caffe2/python/memonger_test.py
@@ -533,7 +533,7 @@ class MemongerTest(hu.HypothesisTestCase):
 
         orders_org = memonger.topological_sort_traversal(g)
         orders_gt_org = [2, 0, 1, 3]
-        self.assertEqual(orders_gt_org, orders_org)
+        self.assertEqual(orders_gt_org, list(orders_org))
 
         orders = memonger.topological_sort_traversal_longest_path(g)
         # longer path is in front of the shorter one


### PR DESCRIPTION
Basically:

- more generator vs list changes.
- difference in the return type of bellman_ford(), see _get_path. 2.x returns list.
- nx 2 removed nbunch in topological_order, so we will need to manually use lexicographical_topological_sort with an explicit key derived from the source node order.