### PR TITLE
Fix OSX build w/CUDA=ON

### DIFF
--- a/caffe2/operators/layer_norm_op.cu
+++ b/caffe2/operators/layer_norm_op.cu
@@ -252,8 +252,8 @@ bool LayerNormGradientOp<CUDAContext>::DoRunWithType<float>() {
   auto* ginput = Output(0);
 
   const auto canonical_axis = norm_inputs.canonical_axis_index(axis_);
-  const int left = norm_inputs.size_to_dim(canonical_axis);
-  const int right = norm_inputs.size_from_dim(canonical_axis);
+  const unsigned long left = norm_inputs.size_to_dim(canonical_axis);
+  const unsigned long right = norm_inputs.size_from_dim(canonical_axis);
 
   ginput->ResizeLike(norm_inputs);
   std::vector<TIndex> stats_dims(


### PR DESCRIPTION
connect to https://github.com/caffe2/caffe2/issues/1249

With this change, build, install, and smoke test pass on OSX with CUDA=ON.
```
$ cmake -DUSE_CUDA=ON ..
$ sudo make install
$ python -c 'from caffe2.python import core' 2>/dev/null && echo "Success" || echo "Failure"
Success
```
