### PR TITLE
Fix linguist detection with gitattribute overrides

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-documentation


### PR DESCRIPTION
Before:
```
34.34%  Jupyter Notebook
34.06%  C++
20.95%  Python
4.84%   Cuda
2.36%   C
1.78%   Objective-C++
1.05%   CMake
0.27%   Metal
0.19%   Shell
0.05%   Objective-C
0.04%   Batchfile
0.04%   HTML
0.02%   CSS
0.01%   Makefile
```
After:
```
51.87%  C++
31.91%  Python
7.37%   Cuda
3.59%   C
2.72%   Objective-C++
1.59%   CMake
0.42%   Metal
0.30%   Shell
0.08%   Objective-C
0.06%   Batchfile
0.06%   HTML
0.02%   CSS
0.01%   Makefile
```