### PR TITLE
Fix bug introduced in a recent commit

### DIFF
--- a/caffe2/operators/weighted_sample_op.cc
+++ b/caffe2/operators/weighted_sample_op.cc
@@ -79,7 +79,7 @@ OPERATOR_SCHEMA(WeightedSample)
       vector<TensorShape> out(2);
       int batch_size = in[0].dims(0);
       out[0] = CreateTensorShape(vector<int>{batch_size}, TensorProto::INT32);
-      out[1] = CreateTensorShape(vector<float>{batch_size}, TensorProto::FLOAT);
+      out[1] = CreateTensorShape(vector<int>{batch_size}, TensorProto::FLOAT);
       return out;
     })
     .SetDoc(R"DOC(


### PR DESCRIPTION
This is introduced in https://github.com/caffe2/caffe2/commit/8539a1e78b7fd8aa92b08a8f24b2b0f7978bf5a5 - vector<float> should not be used in Tensor shape inference.