### PR TITLE
Fix function signature in ATenOp for at::Half Set function (GPU version)

### DIFF
--- a/caffe2/contrib/aten/aten_op_cuda.cc
+++ b/caffe2/contrib/aten/aten_op_cuda.cc
@@ -27,7 +27,7 @@ at::Backend ATenOp<CUDAContext>::backend() const {
 
 namespace math {
 template<>
-void Set<at::Half,CUDAContext>(TIndex N, at::Half h, at::Half* v, CUDAContext * c) {
+void Set<at::Half,CUDAContext>(const size_t N, const at::Half h, at::Half* v, CUDAContext * c) {
   Set(0, h.x, (uint16_t*) v, c);
 }
 }


### PR DESCRIPTION
The CPU version is fixed here. https://github.com/caffe2/caffe2/pull/1464/files

Now fix GPU version. 