### PR TITLE
Fix Batched Matmul test accuracy

### DIFF
--- a/caffe2/python/operator_test/matmul_op_test.py
+++ b/caffe2/python/operator_test/matmul_op_test.py
@@ -174,10 +174,10 @@ class TestBatchMatMul(hu.HypothesisTestCase):
             'BatchMatMul', ['X', 'Y'], 'out', trans_a=trans_a, trans_b=trans_b
         )
 
-        def matmul_ref(X, Y, trans_a, trans_b):
-            XX = X.swapaxes(-1, -2) if trans_a else X
-            YY = Y.swapaxes(-1, -2) if trans_b else Y
-            return (np.matmul(XX, YY),)
+        def matmul_ref(X, Y, trans_a, trans_b, dtype):
+            XX = (X.swapaxes(-1, -2) if trans_a else X).astype(np.float32)
+            YY = (Y.swapaxes(-1, -2) if trans_b else Y).astype(np.float32)
+            return (np.matmul(XX, YY).astype(dtype),)
 
         # relaxing the "threshold" for fp16 to 150x of the default
         def relax_fp16_check(check_func, *args, **kwargs):

--- a/caffe2/python/operator_test/matmul_op_test.py
+++ b/caffe2/python/operator_test/matmul_op_test.py
@@ -192,7 +192,7 @@ class TestBatchMatMul(hu.HypothesisTestCase):
             check_func(*args, threshold=threshold, **kwargs)
 
         # Check against numpy reference
-        relax_fp16_check(self.assertReferenceChecks, gc, op, [X, Y, trans_a, trans_b], matmul_ref)
+        relax_fp16_check(self.assertReferenceChecks, gc, op, [X, Y, trans_a, trans_b, dtype], matmul_ref)
         # Check over multiple devices
         relax_fp16_check(self.assertDeviceChecks, dc, op, [X, Y], [0])
         # Gradient check wrt X


### PR DESCRIPTION
Datatypes was being handled badly in reference check, causing sporadic fails in CI. All batched mat-mul with fp16 data is performed as pseudo-fp16, with all math in fp32. Adjusted the reference implementation to reflect this.

Adjusted the gradient check threshold to the best I could get to consistently pass.