### PR TITLE
Make Jenkins test directory less strict.

### DIFF
--- a/.jenkins/test.sh
+++ b/.jenkins/test.sh
@@ -14,8 +14,8 @@ fi
 export PYTHONPATH="${PYTHONPATH}:/usr/local/caffe2"
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/caffe2/lib"
 
-if [ -d ./test ]; then
-  echo "Directory ./test already exists; please remove it..."
+if [ -d ./test ] && ! [ -z "$(ls -A ./test)" ]; then
+  echo "Directory ./test already exists and contains files; please remove it..."
   exit 1
 fi
 


### PR DESCRIPTION
I need this change for my plans in CI side, where I plan to mount a
directory onto the test directory so that I can easily transfer the test
files back to a host Jenkins instance.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

