### PR TITLE
Enable building mobile directory files in OSS

### DIFF
--- a/caffe2/mobile/CMakeLists.txt
+++ b/caffe2/mobile/CMakeLists.txt
@@ -1,1 +1,11 @@
 add_subdirectory(contrib)
+
+# CPU source, test sources, binary sources
+set(Caffe2_CPU_SRCS ${Caffe2_CPU_SRCS} PARENT_SCOPE)
+set(Caffe2_CPU_TEST_SRCS ${Caffe2_CPU_TEST_SRCS} PARENT_SCOPE)
+set(Caffe2_CPU_BINARY_SRCS ${Caffe2_CPU_BINARY_SRCS} PARENT_SCOPE)
+
+# GPU source, test sources, binary sources
+set(Caffe2_GPU_SRCS ${Caffe2_GPU_SRCS} PARENT_SCOPE)
+set(Caffe2_GPU_TEST_SRCS ${Caffe2_GPU_TEST_SRCS} PARENT_SCOPE)
+set(Caffe2_GPU_BINARY_SRCS ${Caffe2_GPU_BINARY_SRCS} PARENT_SCOPE)


### PR DESCRIPTION
The source files are not exposed to the parent directory in mobile. Expose them now so that the files are built in OSS. 