### PR TITLE
Fix for wrong newline in caffe_translator.py (Crop layer translation)

### DIFF
--- a/caffe2/python/caffe_translator.py
+++ b/caffe2/python/caffe_translator.py
@@ -490,8 +490,7 @@ def TranslateDeconv(layer, pretrained_blobs, is_test, **kwargs):
 
 @TranslatorRegistry.Register("Crop")
 def TranslateCrop(layer, pretrained_blobs, is_test, **kwargs):
-    net, net_params, input_dims = kwargs['net'], kwargs['net_params'],
-    kwargs['input_dims']
+    net, net_params, input_dims = kwargs['net'], kwargs['net_params'], kwargs['input_dims']
     n, c, h, w = input_dims
     dummy_input = np.random.randn(n, c, h, w).astype(np.float32)
     dim_map = _GetBlobDimMap(net, net_params, dummy_input)


### PR DESCRIPTION
- fixed the false newline at the initialization of the crop layer translation which caused the exceptions described in issue #1215

