### PR TITLE
Disable protobuf libprotoc and protoc build for cross compilation.

### DIFF
--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -42,16 +42,16 @@ if (WIN32)
   find_package(Protobuf NO_MODULE)
 elseif (ANDROID OR IOS)
   custom_protobuf_find()
-  if (IOS_PLATFORM STREQUAL "WATCHOS")
-    # Unfortunately, WatchOS does not support building libprotoc and protoc,
-    # so we will need to exclude it. The problem of using EXCLUDE_FROM_ALL is
-    # that one is not going to be able to run cmake install. A proper solution
-    # has to be implemented by protobuf since we derive our cmake files from
-    # there.
-    set_target_properties(
-        libprotoc protoc PROPERTIES
-        EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
-  endif()
+  # Unfortunately, new protobuf does not support libprotoc and protoc
+  # cross-compilation so we will need to exclude it.
+  # The problem of using EXCLUDE_FROM_ALL is that one is not going to be able
+  # to run cmake install. A proper solution has to be implemented by protobuf
+  # since we derive our cmake files from there.
+  # TODO(jiayq): change this once https://github.com/google/protobuf/pull/3878
+  # merges.
+  set_target_properties(
+      libprotoc protoc PROPERTIES
+      EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
 else()
   # Always use libprotobuf from tree if a custom PROTOBUF
   if(EXISTS "${CAFFE2_CUSTOM_PROTOC_EXECUTABLE}")


### PR DESCRIPTION
Also bumped third_party/protobuf to v3.4.1 similar to #1462 . cc @pietern 