### PR TITLE
Caffe2_benchmark can benchmark multiple backend engines

### DIFF
--- a/caffe2/mobile/CMakeLists.txt
+++ b/caffe2/mobile/CMakeLists.txt
@@ -1,1 +1,11 @@
 add_subdirectory(contrib)
+
+# CPU source, test sources, binary sources
+set(Caffe2_CPU_SRCS ${Caffe2_CPU_SRCS} PARENT_SCOPE)
+set(Caffe2_CPU_TEST_SRCS ${Caffe2_CPU_TEST_SRCS} PARENT_SCOPE)
+set(Caffe2_CPU_BINARY_SRCS ${Caffe2_CPU_BINARY_SRCS} PARENT_SCOPE)
+
+# GPU source, test sources, binary sources
+set(Caffe2_GPU_SRCS ${Caffe2_GPU_SRCS} PARENT_SCOPE)
+set(Caffe2_GPU_TEST_SRCS ${Caffe2_GPU_TEST_SRCS} PARENT_SCOPE)
+set(Caffe2_GPU_BINARY_SRCS ${Caffe2_GPU_BINARY_SRCS} PARENT_SCOPE)

--- a/caffe2/share/contrib/binaries/caffe2_benchmark/caffe2_benchmark.cc
+++ b/caffe2/share/contrib/binaries/caffe2_benchmark/caffe2_benchmark.cc
@@ -13,10 +13,10 @@
 #include "caffe2/utils/string_utils.h"
 
 CAFFE2_DEFINE_string(
-    engine,
+    backend,
     "default",
-    "The backend engine to use when running the model. The allowed "
-    "engines choices are: default, nnpack, opengl");
+    "The backend to use when running the model. The allowed "
+    "backend choices are: default, nnpack, opengl");
 CAFFE2_DEFINE_string(
     init_net,
     "",
@@ -158,7 +158,7 @@ int main(int argc, char** argv) {
   // Run main network.
   caffe2::NetDef net_def;
   CAFFE_ENFORCE(ReadProtoFromFile(caffe2::FLAGS_net, &net_def));
-  if (caffe2::FLAGS_engine == "opengl") {
+  if (caffe2::FLAGS_backend == "opengl") {
     caffe2::NetDef opengl_net_def;
     if (caffe2::tryConvertToOpenGL(init_net_def, net_def, &opengl_net_def)) {
       net_def = opengl_net_def;
@@ -171,13 +171,13 @@ int main(int argc, char** argv) {
       LOG(ERROR)
           << "Net cannot be converted to OpenGL format, use original model instead";
     }
-  } else if (caffe2::FLAGS_engine == "nnpack") {
+  } else if (caffe2::FLAGS_backend == "nnpack") {
     for (int i = 0; i < net_def.op_size(); i++) {
       caffe2::OperatorDef* op_def = net_def.mutable_op(i);
       op_def->set_engine("NNPACK");
     }
   } else {
-    CAFFE_ENFORCE(caffe2::FLAGS_engine == "default", "Engine is not supported");
+    CAFFE_ENFORCE(caffe2::FLAGS_backend == "default", "Backend is not supported");
   }
 
   caffe2::NetBase* net = workspace->CreateNet(net_def);

--- a/caffe2/share/contrib/binaries/caffe2_benchmark/caffe2_benchmark.cc
+++ b/caffe2/share/contrib/binaries/caffe2_benchmark/caffe2_benchmark.cc
@@ -6,8 +6,8 @@
 #include "caffe2/core/init.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
-#include "caffe2/proto/caffe2.pb.h"
 #include "caffe2/mobile/contrib/opengl/core/rewrite_net.h"
+#include "caffe2/proto/caffe2.pb.h"
 #include "caffe2/share/contrib/observers/observer_config.h"
 #include "caffe2/utils/proto_utils.h"
 #include "caffe2/utils/string_utils.h"
@@ -164,10 +164,12 @@ int main(int argc, char** argv) {
       net_def = opengl_net_def;
       if (caffe2::FLAGS_run_individual) {
         caffe2::FLAGS_run_individual = false;
-        LOG(INFO) << "OpenGL implementation does not support individual operator delay. Run net delay only";
+        LOG(INFO)
+            << "OpenGL implementation does not support individual operator delay. Run net delay only";
       }
     } else {
-      LOG(ERROR) << "Net cannot be converted to OpenGL format, use original model instead";
+      LOG(ERROR)
+          << "Net cannot be converted to OpenGL format, use original model instead";
     }
   } else if (caffe2::FLAGS_engine == "nnpack") {
     for (int i = 0; i < net_def.op_size(); i++) {

--- a/caffe2/share/contrib/binaries/caffe2_benchmark/caffe2_benchmark.cc
+++ b/caffe2/share/contrib/binaries/caffe2_benchmark/caffe2_benchmark.cc
@@ -176,8 +176,7 @@ int main(int argc, char** argv) {
           << "Net cannot be converted to OpenGL format, use original model instead";
     }
 #else
-    LOG(ERROR)
-        << "OpenGL build can only be used in mobile platform";
+    LOG(ERROR) << "OpenGL build can only be used in mobile platform";
 #endif
 
   } else if (caffe2::FLAGS_backend == "nnpack") {

--- a/caffe2/share/contrib/binaries/caffe2_benchmark/caffe2_benchmark.cc
+++ b/caffe2/share/contrib/binaries/caffe2_benchmark/caffe2_benchmark.cc
@@ -7,10 +7,16 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/mobile/contrib/opengl/core/rewrite_net.h"
 #include "caffe2/share/contrib/observers/observer_config.h"
 #include "caffe2/utils/proto_utils.h"
 #include "caffe2/utils/string_utils.h"
 
+CAFFE2_DEFINE_string(
+    engine,
+    "default",
+    "The backend engine to use when running the model. The allowed "
+    "engines choices are: default, nnpack, opengl");
 CAFFE2_DEFINE_string(
     init_net,
     "",
@@ -106,9 +112,9 @@ int main(int argc, char** argv) {
   unique_ptr<caffe2::Workspace> workspace(new caffe2::Workspace());
 
   // Run initialization network.
-  caffe2::NetDef net_def;
-  CAFFE_ENFORCE(ReadProtoFromFile(caffe2::FLAGS_init_net, &net_def));
-  CAFFE_ENFORCE(workspace->RunNetOnce(net_def));
+  caffe2::NetDef init_net_def;
+  CAFFE_ENFORCE(ReadProtoFromFile(caffe2::FLAGS_init_net, &init_net_def));
+  CAFFE_ENFORCE(workspace->RunNetOnce(init_net_def));
 
   // Load input.
   if (caffe2::FLAGS_input.size()) {
@@ -150,7 +156,28 @@ int main(int argc, char** argv) {
   }
 
   // Run main network.
+  caffe2::NetDef net_def;
   CAFFE_ENFORCE(ReadProtoFromFile(caffe2::FLAGS_net, &net_def));
+  if (caffe2::FLAGS_engine == "opengl") {
+    caffe2::NetDef opengl_net_def;
+    if (caffe2::tryConvertToOpenGL(init_net_def, net_def, &opengl_net_def)) {
+      net_def = opengl_net_def;
+      if (caffe2::FLAGS_run_individual) {
+        caffe2::FLAGS_run_individual = false;
+        LOG(INFO) << "OpenGL implementation does not support individual operator delay. Run net delay only";
+      }
+    } else {
+      LOG(ERROR) << "Net cannot be converted to OpenGL format, use original model instead";
+    }
+  } else if (caffe2::FLAGS_engine == "nnpack") {
+    for (int i = 0; i < net_def.op_size(); i++) {
+      caffe2::OperatorDef* op_def = net_def.mutable_op(i);
+      op_def->set_engine("NNPACK");
+    }
+  } else {
+    CAFFE_ENFORCE(caffe2::FLAGS_engine == "default", "Engine is not supported");
+  }
+
   caffe2::NetBase* net = workspace->CreateNet(net_def);
   CHECK_NOTNULL(net);
 


### PR DESCRIPTION
Support the default, nnpack, and opengl back end engines. There is no need to change the model. The file would convert the model to appropriate backend. 

Test Plan: run caffe2_benchmark with backend nnpack and opengl on some models, and the delay is correctly reported. 