### PR TITLE
Check GCC version on Ubuntu

### DIFF
--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -1,6 +1,33 @@
 include(CheckCXXSourceCompiles)
 include(CMakePushCheckState)
 
+# ---[ If running on Ubuntu, check system version and compiler version.
+if(EXISTS "/etc/os-release")
+  execute_process(COMMAND
+    "sed" "-ne" "s/^ID=\\([a-z]\\+\\)$/\\1/p" "/etc/os-release"
+    OUTPUT_VARIABLE OS_RELEASE_ID
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  execute_process(COMMAND
+    "sed" "-ne" "s/^VERSION_ID=\"\\([0-9\\.]\\+\\)\"$/\\1/p" "/etc/os-release"
+    OUTPUT_VARIABLE OS_RELEASE_VERSION_ID
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  if(OS_RELEASE_ID STREQUAL "ubuntu")
+    if(OS_RELEASE_VERSION_ID VERSION_GREATER "17.04")
+      if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0.0")
+          message(FATAL_ERROR
+            "Please use GCC 6 or higher on Ubuntu 17.04 and higher. "
+            "For more information, see: "
+            "https://github.com/caffe2/caffe2/issues/1633"
+            )
+        endif()
+      endif()
+    endif()
+  endif()
+endif()
+
 # ---[ Check if the data type long and int32_t/int64_t overlap.
 cmake_push_check_state(RESET)
 set(CMAKE_REQUIRED_FLAGS "-std=c++11")


### PR DESCRIPTION
Thanks to @feldim2425 we know that GCC 5 in Ubuntu 17.04 and later
doesn't define the macro _GLIBCXX_USE_C99 and by extension the
std::to_string, std::stoi, and std::stod functions (and probably
more). Instead of avoiding using these functions, we simply recommend
people to use GCC 6 or higher on the newer Ubuntu versions where GCC 5
doesn't work.

As a side note, CUDA 8.0 is compatible with GCC up to version 5. This
implies that compiling Caffe2 with CUDA on Ubuntu >= 17.10 implies
using CUDA >= 9.0. If you need to compile with CUDA 8.0 and are on
Ubuntu, you are stuck on version 16.04 or lower.

I verified this fix by running cmake on Ubuntu 17.10 with
-DCMAKE_CXX_COMPILER=/usr/bin/g++5 and observing the fatal error.

This closes #1633.

