### PR TITLE
Fix RNN scoping situation

### DIFF
--- a/caffe2/python/models/seq2seq/seq2seq_util.py
+++ b/caffe2/python/models/seq2seq/seq2seq_util.py
@@ -579,7 +579,6 @@ def build_embedding_decoder(
             input_size = decoder_cells[-1].get_output_dim()
 
         cell = rnn_cell.LSTMCell(
-            name=get_layer_scope(scope, 'decoder', i),
             forward_only=forward_only,
             input_size=input_size,
             hidden_size=num_units,
@@ -618,6 +617,7 @@ def build_embedding_decoder(
         decoder_num_units=decoder_units_per_layer[-1],
         decoder_cells=decoder_cells,
         weighted_encoder_outputs=weighted_encoder_outputs,
+        name=scope,
     )
     decoder_outputs, _ = attention_decoder.apply_over_sequence(
         model=model,

--- a/caffe2/python/models/seq2seq/translate.py
+++ b/caffe2/python/models/seq2seq/translate.py
@@ -141,7 +141,6 @@ class Seq2SeqModelCaffe2EnsembleDecoder(object):
                 )
 
             cell = rnn_cell.LSTMCell(
-                name=seq2seq_util.get_layer_scope(scope, 'decoder', i),
                 forward_only=True,
                 input_size=input_size,
                 hidden_size=num_units,

--- a/caffe2/python/observer_test.py
+++ b/caffe2/python/observer_test.py
@@ -87,7 +87,6 @@ class TestObservers(unittest.TestCase):
                 initial_states=init_blobs,
                 dim_in=input_dim,
                 dim_out=[hidden_dim] * num_layers,
-                scope="",
                 drop_states=True,
                 forward_only=forward_only,
                 return_last_layer_only=True,

--- a/caffe2/python/operator_test/gru_test.py
+++ b/caffe2/python/operator_test/gru_test.py
@@ -348,13 +348,16 @@ class GRUCellTest(hu.HypothesisTestCase):
                       drop_states=drop_states,
                       linear_before_reset=linear_before_reset)
         with core.DeviceScope(gc):
-            net = _prepare_rnn(t, n, d, create_rnn,
-                                outputs_with_grads=outputs_with_grads,
-                                memory_optim=False,
-                                forget_bias=0.0,
-                                forward_only=fwd_only,
-                                drop_states=drop_states,
-                                linear_before_reset=linear_before_reset)[1]
+            net = _prepare_rnn(
+                t, n, d, create_rnn,
+                outputs_with_grads=outputs_with_grads,
+                memory_optim=False,
+                forget_bias=0.0,
+                forward_only=fwd_only,
+                drop_states=drop_states,
+                linear_before_reset=linear_before_reset,
+                num_states=1,
+            )[1]
         # here we don't provide a real input for the net but just for one of
         # its ops (RecurrentNetworkOp). So have to hardcode this name
         workspace.FeedBlob("test_name_scope/external/recurrent/i2h",

--- a/caffe2/python/operator_test/rnn_cell_test.py
+++ b/caffe2/python/operator_test/rnn_cell_test.py
@@ -1637,7 +1637,6 @@ class RNNCellTest(hu.HypothesisTestCase):
            max_num_units=st.integers(1, 3),
            num_layers=st.integers(2, 3),
            batch_size=st.integers(1, 3))
-    @utils.debug
     def test_multi_lstm(
         self,
         input_length,
@@ -1665,7 +1664,7 @@ class RNNCellTest(hu.HypothesisTestCase):
             initial_states=None,
             dim_in=dim_in,
             dim_out=dim_out,
-            scope='test',
+            # scope='test',
             outputs_with_grads=(0,),
             return_params=False,
             memory_optimization=False,
@@ -1699,23 +1698,26 @@ class RNNCellTest(hu.HypothesisTestCase):
         for i in range(num_layers):
             hidden_input_list.append(
                 workspace.FetchBlob(
-                    'test/test/layer_{}/initial_hidden_state'.format(i)),
+                    'layer_{}/initial_hidden_state'.format(i)),
             )
             cell_input_list.append(
                 workspace.FetchBlob(
-                    'test/test/layer_{}/initial_cell_state'.format(i)),
+                    'layer_{}/initial_cell_state'.format(i)),
             )
+            # Input projection for the first layer is produced outside
+            # of the cell ans thus not scoped
+            prefix = 'layer_{}/'.format(i) if i > 0 else ''
             i2h_w_list.append(
-                workspace.FetchBlob('test/layer_{}/i2h_w'.format(i)),
+                workspace.FetchBlob('{}i2h_w'.format(prefix)),
             )
             i2h_b_list.append(
-                workspace.FetchBlob('test/layer_{}/i2h_b'.format(i)),
+                workspace.FetchBlob('{}i2h_b'.format(prefix)),
             )
             gates_w_list.append(
-                workspace.FetchBlob('test/layer_{}/gates_t_w'.format(i)),
+                workspace.FetchBlob('layer_{}/gates_t_w'.format(i)),
             )
             gates_b_list.append(
-                workspace.FetchBlob('test/layer_{}/gates_t_b'.format(i)),
+                workspace.FetchBlob('layer_{}/gates_t_b'.format(i)),
             )
 
         workspace.RunNetOnce(model.net)
@@ -1772,6 +1774,7 @@ class RNNCellTest(hu.HypothesisTestCase):
                 step_size=0.0001,
                 threshold=0.05,
             )
+
 
 if __name__ == "__main__":
     workspace.GlobalInit([

--- a/caffe2/python/scope.py
+++ b/caffe2/python/scope.py
@@ -50,7 +50,7 @@ def CurrentDeviceScope():
 @contextlib.contextmanager
 def NameScope(prefix, reset=False):
     global _threadlocal_scope
-    assert isinstance(prefix, basestring), \
+    assert isinstance(prefix, basestring) or prefix is None, \
         "NameScope takes in a string as its argument."
     old_scope = CurrentNameScope()
     prefix = prefix + _NAMESCOPE_SEPARATOR if prefix else ''

--- a/caffe2/python/utils.py
+++ b/caffe2/python/utils.py
@@ -290,6 +290,9 @@ class DebugMode(object):
             sys.exit(1)
             raise
 
+def raiseIfNotEqual(a, b, msg):
+    if a != b:
+        raise Exception("{}. {} != {}".format(msg, a, b))
 
 def debug(f):
     '''


### PR DESCRIPTION
There is a long lasting problem of scoping which was introduced in original python wrappers early in H1. Basically each RNNCell implemented has to manually scope outputs of each of the operators. If somebody forgets, then there could be weird bugs with layers etc.

Approach is the following. User has to explicitly specify current scope when using  apply_over_sequence function and others if the function is going to be called several times (like for stacking layers). This way we use Caffe2 native scoping approach instead of inventing one extra API people have to use (i.e. passing scope name as an argument to the RNNCell constructor).