### PR TITLE
Limit this fix to apple clang only

### DIFF
--- a/caffe2/perfkernels/cvtsh_ss_bugfix.h
+++ b/caffe2/perfkernels/cvtsh_ss_bugfix.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#if defined(__APPLE__) && ((__clang_major__ < 8) || ((__clang_major__ == 8) && (__clang_minor__ < 1)))
+#if defined(__apple_build_version__) && ((__clang_major__ < 8) || ((__clang_major__ == 8) && (__clang_minor__ < 1)))
 
 #include <emmintrin.h>
 


### PR DESCRIPTION
Use "__apple_build_version__" macro to distinguish Apple's Clang while brew installed LLVM will compile caffe2 without trouble.