### PR TITLE
Update the sample rate function call since the API is changed

### DIFF
--- a/caffe2/share/contrib/binaries/caffe2_benchmark/caffe2_benchmark.cc
+++ b/caffe2/share/contrib/binaries/caffe2_benchmark/caffe2_benchmark.cc
@@ -169,10 +169,10 @@ int main(int argc, char** argv) {
       caffe2::FLAGS_iter,
       ".");
   for (int i = 0; i < caffe2::FLAGS_iter; ++i) {
-    caffe2::ObserverConfig::initSampleRate(1, 0, caffe2::FLAGS_warmup);
+    caffe2::ObserverConfig::initSampleRate(1, 1, 1, 0, caffe2::FLAGS_warmup);
     CAFFE_ENFORCE(net->Run(), "Main run ", i, " has failed.");
     if (caffe2::FLAGS_run_individual) {
-      caffe2::ObserverConfig::initSampleRate(1, 1, caffe2::FLAGS_warmup);
+      caffe2::ObserverConfig::initSampleRate(1, 1, 1, 1, caffe2::FLAGS_warmup);
       CAFFE_ENFORCE(net->Run(), "Main run ", i, " with operator has failed.");
     }
   }


### PR DESCRIPTION
With the update of the sample rate API, caffe2_benchmark needs to be changed as well. 

Tested building the caffe2_benchmark and running the program on an android phone. See the delay metrics reported in adb. 