### PR TITLE
Fix function signature in ATenOp for at::Half Set function

### DIFF
--- a/caffe2/contrib/aten/aten_op.cc
+++ b/caffe2/contrib/aten/aten_op.cc
@@ -29,7 +29,7 @@ CAFFE_KNOWN_TYPE(at::Half);
 
 namespace math {
 template<>
-void Set<at::Half,CPUContext>(TIndex N, at::Half h, at::Half* v, CPUContext * c) {
+void Set<at::Half,CPUContext>(const size_t N, const at::Half h, at::Half* v, CPUContext * c) {
   Set(0, h.x, (uint16_t*) v, c);
 }
 }


### PR DESCRIPTION
https://github.com/caffe2/caffe2/commit/c777be07d97c556d0acb7b5e15c5f16f4914dcf0 changed the type signature for the Set function, this fixes it for the ATenOp