### PR TITLE
Remove build status from caffe2.ai install pages.

### DIFF
--- a/_docs/getting-started/ios.md
+++ b/_docs/getting-started/ios.md
@@ -2,7 +2,7 @@
 
 ## Install Caffe2 for your development platform
 
-If you want to build Caffe2 for use on Android, first follow the instructions to setup Caffe2 on your Mac platform using the toggler above, and then:
+If you want to build Caffe2 for use on iOS, first follow the instructions to setup Caffe2 on your Mac platform using the toggler above, and then:
 
 > Note Caffe2 for iOS can only be built on a Mac
 

--- a/_docs/getting-started/mac.md
+++ b/_docs/getting-started/mac.md
@@ -2,8 +2,6 @@
 
 <block class="mac compile" />
 
-[![Build Status](https://travis-ci.org/caffe2/caffe2.svg?branch=master)](https://travis-ci.org/caffe2/caffe2)
-
 The Mac build works easiest with Anaconda. Always pull the latest from github, so you get any build fixes. See the Troubleshooting section below for tips.
 
 ### Required Dependencies

--- a/_docs/getting-started/ubuntu.md
+++ b/_docs/getting-started/ubuntu.md
@@ -8,8 +8,6 @@ You can easily try out Caffe2 by using the Cloud services. Caffe2 is available a
 
 <block class="ubuntu compile" />
 
-[![Build Status](https://travis-ci.org/caffe2/caffe2.svg?branch=master)](https://travis-ci.org/caffe2/caffe2)
-
 This build is confirmed for:
 
 * Ubuntu 14.04

--- a/_docs/getting-started/windows.md
+++ b/_docs/getting-started/windows.md
@@ -10,8 +10,6 @@ No binaries available.
 
 <block class="windows compile" />
 
-[![Build Status](https://travis-ci.org/caffe2/caffe2.svg?branch=master)](https://travis-ci.org/caffe2/caffe2)
-
 Windows build is in testing and beta mode. For the easiest route, use the docker images for now in CPU-only mode.
 
 ## Required Dependencies


### PR DESCRIPTION
* Not relevant for installs and link seems to fail even though they are succeeding on the homepage.
* Also switched Android typo to iOS.

