### PR TITLE
Build Redis support on Linux

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -60,6 +60,11 @@ case "${BUILD_ENVIRONMENT}" in
     ;;
 esac
 
+# Try to include Redis support for Linux builds
+if [ "$(uname)" == "Linux" ]; then
+  CMAKE_ARGS+=("-DUSE_REDIS=ON")
+fi
+
 # Configure
 cmake "${ROOT_DIR}" ${CMAKE_ARGS[*]} "$@"
 


### PR DESCRIPTION
Builds can then execute rendezvous where a shared file system is not available.