### PR TITLE
Resuppress adagrad health checks

### DIFF
--- a/caffe2/python/operator_test/adagrad_test.py
+++ b/caffe2/python/operator_test/adagrad_test.py
@@ -21,7 +21,7 @@ from __future__ import unicode_literals
 import functools
 
 import hypothesis
-from hypothesis import given
+from hypothesis import given, settings, HealthCheck
 import hypothesis.strategies as st
 import numpy as np
 
@@ -78,6 +78,9 @@ class TestAdagrad(hu.HypothesisTestCase):
             [param, momentum, grad, lr],
             functools.partial(self.ref_adagrad, epsilon=epsilon))
 
+    # Suppress filter_too_much health check.
+    # Likely caused by `assume` call falling through too often.
+    @settings(suppress_health_check=[HealthCheck.filter_too_much])
     @given(inputs=hu.tensors(n=3),
            lr=st.floats(min_value=0.01, max_value=0.99,
                         allow_nan=False, allow_infinity=False),
@@ -194,6 +197,9 @@ class TestAdagrad(hu.HypothesisTestCase):
                 gc, op, [param_i, momentum_i, indices, grad, lr], ref_sparse
             )
 
+    # Suppress filter_too_much health check.
+    # Likely caused by `assume` call falling through too often.
+    @settings(suppress_health_check=[HealthCheck.filter_too_much])
     @given(inputs=hu.tensors(n=2),
            lr=st.floats(min_value=0.01, max_value=0.99,
                         allow_nan=False, allow_infinity=False),


### PR DESCRIPTION
Commit 479e4ce5 didn't end up solving the health checks firing and
they are likely still caused by the remaining `assume` calls.

