### PR TITLE
Build local

### DIFF
--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -27,4 +27,10 @@ cmake .. \
     -DPROTOBUF_PROTOC_EXECUTABLE=$CAFFE2_ROOT/build_host_protoc/bin/protoc \
     -DBUILD_SHARED_LIBS=OFF \
     || exit 1
-make
+    
+# Cross-platform parallel build
+if [ "$(uname)" = 'Darwin' ]; then
+    cmake --build . -- "-j$(sysctl -n hw.ncpu)"
+else
+    cmake --build . -- "-j$(nproc)"
+fi

--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -28,7 +28,6 @@ cmake .. \
     -DBUILD_SHARED_LIBS=OFF \
     || exit 1
     
-# Cross-platform parallel build
 if [ "$(uname)" = 'Darwin' ]; then
     cmake --build . -- "-j$(sysctl -n hw.ncpu)"
 else


### PR DESCRIPTION
The build_local.sh script current is single thread, which is really slow. Use the same mechanism in build_android.sh to parallelize the build. 