### PR TITLE
[caffe2] Fix contrib/script build

### DIFF
--- a/caffe2/contrib/CMakeLists.txt
+++ b/caffe2/contrib/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(gloo)
 add_subdirectory(nccl)
 add_subdirectory(nnpack)
 add_subdirectory(shm_mutex)
+add_subdirectory(script)
 # Finally pass the src lists back to the parent
 
 # CPU source, test sources, binary sources


### PR DESCRIPTION
Fixes a missing line in https://github.com/caffe2/caffe2/commit/ff2c9735477e4d5076da4ddfc964eb0fd3c360bf

@zdevito @jamesr66a 