### PR TITLE
Install CMake 3.6.3 in base image for Android build

### DIFF
--- a/docker/jenkins/build.sh
+++ b/docker/jenkins/build.sh
@@ -69,6 +69,10 @@ fi
 
 if [[ "$image" == *-android-* ]]; then
   ANDROID=yes
+
+  # The Android NDK requires CMake 3.6 or higher.
+  # See https://github.com/caffe2/caffe2/pull/1740 for more info.
+  CMAKE_VERSION=3.6.3
 fi
 
 if [[ "$image" == *-gcc* ]]; then
@@ -105,5 +109,6 @@ docker build \
        --build-arg "ANDROID=${ANDROID}" \
        --build-arg "GCC_VERSION=${GCC_VERSION}" \
        --build-arg "CLANG_VERSION=${CLANG_VERSION}" \
+       --build-arg "CMAKE_VERSION=${CMAKE_VERSION:-}" \
        "$@" \
        "$(dirname ${DOCKERFILE})"

--- a/docker/jenkins/common/install_cmake.sh
+++ b/docker/jenkins/common/install_cmake.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+[ -n "$CMAKE_VERSION" ]
+
+# Turn 3.6.3 into v3.6
+path=$(echo "${CMAKE_VERSION}" | sed -e 's/\([0-9].[0-9]\+\).*/v\1/')
+file="cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
+
+# Download and install specific CMake version in /usr/local
+pushd /tmp
+curl -Os "https://cmake.org/files/${path}/${file}"
+tar -C /usr/local --strip-components 1 --no-same-owner -zxf cmake-*.tar.gz
+rm -f cmake-*.tar.gz
+popd

--- a/docker/jenkins/ubuntu/Dockerfile
+++ b/docker/jenkins/ubuntu/Dockerfile
@@ -45,6 +45,12 @@ ADD ./install_clang.sh install_clang.sh
 RUN if [ -n "${CLANG_VERSION}" ]; then bash ./install_clang.sh; fi
 RUN rm install_clang.sh
 
+# (optional) Install non-default CMake version
+ARG CMAKE_VERSION
+ADD ./install_cmake.sh install_cmake.sh
+RUN if [ -n "${CMAKE_VERSION}" ]; then bash ./install_cmake.sh; fi
+RUN rm install_cmake.sh
+
 # (optional) Add Jenkins user
 ARG JENKINS
 ARG JENKINS_UID


### PR DESCRIPTION
This is needed for #1740.

Verified that `./build.sh py2-android-ubuntu16.04` builds an Android base image with CMake 3.6.3.