### PR TITLE
Script: Support RPM package for Tizen target

### DIFF
--- a/scripts/tizen/4.0/.gbs.conf
+++ b/scripts/tizen/4.0/.gbs.conf
@@ -1,0 +1,26 @@
+[general]
+#Current profile name which should match a profile section name
+profile = profile.tizen
+tmpdir = /var/tmp
+editor = vim
+packaging_branch = tizen
+workdir = .
+
+[profile.tizen]
+#Common authentication info for whole profile
+#user = 
+#passwd = 
+obs = obs.tizen
+
+repos = repo.unified, repo.base
+buildroot = ~/GBS-ROOT-mytizen/
+
+[obs.tizen]
+#OBS API URL pointing to a remote OBS.
+url = https://api.tizen.org
+
+[repo.base]
+url = http://download.tizen.org/snapshots/tizen/base/latest/repos/standard/packages/
+
+[repo.unified]
+url = http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/

--- a/scripts/tizen/4.0/packaging/caffe2-eigen3-path.patch
+++ b/scripts/tizen/4.0/packaging/caffe2-eigen3-path.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4205569..d50f714 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -60,6 +60,10 @@ option(USE_OPENMP "Use OpenMP for parallel code" ON)
+ option(BUILD_PYTHON "Build python binaries" ON)
+ option(BUILD_BINARY "Build c++ binary executives" ON)
+ 
++# Eigen3 path
++# Note that Eigen3 is located in /usr/include/eigen3 in Tizen platform.
++INCLUDE_DIRECTORIES(/usr/include/eigen3)
++
+ # External projects
+ include(ExternalProject)
+ 

--- a/scripts/tizen/4.0/packaging/caffe2.manifest
+++ b/scripts/tizen/4.0/packaging/caffe2.manifest
@@ -1,0 +1,5 @@
+<manifest>
+ <request>
+    <domain name="_"/>
+ </request>
+</manifest>

--- a/scripts/tizen/4.0/packaging/caffe2.spec
+++ b/scripts/tizen/4.0/packaging/caffe2.spec
@@ -1,0 +1,176 @@
+Name:           caffe2
+Version:        0.7.0
+Release:        0
+Summary:        A deep learning, cross platform ML framework with the flexibility of Python and the speed of C++.
+Group:          Development/Tools
+License:        Apache-2.0
+URL:            https://github.com/caffe2/caffe2
+Distribution:   Tizen
+Vendor:         Samsung Electronics
+Packager:       Geunsik Lim <geunsik.lim@samsung.com>
+Source0:        %{name}-%{version}.tar.gz
+Source1001:     %{name}.manifest
+Patch0:         %{name}-eigen3-path.patch
+
+BuildRequires:  make cmake gcc binutils glibc glibc-devel cpp libstdc++
+BuildRequires:  protobuf-devel
+BuildRequires:  eigen3-devel
+BuildRequires:  openblas-devel
+BuildRequires:  lmdb-devel
+BuildRequires:  leveldb-devel
+BuildRequires:  gflags-devel
+BuildRequires:  boost-devel
+BuildRequires:  opencv-devel mesa
+
+BuildRequires:  python-python-gflags
+BuildRequires:  python = 2.7
+BuildRequires:  python-numpy-devel >= 1.7
+BuildRequires:  python-pybind11-devel
+
+Requires:       libleveldb
+Requires:       python-pybind11
+Requires:       opencv
+
+# Note that do not add git package to keep the build structure of GBS/OBS
+# BuildRequires:  git
+
+%description
+Caffe2 is a deep learning framework that provides an easy and straightforward
+way for you to experiment with deep learning and leverage community contributions
+of new models and algorithms. You can bring your creations to scale using the
+power of GPUs in the cloud or to the masses on mobile with cross-platform
+libraries of Caffe2.
+
+%package devel
+Summary:	caffe2 development package
+Group:		Development/Libraries/C and C++
+Provides:	caffe-devel = %{version}-%{release}
+Requires:	%{name} = %{version}
+Requires:	glibc-devel
+Requires:	gflags-devel
+Requires:	openblas-devel
+Requires:	protobuf-devel
+Requires:	glog-devel
+
+%description devel
+Header files and documentation for %{name} development.
+
+%package python
+Summary:	caffe2 python libraries
+Group:		Development/Libraries/C and C++
+Provides:	caffe-devel = %{version}-%{release}
+Requires:	%{name} = %{version}
+Requires:	libprotobuf
+
+%description python
+python libraries for %{name}.
+
+%prep
+%setup -q
+cp %{SOURCE1001} .
+%patch0 -p1 -b .path
+
+%build
+
+mkdir build
+pushd ./build
+# Note: add more dependencies above if you need libraries such as leveldb, lmdb, and so on.
+# If you have to disable a specific package due to a package absence
+# from https://git.tizen.org/cgit/, append -Dxxx_xxx=OFF option before executing cmake.
+#  -DUSE_BENCHMARK=OFF \
+#  -DCMAKE_INSTALL_PREFIX:PATH=/home/abuild/caffe2_deploy ..
+cmake \
+    -DCMAKE_VERBOSE_MAKEFILE=1 \
+    -DBUILD_TEST=OFF \
+    -DUSE_GFLAGS=ON  \
+    -DUSE_GLOG=ON \
+    -DUSE_NNPACK=OFF \
+    -DRUN_HAVE_STD_REGEX=0 \
+    -DRUN_HAVE_POSIX_REGEX=0 \
+    -DHAVE_GNU_POSIX_REGEX=0 \
+    -DUSE_MPI=OFF \
+    -DUSE_OPENMP=ON \
+    -DUSE_ROCKSDB=OFF \
+    -DUSE_LEVELDB=ON \
+    -DUSE_LMDB=ON \
+    -DBUILD_PYTHON=ON \
+    -DUSE_GLOO=OFF \
+    -DUSE_OPENCV=ON \
+    -DUSE_CUDA=OFF \
+%ifarch armv7l
+    -DCAFFE2_CPU_FLAGS="-mfpu=neon -mfloat-abi=soft" \
+%endif
+%ifarch aarch64
+    -DCAFFE2_CPU_FLAGS="-mtune=cortex-a53 -mabi=lp64" \
+%endif
+    .. \
+    || exit 1
+echo -e "Building Caffe2"
+make %{?_smp_mflags} || exit 1
+
+# verify a share file that is generated for Caffe2/CPU
+size ./caffe2/libCaffe2_CPU.so 
+size --format=sysv ./caffe2/libCaffe2_CPU.so 
+popd
+
+%install
+pushd build
+# create folders
+mkdir -p %{buildroot}%{_bindir}
+mkdir -p %{buildroot}%{_libdir}
+mkdir -p %{buildroot}%{_includedir}/caffe2/core/
+mkdir -p %{buildroot}%{_includedir}/caffe2/proto/
+mkdir -p %{buildroot}%{_includedir}/caffe/proto/
+mkdir -p %{buildroot}%{python_sitelib}/caffe2/
+
+# binary tools
+install -m 0755 -p ./caffe2/binaries/convert_caffe_image_db %{buildroot}%{_bindir}
+install -m 0755 -p ./caffe2/binaries/convert_db %{buildroot}%{_bindir}
+install -m 0755 -p ./caffe2/binaries/db_throughput %{buildroot}%{_bindir}
+install -m 0755 -p ./caffe2/binaries/make_cifar_db %{buildroot}%{_bindir}
+install -m 0755 -p ./caffe2/binaries/make_mnist_db %{buildroot}%{_bindir}
+install -m 0755 -p ./caffe2/binaries/predictor_verifier %{buildroot}%{_bindir}
+install -m 0755 -p ./caffe2/binaries/print_registered_core_operators %{buildroot}%{_bindir}
+install -m 0755 -p ./caffe2/binaries/run_plan %{buildroot}%{_bindir}
+install -m 0755 -p ./caffe2/binaries/speed_benchmark %{buildroot}%{_bindir}
+install -m 0755 -p ./caffe2/binaries/split_db %{buildroot}%{_bindir}
+
+# for CPU
+# TODO: support another architecture such as GPU, NPU.
+install -m 0644 -p ./caffe2/libCaffe2_CPU.so %{buildroot}%{_libdir}
+
+# for -devel
+install -m 0644 -p ./caffe2/core/*.h  %{buildroot}%{_includedir}/caffe2/core/
+install -m 0644 -p ./caffe2/proto/*.h  %{buildroot}%{_includedir}/caffe2/proto/
+
+# to convert caffe to caffe2 models
+install -m 0644 -p ./caffe/proto/caffe.pb.h  %{buildroot}%{_includedir}/caffe/proto/
+
+# install python packages
+cp -rf ./caffe2/python/* %{buildroot}%{python_sitelib}/caffe2/
+
+popd
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
+%files
+%defattr(-,root,root)
+%manifest %{name}.manifest
+%doc ./LICENSE
+%doc ./PATENTS
+%{_bindir}/*
+%{_libdir}/libCaffe2_CPU.so
+
+%files devel
+%{_includedir}/caffe2/*
+%{_includedir}/caffe/proto/*
+
+%files python
+%{python_sitelib}/caffe2/*
+
+%changelog
+* Thu Dec 28 2017 Geunsik Lim <geunsik.lim@samsung.com>
+- Tizen 4.0 (snapshot), Caffe2 0.7.0 f71695d (on Apr-19-2017)
+


### PR DESCRIPTION
PR Description
---------------------

Fixes issue #1692.
This PR is to support a Tizen-based RPM package generation in order that
developers can easily compile & install Caffe2 from source with "gbs build" command
in Linux-based Tizen software platform. This PR is done as a next activity after merging
build script for Tizen target (PR #877).
- https://source.tizen.org/documentation/reference/git-build-system

**Changes proposed in this PR:**
1. Added RPM spec file for Tizen platform.
2. Added gbs configuration file (e.g., tizen/4.0/.gbs.conf)
3. Added caffe2-eigen3-path.patch to handle correctly Eigen3 path of Tizen

**Self assessment:**
* GBS build: Checked and Passed
* OBS build: Checked and Passed

**How to evaluate:**
ubuntu16.04$ git clone https://github.com/caffe2/caffe2.git
ubuntu16.04$ ln -s ./script/tizen/4.0/packaging ./packaging
ubuntu16.04$ time gbs build -A {arch_name}  --clean --include-all

* In case of x86_64:
ubuntu16.04$ time gbs build -A x86_64  --clean --include-all
caffe2-0.7.0-18.1.src.rpm
caffe2-0.7.0-18.1.x86_64.rpm
caffe2-devel-0.7.0-18.1.x86_64.rpm
caffe2-python-0.7.0-18.1.x86_64.rpm

* In case of i586:
ubuntu16.04$ time gbs build -A i586    --clean --include-all
caffe2-0.7.0-18.1.i686.rpm
caffe2-0.7.0-18.1.src.rpm
caffe2-devel-0.7.0-18.1.i686.rpm
caffe2-python-0.7.0-18.1.i686.rpm

* In case of armv7l:
ubuntu16.04$ time gbs build -A armv7l  --clean --include-all
caffe2-0.7.0-18.1.armv7l.rpm
caffe2-0.7.0-18.1.src.rpm
caffe2-devel-0.7.0-18.1.armv7l.rpm
caffe2-python-0.7.0-18.1.armv7l.rpm

* In case of aarch64:
ubuntu16.04$ time gbs build -A aarch64 --clean --include-all
caffe2-0.7.0-18.1.aarch64.rpm
caffe2-0.7.0-18.1.src.rpm
caffe2-devel-0.7.0-18.1.aarch64.rpm
caffe2-python-0.7.0-18.1.aarch64.rpm

**Simple test with python interface after building Caffe2:**
Let's assume the path of Caffe2 git repository is /work2/git-repository/caffe2/.

* Add the library path to LD_LIBRARY_PATH. Then, add the install directory to PYTHONPATH to be able to use Caffe2 from Python:
```bash
$ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/work2/git-repository/caffe2/build/lib
$ export PYTHONPATH=$PYTHONPATH:/work2/git-repository/caffe2/build/
```

* Evaluate **import core** command by default
```bash
$ python -c 'from caffe2.python import core' 2>/dev/null && echo "Success" || echo "Failure"
Success
```

* Use Caffe2 in your real target (or Tizen/QEMU) and enjoy:
Python files are located in ./caffe2/python/ folder.
```bash
$ python -m caffe2.python.operator_test.relu_op_test
 . . .  Omission . . .
  Trying example: test_relu(self=<__main__.TestRelu testMethod=test_relu>,
  X=array([-0.80482125], dtype=float32),
  gc=<caffe2.proto.caffe2_pb2.DeviceOption at 0x7f403bdc55f0>,
  dc=[<caffe2.proto.caffe2_pb2.DeviceOption at 0x7f403bdc55f0>], engine=u'')
  Trying example: test_relu(self=<__main__.TestRelu testMethod=test_relu>,
  X=array([ 0.], dtype=float32), gc=<caffe2.proto.caffe2_pb2.DeviceOption
  at 0x7f403bdc55f0>, dc=[<caffe2.proto.caffe2_pb2.DeviceOption
  at 0x7f403bdc55f0>], engine=u'')
  ----------------------------------------------------------------------
  Ran 1 test in 0.049s

  OK
```

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>
Cc: Yangqing <me@daggerfs.com>