### PR TITLE
Lock hypothesis in Docker image to 3.44.6

### DIFF
--- a/docker/jenkins/common/install_python.sh
+++ b/docker/jenkins/common/install_python.sh
@@ -88,10 +88,13 @@ pushd pip-9.0.1
 popd
 rm -rf pip-9.0.1*
 
-# Install pip packages
+# Install pip packages.
+# Lock hypothesis to 3.44.6. Version 3.44.7 (and possibly beyond)
+# don't work with the ancient version of setuptools that is included
+# in Ubuntu Trusty (setuptools 3.3)
 pip install --no-cache-dir \
     future \
-    hypothesis \
+    hypothesis==3.44.6 \
     jupyter \
     numpy \
     protobuf \


### PR DESCRIPTION
Version 3.44.7 doesn't work with the ancient version of setuptools
that is included in Ubuntu Trusty (setuptools 3.3).

Also see HypothesisWorks/hypothesis-python@eadd62e467d6cee6216e71b391951ec25b4f5830.

@Yangqing @ezyang Should we lock versions of all packages here?