### PR TITLE
Set of bugfixes for script compiler

### DIFF
--- a/caffe2/contrib/script/compiler.cc
+++ b/caffe2/contrib/script/compiler.cc
@@ -120,7 +120,7 @@ struct DefCompiler {
         return "Add";
       case '-':
         if (ninputs == 1)
-          return "Negate";
+          return "Negative";
         else
           return "Sub";
       case '*':
@@ -158,7 +158,7 @@ struct DefCompiler {
       } break;
       case TK_LIST:
         for (auto t : value->trees()) {
-          auto v = t->doubleValue();
+          auto v = t->tree(0)->doubleValue();
           if (attr.format() == "f")
             arg->add_floats(v);
           else

--- a/caffe2/contrib/script/parser.h
+++ b/caffe2/contrib/script/parser.h
@@ -122,18 +122,20 @@ struct Parser {
     return parseList('(', ',', ')', [&](int i) { return parseExp(); });
   }
   TreeRef parseConst() {
+    float mult = 1.0f;
+    while (L.nextIf('-')) {
+      mult *= -1.0f;
+    }
     auto t = L.expect(TK_NUMBER);
-    return c(TK_CONST, t.range, {d(t.doubleValue())});
+    return c(TK_CONST, t.range, {d(mult * t.doubleValue())});
   }
   TreeRef parseAttributeValue() {
     int kind = L.cur().kind;
     switch (kind) {
-      case TK_NUMBER:
-        return parseConst();
-      case '{':
-        return parseList('{', ',', '}', [&](int i) { return parseConst(); });
+      case '[':
+        return parseList('[', ',', ']', [&](int i) { return parseConst(); });
       default:
-        L.expected("a constant expression");
+        return parseConst();
     }
   }
   std::pair<TreeRef, TreeRef> parseOperatorArguments() {


### PR DESCRIPTION
* Fix typo in negative constant handling "Negate" -> "Negative"
* Fix unpacking constant in parsing elements for a list attribute
* Parse negative signs in constants
* Switch list syntax to use square brackets in attributes