### PR TITLE
Resolve Windows warning C4099 issue (class/struct name mixture)

### DIFF
--- a/caffe2/core/event.h
+++ b/caffe2/core/event.h
@@ -63,13 +63,13 @@ class Event {
   static EventFinishFunction event_finisher_[MaxDeviceTypes];
 
   template <int d>
-  friend class EventCreateFunctionRegisterer;
+  friend struct EventCreateFunctionRegisterer;
   template <int d>
-  friend class EventRecordFunctionRegisterer;
+  friend struct EventRecordFunctionRegisterer;
   template <int w, int d>
-  friend class EventWaitFunctionRegisterer;
+  friend struct EventWaitFunctionRegisterer;
   template <int d>
-  friend class EventFinishFunctionRegisterer;
+  friend struct EventFinishFunctionRegisterer;
 };
 
 template <int d>

--- a/caffe2/core/plan_executor.cc
+++ b/caffe2/core/plan_executor.cc
@@ -167,7 +167,7 @@ struct ExecutionStepWrapper {
     CompiledGuard() {}
     std::unique_ptr<CompiledExecutionStep> compiled_;
     CompiledExecutionStep* compiledRef_;
-    friend class ExecutionStepWrapper;
+    friend struct ExecutionStepWrapper;
   };
 
   const ExecutionStep& step() {


### PR DESCRIPTION
TSIA - no functionality change introduced. See current build (e.g. https://ci.appveyor.com/project/Yangqing/caffe2/build/2148/job/mj9auhnernrgdfpe) for the warning messages produced right now.