### PR TITLE
Fix AppVeyor Windows build due to template chaining

### DIFF
--- a/caffe2/core/plan_executor.cc
+++ b/caffe2/core/plan_executor.cc
@@ -138,18 +138,18 @@ struct WorkspaceIdInjector {
   static const string GLOBAL_WORKSPACE_ID;
 
   void InjectWorkspaceId(Workspace* workspace) {
-      Blob* node_id_blob = workspace->GetBlob(NODE_ID);
-      if (node_id_blob) {
-          TensorCPU node_id_tensor = node_id_blob->template Get<TensorCPU>();
-          int node_id = node_id_tensor.template data<int32_t>()[0];
-          int64_t global_ws_id = (seq_++) + (static_cast<int64_t>(node_id) << 32);
-          Blob* global_ws_id_blob = workspace->CreateLocalBlob(GLOBAL_WORKSPACE_ID);
-          TensorCPU* global_ws_id_tensor =
-              global_ws_id_blob->template GetMutable<TensorCPU>();
-          global_ws_id_tensor->template Resize();
-          global_ws_id_tensor->template mutable_data<int64_t>()[0] = global_ws_id;
-          VLOG(1) << "Adding " << GLOBAL_WORKSPACE_ID << " = " << global_ws_id;
-      }
+    Blob* node_id_blob = workspace->GetBlob(NODE_ID);
+    if (node_id_blob) {
+      TensorCPU node_id_tensor = node_id_blob->template Get<TensorCPU>();
+      int node_id = node_id_tensor.template data<int32_t>()[0];
+      int64_t global_ws_id = (seq_++) + (static_cast<int64_t>(node_id) << 32);
+      Blob* global_ws_id_blob = workspace->CreateLocalBlob(GLOBAL_WORKSPACE_ID);
+      TensorCPU* global_ws_id_tensor =
+          global_ws_id_blob->template GetMutable<TensorCPU>();
+      global_ws_id_tensor->Resize();
+      global_ws_id_tensor->template mutable_data<int64_t>()[0] = global_ws_id;
+      VLOG(1) << "Adding " << GLOBAL_WORKSPACE_ID << " = " << global_ws_id;
+    }
   }
 
  private:

--- a/caffe2/core/plan_executor.cc
+++ b/caffe2/core/plan_executor.cc
@@ -138,17 +138,18 @@ struct WorkspaceIdInjector {
   static const string GLOBAL_WORKSPACE_ID;
 
   void InjectWorkspaceId(Workspace* workspace) {
-    Blob* node_id_blob = workspace->GetBlob(NODE_ID);
-    if (node_id_blob) {
-      int node_id =
-          node_id_blob->template Get<TensorCPU>().template data<int32_t>()[0];
-      int64_t global_ws_id = (seq_++) + (static_cast<int64_t>(node_id) << 32);
-      Blob* global_ws_id_blob = workspace->CreateLocalBlob(GLOBAL_WORKSPACE_ID);
-      global_ws_id_blob->template GetMutable<TensorCPU>()->template Resize();
-      global_ws_id_blob->template GetMutable<TensorCPU>()
-          ->template mutable_data<int64_t>()[0] = global_ws_id;
-      VLOG(1) << "Adding " << GLOBAL_WORKSPACE_ID << " = " << global_ws_id;
-    }
+      Blob* node_id_blob = workspace->GetBlob(NODE_ID);
+      if (node_id_blob) {
+          TensorCPU node_id_tensor = node_id_blob->template Get<TensorCPU>();
+          int node_id = node_id_tensor.template data<int32_t>()[0];
+          int64_t global_ws_id = (seq_++) + (static_cast<int64_t>(node_id) << 32);
+          Blob* global_ws_id_blob = workspace->CreateLocalBlob(GLOBAL_WORKSPACE_ID);
+          TensorCPU* global_ws_id_tensor =
+              global_ws_id_blob->template GetMutable<TensorCPU>();
+          global_ws_id_tensor->template Resize();
+          global_ws_id_tensor->template mutable_data<int64_t>()[0] = global_ws_id;
+          VLOG(1) << "Adding " << GLOBAL_WORKSPACE_ID << " = " << global_ws_id;
+      }
   }
 
  private:


### PR DESCRIPTION
The windows compiler has a bug with chained templates. This diff avoids using such pattern in `plan_executor.cc`.