### PR TITLE
Add a free Automatic Speech Recognition corpus.

### DIFF
--- a/_docs/datasets.md
+++ b/_docs/datasets.md
@@ -36,3 +36,4 @@ You may also want to check out the pre-trained models at [Caffe2's Model Zoo](zo
 | [UCI Datasets](https://archive.ics.uci.edu/ml/datasets.html) | ![variety](../static/images/caffe2variety.png) | [![download](../static/images/download.png)](https://archive.ics.uci.edu/ml/datasets.html) |
 | [US Census](https://catalog.data.gov/dataset): demographic data | ![line graph](../static/images/linegraph.png)            | [![download](../static/images/download.png)](https://catalog.data.gov/dataset) |
 | [VGG-Face](http://www.robots.ox.ac.uk/~vgg/software/vgg_face/) millions of faces | ![faces](../static/images/faces.jpg) | [![download](../static/images/download.png)](http://www.robots.ox.ac.uk/~vgg/software/vgg_face/src/vgg_face_caffe.tar.gz)|
+| [LibriSpeech](http://www.openslr.org/12/) 1000 hours free speech recognition traning dataset| ![language](../static/images/landing-audio.png) | [![download](../static/images/download.png)](http://www.openslr.org/12/)|


### PR DESCRIPTION
LibriSpeech contains more than 1000 hours of reading audio books. The dataset is divide as following:
dev-clean.tar.gz [337M]   (development set, "clean" speech )
dev-other.tar.gz [314M]   (development set, "other", more challenging, speech )
test-clean.tar.gz [346M]   (test set, "clean" speech )
test-other.tar.gz [328M]   (test set, "other" speech )
train-clean-100.tar.gz [6.3G]   (training set of 100 hours "clean" speech )
train-clean-360.tar.gz [23G]   (training set of 360 hours "clean" speech )
train-other-500.tar.gz [30G]   (training set of 500 hours "other" speech ) 