### PR TITLE
make sure we do integer division

### DIFF
--- a/caffe2/python/models/seq2seq/train.py
+++ b/caffe2/python/models/seq2seq/train.py
@@ -754,7 +754,7 @@ def main():
 
     if args.use_bidirectional_encoder:
         assert args.encoder_cell_num_units % 2 == 0
-        encoder_layer_configs[0]['num_units'] /= 2
+        encoder_layer_configs[0]['num_units'] //= 2
 
     decoder_layer_configs = [
         dict(


### PR DESCRIPTION
when building a bidirectional encoder, this may end up giving us a float, rather than an integer
fixes issue #1517 