### PR TITLE
Fix the ATen static building issue on CUDA

### DIFF
--- a/caffe2/contrib/aten/aten_op_template.h
+++ b/caffe2/contrib/aten/aten_op_template.h
@@ -34,14 +34,6 @@ namespace caffe2 {
 
 using at::Half; // for AT_FORALL_SCALAR_TYPES
 
-std::function<void(void*)> deleterFor(at::Tensor t) {
-  // return a closure that holds a handle to t until it is called
-  // to keep the aten memory alive
-  return [t](void * ptr) mutable {
-    t.reset();
-  };
-}
-
 template <class Context>
 class ATenOp : public Operator<Context> {
  public:
@@ -110,7 +102,12 @@ private:
     auto at_sizes = src.sizes();
     std::vector<int64_t> dims(at_sizes.begin(),at_sizes.end());
     dst->Resize(dims);
-    dst->ShareExternalPointer(src.data_ptr(), typeMetaFor(src), 0, deleterFor(src));
+    dst->ShareExternalPointer(src.data_ptr(), typeMetaFor(src), 0,
+        [src](void * ptr) mutable {
+          // return a closure that holds a handle to t until it is called
+          // to keep the aten memory alive
+          return src.reset();
+        });
   }
   void assignListStartingAt(
       size_t offset,


### PR DESCRIPTION
@Yangqing @pietern 

With https://github.com/caffe2/caffe2/pull/1627, Caffe2 can statically built with USE_ATEN=ON and USE_CUDA=OFF. But the function deleterFor defined in aten_op_template.h causes duplicated symbols in libcaffe2.a and libcaffe2_gpu.a.

I checked at only one place we call this function, so directly manually inline it into the caller. Later when we use it at other places, we can just extract it again, and put the implementation in aten_op.cc.