### PR TITLE
Fixed layout of highlighted code

### DIFF
--- a/_sass/_syntax-highlighting.scss
+++ b/_sass/_syntax-highlighting.scss
@@ -85,6 +85,7 @@
     table {
       background: none;
       border: none;
+      table-layout: auto;
 
       tbody {
         tr {


### PR DESCRIPTION
Just fixing the way code looks in the manuals.

Currently caffe2.ai it looks like this on my devices:

![screenshot from 2017-11-11 17-31-10](https://user-images.githubusercontent.com/6318811/32690337-324ac3f4-c706-11e7-8284-afd9c994c57f.png)
 