### PR TITLE
Fix typo in clang ifdef to fix clang 3.9 build

### DIFF
--- a/caffe2/perfkernels/cvtsh_ss_bugfix.h
+++ b/caffe2/perfkernels/cvtsh_ss_bugfix.h
@@ -22,7 +22,7 @@
 #endif
 
 // Regular clang was fixed in 3.9
-#if defined(__clang__) && (__clang_major__ < 4) && (__clang__minor__ < 9)
+#if defined(__clang__) && (__clang_major__ < 4) && (__clang_minor__ < 9)
 #define __CLANG_NEED_FIX 1
 #endif
 


### PR DESCRIPTION
This prevented building with clang 3.9.