### PR TITLE
Compile with MKL in conda-build

### DIFF
--- a/conda/build.sh
+++ b/conda/build.sh
@@ -14,7 +14,7 @@ PYTHON_ARGS="$(python ./scripts/get_python_cmake_flags.py)"
 
 mkdir -p build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_PREFIX_PATH="$PREFIX" $CONDA_CMAKE_ARGS $PYTHON_ARGS ..
+cmake -DBLAS=MKL -DMKL_INCLUDE_DIR=$CONDA_PREFIX/include -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_PREFIX_PATH="$PREFIX" $CONDA_CMAKE_ARGS $PYTHON_ARGS ..
 make -j20
 
 make install/fast

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -26,6 +26,8 @@ requirements:
     - leveldb
     - lmdb
     - snappy
+    - mkl-include
+    - mkl
   run:
     - future
     - glog
@@ -38,6 +40,7 @@ requirements:
     - lmdb
     - snappy
     - future
+    - mkl
 
 about:
   home: https://caffe2.ai/


### PR DESCRIPTION
Problem:
Without -DBLAS=MKL, conda-build won't include MKL library into Caffe2 build. And the BLAS performance is bad on CPU.

Solution:
Explicitly add the flag. Add mkl and mkl-include as dependencies.

@ezyang @Yangqing 