### PR TITLE
Fix example in zoo.md

### DIFF
--- a/_docs/zoo.md
+++ b/_docs/zoo.md
@@ -66,10 +66,17 @@ Then you can use python to import the model directly as a module. If you have tr
 ```python
 from caffe2.python import workspace
 from caffe2.python.models import squeezenet as mynet
+import numpy as np
+
 init_net = mynet.init_net
 predict_net = mynet.predict_net
 # you must name it something
 predict_net.name = "squeezenet_predict"
+
+# Dummy batch
+data = np.random.rand(1, 3, 227, 227)
+workspace.FeedBlob("data", data)
+
 workspace.RunNetOnce(init_net)
 workspace.CreateNet(predict_net)
 p = workspace.Predictor(init_net.SerializeToString(), predict_net.SerializeToString())


### PR DESCRIPTION
Running the code at the bottom of the example errors:

```
W1201 20:27:49.700076 3761611712 workspace.cc:190] Blob data not in the workspace.
Traceback for operator 0 in network squeezenet_predict
Traceback (most recent call last):
  File "pre_trained_simple.py", line 12, in <module>
    workspace.CreateNet(predict_net)
  File "/usr/local/caffe2/python/workspace.py", line 167, in CreateNet
    StringifyProto(net), overwrite,
  File "/usr/local/caffe2/python/workspace.py", line 193, in CallWithExceptionIntercept
    return func(*args, **kwargs)
RuntimeError: [enforce fail at operator.cc:53] blob != nullptr. op Conv: Encountered a non-existing input blob: data
```

I added some lines to create a dummy `data` batch. Now the example works