### PR TITLE
[cmake] FFmpeg libswresample added

### DIFF
--- a/cmake/Modules/FindFFmpeg.cmake
+++ b/cmake/Modules/FindFFmpeg.cmake
@@ -39,6 +39,11 @@ else (FFMPEG_LIBRARIES AND FFMPEG_INCLUDE_DIR)
     PATHS ${_FFMPEG_SWSCALE_LIBRARY_DIRS} /usr/lib /usr/local/lib /opt/local/lib /sw/lib
   )
 
+  find_library(FFMPEG_LIBSWRESAMPLE
+    NAMES swresample
+    PATHS ${_FFMPEG_SWRESAMPLE_LIBRARY_DIRS} /usr/lib /usr/local/lib /opt/local/lib /sw/lib
+  )
+
   if (FFMPEG_LIBAVCODEC AND FFMPEG_LIBAVFORMAT)
     set(FFMPEG_FOUND TRUE)
   endif()
@@ -51,6 +56,7 @@ else (FFMPEG_LIBRARIES AND FFMPEG_INCLUDE_DIR)
       ${FFMPEG_LIBAVFORMAT}
       ${FFMPEG_LIBAVUTIL}
       ${FFMPEG_LIBSWSCALE}
+      ${FFMPEG_LIBSWRESAMPLE}
     )
 
     if (NOT FFMPEG_FIND_QUIETLY)


### PR DESCRIPTION
when caffe2 build with ffmpeg, It is needed to add libswresample.
So I added it