### PR TITLE
Re-enable mkl_utils_test

### DIFF
--- a/.jenkins/test.sh
+++ b/.jenkins/test.sh
@@ -28,9 +28,6 @@ for test in ./test/*; do
     net_test)
       continue
       ;;
-    mkl_utils_test)
-      continue
-      ;;
   esac
 
   "$test" --gtest_output=xml:"$TEST_DIR"/cpp/$(basename "$test").xml


### PR DESCRIPTION
Disabled when configuring Jenkins to get a run where tests pass.