### PR TITLE
Fix #1355: do not expose Eigen header includes

### DIFF
--- a/caffe2/contrib/gloo/broadcast_ops.h
+++ b/caffe2/contrib/gloo/broadcast_ops.h
@@ -20,6 +20,7 @@
 
 #include "caffe2/contrib/gloo/common.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/core/types.h"
 
 #include <gloo/algorithm.h>
 #include <gloo/common/error.h>

--- a/caffe2/core/context.cc
+++ b/caffe2/core/context.cc
@@ -17,6 +17,11 @@
 #include <atomic>
 #include "caffe2/core/context.h"
 
+#if defined(_MSC_VER)
+#include <process.h>
+#endif
+
+
 namespace caffe2 {
 
 uint32_t RandomNumberSeed() {

--- a/caffe2/core/context.cc
+++ b/caffe2/core/context.cc
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <atomic>
+#include "caffe2/core/context.h"
+
+namespace caffe2 {
+
+uint32_t RandomNumberSeed() {
+  // Originally copied from folly::randomNumberSeed (at 418ad4)
+  // modified to use chrono instead of sys/time.h
+  static std::atomic<uint32_t> seedInput(0);
+  auto tv = std::chrono::system_clock::now().time_since_epoch();
+  uint64_t usec = static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::microseconds>(tv).count());
+  uint32_t tv_sec = usec / 1000000;
+  uint32_t tv_usec = usec % 1000000;
+  const uint32_t kPrime0 = 51551;
+  const uint32_t kPrime1 = 61631;
+  const uint32_t kPrime2 = 64997;
+  const uint32_t kPrime3 = 111857;
+  return kPrime0 * (seedInput++) + kPrime1 * static_cast<uint32_t>(getpid()) +
+      kPrime2 * tv_sec + kPrime3 * tv_usec;
+}
+
+
+} // namespace caffe2

--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -27,11 +27,16 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/typeid.h"
 #include "caffe2/proto/caffe2.pb.h"
-#include "caffe2/utils/math.h"
 
 CAFFE2_DECLARE_bool(caffe2_report_cpu_memory_usage);
 
 namespace caffe2 {
+
+/**
+ * A function to generate a random number seed that is unique in a best-effort
+ * basis, using an ever-incrementing seed and the current time.
+ */
+uint32_t RandomNumberSeed();
 
 /**
  * The CPU Context, representing the bare minimum of what a Context class in
@@ -77,11 +82,11 @@ namespace caffe2 {
 class CPUContext final {
  public:
   typedef std::mt19937 rand_gen_type;
-  CPUContext() : random_seed_(math::randomNumberSeed()) {}
+  CPUContext() : random_seed_(RandomNumberSeed()) {}
   explicit CPUContext(const DeviceOption& option)
       : random_seed_(
             option.has_random_seed() ? option.random_seed()
-                                     : math::randomNumberSeed()) {
+                                     : RandomNumberSeed()) {
     CAFFE_ENFORCE_EQ(option.device_type(), CPU);
   }
 

--- a/caffe2/core/context_gpu.cu
+++ b/caffe2/core/context_gpu.cu
@@ -256,7 +256,7 @@ struct Caffe2CudaInitializerHelper {
 
 CUDAContext::CUDAContext(const int gpu_id)
     : gpu_id_(gpu_id == -1 ? GetDefaultGPUID() : gpu_id)
-    , random_seed_(math::randomNumberSeed()) {
+    , random_seed_(RandomNumberSeed()) {
   static Caffe2CudaInitializerHelper g_cuda_initializer_;
 }
 
@@ -264,7 +264,7 @@ CUDAContext::CUDAContext(const DeviceOption& option)
     : gpu_id_(option.has_cuda_gpu_id() ?
               option.cuda_gpu_id() : GetDefaultGPUID()),
       random_seed_(option.has_random_seed() ?
-                   option.random_seed() : math::randomNumberSeed()) {
+                   option.random_seed() : RandomNumberSeed()) {
   static Caffe2CudaInitializerHelper g_cuda_initializer_;
   DCHECK_EQ(option.device_type(), CUDA);
 }

--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -22,6 +22,7 @@
 #include "caffe2/core/net.h"
 #include "caffe2/core/operator_gradient.h"
 #include "caffe2/core/tensor.h"
+#include "caffe2/core/types.h"
 #include "caffe2/core/workspace.h"
 
 #include "caffe2/proto/caffe2.pb.h"

--- a/caffe2/mkl/operators/packed_fc_op.cc
+++ b/caffe2/mkl/operators/packed_fc_op.cc
@@ -20,6 +20,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/mkl/mkl_utils.h"
 #include "caffe2/utils/cpuid.h"
+#include "caffe2/utils/math.h"
 
 #ifdef CAFFE2_HAS_MKL_SGEMM_PACK
 

--- a/caffe2/mkl/utils/mkl_context.h
+++ b/caffe2/mkl/utils/mkl_context.h
@@ -35,11 +35,11 @@ namespace caffe2 {
  */
 class MKLContext final {
  public:
-  MKLContext() : random_seed_(math::randomNumberSeed()) {}
+  MKLContext() : random_seed_(RandomNumberSeed()) {}
   explicit MKLContext(const DeviceOption& option)
       : random_seed_(
             option.has_random_seed() ? option.random_seed()
-                                     : math::randomNumberSeed()) {
+                                     : RandomNumberSeed()) {
     CAFFE_ENFORCE_EQ(option.device_type(), MKLDNN);
   }
 

--- a/caffe2/mobile/contrib/opengl/operators/GLConcat.cc
+++ b/caffe2/mobile/contrib/opengl/operators/GLConcat.cc
@@ -22,6 +22,7 @@
 
 #include "caffe2/core/operator.h"
 #include "caffe2/core/timer.h"
+#include "caffe2/core/types.h"
 #include <iostream>
 #include <vector>
 

--- a/caffe2/mobile/contrib/opengl/operators/GLConvolution.cc
+++ b/caffe2/mobile/contrib/opengl/operators/GLConvolution.cc
@@ -21,6 +21,7 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/context.h"
 #include "caffe2/core/timer.h"
+#include "caffe2/core/types.h"
 #include "caffe2/operators/conv_pool_op_base.h"
 #include "caffe2/operators/conv_transpose_unpool_op_base.h"
 #include <iostream>

--- a/caffe2/mobile/contrib/opengl/operators/GLInstanceNorm.cc
+++ b/caffe2/mobile/contrib/opengl/operators/GLInstanceNorm.cc
@@ -21,6 +21,7 @@
 
 #include "caffe2/core/operator.h"
 #include "caffe2/core/timer.h"
+#include "caffe2/core/types.h"
 #include <iostream>
 #include <vector>
 

--- a/caffe2/mobile/contrib/opengl/operators/GLNormPlanarYUV.cc
+++ b/caffe2/mobile/contrib/opengl/operators/GLNormPlanarYUV.cc
@@ -21,6 +21,7 @@
 
 #include "caffe2/core/operator.h"
 #include "caffe2/core/timer.h"
+#include "caffe2/core/types.h"
 #include <iostream>
 #include <vector>
 

--- a/caffe2/mobile/contrib/opengl/operators/GLPRelu.cc
+++ b/caffe2/mobile/contrib/opengl/operators/GLPRelu.cc
@@ -21,6 +21,7 @@
 
 #include "caffe2/core/operator.h"
 #include "caffe2/core/timer.h"
+#include "caffe2/core/types.h"
 #include <iostream>
 #include <vector>
 

--- a/caffe2/mobile/contrib/opengl/operators/GLPadImage.cc
+++ b/caffe2/mobile/contrib/opengl/operators/GLPadImage.cc
@@ -21,6 +21,7 @@
 
 #include "caffe2/core/operator.h"
 #include "caffe2/core/timer.h"
+#include "caffe2/core/types.h"
 #include "caffe2/operators/conv_pool_op_base.h"
 
 class GLPadImage : public GLFilter {

--- a/caffe2/mobile/contrib/opengl/operators/GLPool.cc
+++ b/caffe2/mobile/contrib/opengl/operators/GLPool.cc
@@ -20,6 +20,7 @@
 #include "../core/ImageAllocator.h"
 
 #include "caffe2/core/timer.h"
+#include "caffe2/core/types.h"
 #include "caffe2/operators/pool_op.h"
 
 class GLPool : public GLFilter {

--- a/caffe2/mobile/contrib/opengl/operators/GLSoftmax.cc
+++ b/caffe2/mobile/contrib/opengl/operators/GLSoftmax.cc
@@ -19,6 +19,7 @@
 #include "../core/GLImage.h"
 
 #include "caffe2/core/timer.h"
+#include "caffe2/core/types.h"
 #include <iostream>
 #include <vector>
 

--- a/caffe2/operators/conv_transpose_op_mobile_test.cc
+++ b/caffe2/operators/conv_transpose_op_mobile_test.cc
@@ -18,6 +18,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/utils/proto_utils.h"
+#include "caffe2/utils/math.h"
 
 #include "gtest/gtest.h"
 #include <cmath>

--- a/caffe2/operators/extend_tensor_op.cc
+++ b/caffe2/operators/extend_tensor_op.cc
@@ -20,6 +20,7 @@
 #include <vector>
 #include "caffe2/core/operator.h"
 #include "caffe2/core/tensor.h"
+#include "caffe2/utils/math.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/norm_planar_yuv_op.cc
+++ b/caffe2/operators/norm_planar_yuv_op.cc
@@ -16,6 +16,7 @@
 
 #include <array>
 #include "caffe2/core/operator.h"
+#include "caffe2/utils/math.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/prelu_op.cc
+++ b/caffe2/operators/prelu_op.cc
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
+#include "caffe2/utils/math.h"
 #include "caffe2/operators/prelu_op.h"
 
+#include "caffe2/core/types.h"
 #include "caffe2/utils/cpu_neon.h"
-#include "caffe2/utils/math.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/recurrent_network_op.h
+++ b/caffe2/operators/recurrent_network_op.h
@@ -23,6 +23,7 @@
 #include "caffe2/core/tensor.h"
 #include "caffe2/operators/recurrent_network_executor.h"
 #include "caffe2/utils/conversions.h"
+#include "caffe2/utils/math.h"
 
 CAFFE2_DECLARE_bool(caffe2_rnn_executor);
 

--- a/caffe2/operators/reshape_op.cc
+++ b/caffe2/operators/reshape_op.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "caffe2/utils/math.h"
 #include "caffe2/operators/reshape_op.h"
 
 namespace caffe2 {

--- a/caffe2/operators/reshape_op_gpu.cc
+++ b/caffe2/operators/reshape_op_gpu.cc
@@ -15,6 +15,7 @@
  */
 
 #include "caffe2/core/context_gpu.h"
+#include "caffe2/utils/math.h"
 #include "caffe2/operators/reshape_op.h"
 
 namespace caffe2 {

--- a/caffe2/operators/reshape_op_gpu_test.cc
+++ b/caffe2/operators/reshape_op_gpu_test.cc
@@ -19,6 +19,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/core/flags.h"
+#include "caffe2/utils/math.h"
 #include "caffe2/operators/reshape_op.h"
 #include <gtest/gtest.h>
 

--- a/caffe2/operators/slice_op.cc
+++ b/caffe2/operators/slice_op.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "caffe2/utils/math.h"
 #include "caffe2/operators/slice_op.h"
 
 namespace caffe2 {

--- a/caffe2/operators/slice_op.cu
+++ b/caffe2/operators/slice_op.cu
@@ -15,6 +15,7 @@
  */
 
 #include "caffe2/core/context_gpu.h"
+#include "caffe2/utils/math.h"
 #include "caffe2/operators/slice_op.h"
 
 namespace caffe2 {

--- a/caffe2/operators/stylizer_ops.cc
+++ b/caffe2/operators/stylizer_ops.cc
@@ -16,6 +16,7 @@
 
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/cpu_neon.h"
+#include "caffe2/utils/math.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/swish_op.cc
+++ b/caffe2/operators/swish_op.cc
@@ -15,6 +15,7 @@
  */
 
 #include "swish_op.h"
+#include "caffe2/core/types.h"
 #include "caffe2/operators/elementwise_op.h"
 #include "caffe2/utils/math.h"
 

--- a/caffe2/operators/swish_op.h
+++ b/caffe2/operators/swish_op.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "caffe2/core/operator.h"
+#include "caffe2/utils/math.h"
 
 namespace caffe2 {
 struct SwishCPUFunctor {

--- a/caffe2/operators/text_file_reader.cc
+++ b/caffe2/operators/text_file_reader.cc
@@ -17,6 +17,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/tensor.h"
+#include "caffe2/core/types.h"
 #include "caffe2/operators/text_file_reader_utils.h"
 #include "caffe2/utils/string_utils.h"
 

--- a/caffe2/operators/utility_ops_gpu.cc
+++ b/caffe2/operators/utility_ops_gpu.cc
@@ -15,6 +15,7 @@
  */
 
 #include "caffe2/core/context_gpu.h"
+#include "caffe2/utils/math.h"
 #include "caffe2/operators/reshape_op.h"
 #include "caffe2/operators/utility_ops.h"
 

--- a/caffe2/queue/queue_ops.cc
+++ b/caffe2/queue/queue_ops.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "caffe2/utils/math.h"
 #include "queue_ops.h"
 #include <memory>
 

--- a/caffe2/queue/queue_ops_gpu.cc
+++ b/caffe2/queue/queue_ops_gpu.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "caffe2/utils/math.h"
 #include "queue_ops.h"
 
 #include "caffe2/core/context_gpu.h"

--- a/caffe2/sgd/rmsprop_op.cc
+++ b/caffe2/sgd/rmsprop_op.cc
@@ -16,6 +16,8 @@
 
 #include "rmsprop_op.h"
 
+#include "caffe2/utils/math.h"
+
 namespace caffe2 {
 
 template <>

--- a/caffe2/utils/math.h
+++ b/caffe2/utils/math.h
@@ -441,8 +441,6 @@ void CopyMatrix(
 template <typename T, class Context>
 void CopyVector(const int N, const T* A, T* B, Context* context);
 
-uint32_t randomNumberSeed();
-
 // Function uses casting from int to unsigned to compare if value of
 // parameter a is greater or equal to zero and lower than value of
 // parameter b. The b parameter is of type signed and is always

--- a/caffe2/utils/math_cpu.cc
+++ b/caffe2/utils/math_cpu.cc
@@ -1478,22 +1478,5 @@ void CopyMatrix<CPUContext>(
 CAFFE2_SPECIALIZED_COPYVECTOR(float)
 #undef CAFFE2_SPECIALIZED_COPYVECTOR
 
-uint32_t randomNumberSeed() {
-  // Originally copied from folly::randomNumberSeed (at 418ad4)
-  // modified to use chrono instead of sys/time.h
-  static std::atomic<uint32_t> seedInput(0);
-  auto tv = std::chrono::system_clock::now().time_since_epoch();
-  uint64_t usec = static_cast<uint64_t>(
-      std::chrono::duration_cast<std::chrono::microseconds>(tv).count());
-  uint32_t tv_sec = usec / 1000000;
-  uint32_t tv_usec = usec % 1000000;
-  const uint32_t kPrime0 = 51551;
-  const uint32_t kPrime1 = 61631;
-  const uint32_t kPrime2 = 64997;
-  const uint32_t kPrime3 = 111857;
-  return kPrime0 * (seedInput++) + kPrime1 * static_cast<uint32_t>(getpid()) +
-      kPrime2 * tv_sec + kPrime3 * tv_usec;
-}
-
 }  // namespace math
 }  // namespace caffe2

--- a/caffe2/utils/math_cpu.cc
+++ b/caffe2/utils/math_cpu.cc
@@ -43,9 +43,6 @@
 #include <mkl.h>
 #endif  // CAFFE2_USE_MKL
 
-#if defined(_MSC_VER)
-#include <process.h>
-#endif
 
 namespace caffe2 {
 namespace math {


### PR DESCRIPTION
Exposing includes of Eigen headers in Caffe2 headers leads to compiler
errors in C++ code using Caffe2 if Eigen is _not_ the BLAS back-end.

The PR is based on PR #1361.
