### PR TITLE
 Corrected MacOS X and macOS Sierra naming.

### DIFF
--- a/_docs/getting-started/mac.md
+++ b/_docs/getting-started/mac.md
@@ -117,7 +117,7 @@ sudo install_name_tool -change libpython2.7.dylib ~/anaconda/lib/libpython2.7.dy
 
 |Python errors
 ----|-----
-Python version | [Python](https://www.python.org/) is core to run Caffe2. We currently require [Python2.7](https://www.python.org/download/releases/2.7/). MacOSx Sierra comes pre-installed with Python 2.7.10, but you may need to update to run Caffe2. To check your version: `python --version`
+Python version | [Python](https://www.python.org/) is core to run Caffe2. We currently require [Python2.7](https://www.python.org/download/releases/2.7/). macOS Sierra comes pre-installed with Python 2.7.10, but you may need to update to run Caffe2. To check your version: `python --version`
 Solution | You can install the package for Python: `brew install python` or install [Anaconda](https://www.continuum.io/downloads).
 Python environment | You may have another version of Python installed or need to support Python version 3 for other projects.
 Solution | Try virtualenv or Anaconda. The [Anaconda](https://www.continuum.io/downloads) platform provides a single script to install many of the necessary packages for Caffe2, including Python. Using Anaconda is outside the scope of these instructions, but if you are interested, it may work well for you.
@@ -142,12 +142,12 @@ Solution | Install dependencies of NNPACK: `[sudo] pip install --upgrade git+htt
 
 |GPU Support
 ----|-----
-GPU | The easiest route is to go to [NVIDIA's site and download](https://developer.nvidia.com/cuda-downloads) and install their binary for MacOSx.
-Solution | Caffe2's GPU support is [Nvidia CUDA 6.5 or greater](https://developer.nvidia.com/cuda-zone): install from NVIDIA's site; free developer account required. [NVIDIA MacOSx Installation guide](http://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/)
+GPU | The easiest route is to go to [NVIDIA's site and download](https://developer.nvidia.com/cuda-downloads) and install their binary for MacOS X.
+Solution | Caffe2's GPU support is [Nvidia CUDA 6.5 or greater](https://developer.nvidia.com/cuda-zone): install from NVIDIA's site; free developer account required. [NVIDIA MacOS X Installation guide](http://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/)
 
 |Misc.
 ----|-----
-malloc error | If you are using homebrew leveldb on a Mac OS, you might see an error warning you that malloc_zone_unregister() failed. This is not a caffe2 issue but is due to the homebrew leveldb having an incompatible memory allocator. It does not affect usage.
+malloc error | If you are using homebrew leveldb on a Mac, you might see an error warning you that malloc_zone_unregister() failed. This is not a caffe2 issue but is due to the homebrew leveldb having an incompatible memory allocator. It does not affect usage.
 
 {{ outro | markdownify }}
 


### PR DESCRIPTION
* This capitalization is confusing, but want to clean it up a bit.

