### PR TITLE
Pybind v2.2.1

### DIFF
--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -241,8 +241,6 @@ PythonOpBase::PythonOpBase(
   if (!pickled.empty()) {
     py::gil_scoped_acquire g;
     try {
-      //auto pickle =
-      //    py::object(PyImport_ImportModule("pickle"), /* borrowed */ false);
       auto pickle =
           py::reinterpret_steal<py::object>(PyImport_ImportModule("pickle"));
       CAFFE_ENFORCE(pickle);

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -241,6 +241,8 @@ PythonOpBase::PythonOpBase(
   if (!pickled.empty()) {
     py::gil_scoped_acquire g;
     try {
+      //auto pickle =
+      //    py::object(PyImport_ImportModule("pickle"), /* borrowed */ false);
       auto pickle =
           py::reinterpret_steal<py::object>(PyImport_ImportModule("pickle"));
       CAFFE_ENFORCE(pickle);


### PR DESCRIPTION
Bumps the pybind version from v1.8.1 to v2.2.1, resolving all compile & runtime issues that arose.

Upgrades to the API used https://github.com/pybind/pybind11/blob/master/docs/upgrade.rst as the point of reference.

This also solves a long-standing bug we had, where a type would spontaneously and intermittently change in the C++ -> Python boundary.

\cc @Yangqing 