### PR TITLE
[caffe2][script] Set broadcast flag for binary operators 

### DIFF
--- a/caffe2/contrib/script/compiler.cc
+++ b/caffe2/contrib/script/compiler.cc
@@ -120,7 +120,7 @@ struct DefCompiler {
         return "Add";
       case '-':
         if (ninputs == 1)
-          return "Negate";
+          return "Negative";
         else
           return "Sub";
       case '*':
@@ -158,7 +158,7 @@ struct DefCompiler {
       } break;
       case TK_LIST:
         for (auto t : value->trees()) {
-          auto v = t->doubleValue();
+          auto v = t->tree(0)->doubleValue();
           if (attr.format() == "f")
             arg->add_floats(v);
           else

--- a/caffe2/contrib/script/compiler.cc
+++ b/caffe2/contrib/script/compiler.cc
@@ -204,6 +204,9 @@ struct DefCompiler {
           op->add_input(v);
         }
         op->add_output(fresh());
+        auto broadcast = op->add_arg();
+        broadcast->set_name("broadcast");
+        broadcast->set_i(1);
         return op;
       }
       case TK_APPLY: {

--- a/caffe2/contrib/script/parser.h
+++ b/caffe2/contrib/script/parser.h
@@ -127,7 +127,13 @@ struct Parser {
       mult *= -1.0f;
     }
     auto t = L.expect(TK_NUMBER);
-    return c(TK_CONST, t.range, {d(mult * t.doubleValue())});
+    std::string type_ident;
+
+    if (L.cur().kind == TK_IDENT) {
+      Token type_ident_tok = L.expect(TK_IDENT);
+      type_ident = type_ident_tok.text();
+    }
+    return c(TK_CONST, t.range, {d(mult * t.doubleValue()), s(type_ident)});
   }
   TreeRef parseAttributeValue() {
     int kind = L.cur().kind;
@@ -149,8 +155,7 @@ struct Parser {
           auto ident = parseIdent();
           L.expect('=');
           auto v = parseAttributeValue();
-          auto f = s(L.expect(TK_IDENT).text());
-          attributes.push_back(Attribute::create(ident->range(), ident, v, f));
+          attributes.push_back(Attribute::create(ident->range(), ident, v));
         } else {
           inputs.push_back(parseExp());
         }

--- a/caffe2/contrib/script/parser.h
+++ b/caffe2/contrib/script/parser.h
@@ -122,18 +122,20 @@ struct Parser {
     return parseList('(', ',', ')', [&](int i) { return parseExp(); });
   }
   TreeRef parseConst() {
+    float mult = 1.0f;
+    while (L.nextIf('-')) {
+      mult *= -1.0f;
+    }
     auto t = L.expect(TK_NUMBER);
-    return c(TK_CONST, t.range, {d(t.doubleValue())});
+    return c(TK_CONST, t.range, {d(mult * t.doubleValue())});
   }
   TreeRef parseAttributeValue() {
     int kind = L.cur().kind;
     switch (kind) {
-      case TK_NUMBER:
-        return parseConst();
-      case '{':
-        return parseList('{', ',', '}', [&](int i) { return parseConst(); });
+      case '[':
+        return parseList('[', ',', ']', [&](int i) { return parseConst(); });
       default:
-        L.expected("a constant expression");
+        return parseConst();
     }
   }
   std::pair<TreeRef, TreeRef> parseOperatorArguments() {

--- a/caffe2/contrib/script/tree_views.h
+++ b/caffe2/contrib/script/tree_views.h
@@ -113,7 +113,7 @@ struct Ident : public TreeView {
 
 struct Attribute : public TreeView {
   explicit Attribute(const TreeRef& tree) : TreeView(tree) {
-    tree_->match(TK_ATTRIBUTE, name_, value_, format_);
+    tree_->match(TK_ATTRIBUTE, name_, value_);
   }
   Ident name() const {
     return Ident(name_);
@@ -121,21 +121,13 @@ struct Attribute : public TreeView {
   TreeRef value() const {
     return value_;
   }
-  const std::string& format() const {
-    return format_->stringValue();
-  }
-  static TreeRef create(
-      const SourceRange& range,
-      TreeRef name,
-      TreeRef value,
-      TreeRef format) {
-    return Compound::create(TK_ATTRIBUTE, range, {name, value, format});
+  static TreeRef create(const SourceRange& range, TreeRef name, TreeRef value) {
+    return Compound::create(TK_ATTRIBUTE, range, {name, value});
   }
 
  private:
   TreeRef name_;
   TreeRef value_;
-  TreeRef format_;
 };
 
 struct Apply : public TreeView {


### PR DESCRIPTION
lines such as

    output_scores = best_scores_per_hypo + scores_t_squeezed
    hypo_t_int64 = best_indices / 6LL

will emit the respective binary operator (e.g. `Add`, `Div`) with the `broadcast` flag set to 1