### PR TITLE
disable travis Linux host build, as we are moving to using jenkins for contbuild.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ env:
     - BUILD_CCACHE_DIR=~/build/ccache
     - BUILD_NINJA_DIR=~/build/ninja
   matrix:
-    - BUILD=linux
-    - BUILD=linux-gcc5
-    - BUILD=linux-cuda
-    - BUILD=linux-mkl
+    #- BUILD=linux
+    #- BUILD=linux-gcc5
+    #- BUILD=linux-cuda
+    #- BUILD=linux-mkl
     - BUILD=linux-android
 
 matrix:


### PR DESCRIPTION
I only commented them out so that if we want to run Travis in the future, we could potentially still enable them.