### PR TITLE
Re-enable event_test/event_gpu_test

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -36,7 +36,7 @@ case "${BUILD_ENVIRONMENT}" in
 esac
 
 # Configure
-cmake .. ${CMAKE_ARGS[*]}
+cmake .. ${CMAKE_ARGS[*]} "$@"
 
 # Build
 if [ "$(uname)" == "Linux" ]; then

--- a/.jenkins/test.sh
+++ b/.jenkins/test.sh
@@ -25,12 +25,6 @@ echo "Running C++ tests.."
 for test in ./test/*; do
   # Skip tests we know are hanging or bad
   case "$(basename "$test")" in
-    event_test)
-      continue
-      ;;
-    event_gpu_test)
-      continue
-      ;;
     net_test)
       continue
       ;;


### PR DESCRIPTION
Disabled when configuring Jenkins to get a run where tests pass.