### PR TITLE
docs: add how to install pybind11 in Ubuntu

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,7 @@
 #### Ubuntu
 
     sudo apt-get install libprotobuf-dev protobuf-compiler libatlas-base-dev libgoogle-glog-dev libgtest-dev liblmdb-dev libleveldb-dev libsnappy-dev python-dev python-pip libiomp-dev libopencv-dev libpthread-stubs0-dev cmake
-    sudo pip install numpy
+    sudo pip install numpy pybind11
     wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1404/x86_64/cuda-repo-ubuntu1404_8.0.44-1_amd64.deb
     sudo dpkg -i cuda-repo-ubuntu1404_8.0.44-1_amd64.deb
     sudo apt-get update


### PR DESCRIPTION
Fixes issue #1694.
This commit is to append how to install pybind11 (python package)
to get caffe2_pybind11_state.so while compiling Caffe2 source in
Ubuntu distribution.

**Self assessment:**
Passed in Ubuntu 14.04/16.04.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>

