### PR TITLE
LSTM sequence lengths: allow unspecified sequence lengths

### DIFF
--- a/caffe2/operators/lstm_unit_op.cc
+++ b/caffe2/operators/lstm_unit_op.cc
@@ -31,9 +31,13 @@ activations, avoiding computation if the input is invalid (as in, the
 value at X{t][n] >= seqLengths[n].
 
 )DOC")
-    .Arg("forget_bias", "Bias term to add in while calculating forget gate");
+    .Arg("forget_bias", "Bias term to add in while calculating forget gate")
+    .Arg("no_sequence_lengths", "Ignore the sequence lengths input");
 REGISTER_CPU_OPERATOR(LSTMUnitGradient, LSTMUnitGradientOp<CPUContext>);
-OPERATOR_SCHEMA(LSTMUnitGradient).NumInputs(9).NumOutputs(3);
+OPERATOR_SCHEMA(LSTMUnitGradient)
+    .NumInputs(9)
+    .NumOutputs(3)
+    .Arg("no_sequence_lengths", "Ignore the sequence lengths input");
 
 class GetLSTMUnitGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;

--- a/caffe2/operators/lstm_unit_op_gpu.cu
+++ b/caffe2/operators/lstm_unit_op_gpu.cu
@@ -45,7 +45,7 @@ __global__ void LSTMUnitKernel(
   CUDA_1D_KERNEL_LOOP(index, nthreads) {
     const int n = index / dim;
     const int d = index % dim;
-    const bool valid = t < seqLengths[n];
+    const bool valid = seqLengths == nullptr || t < seqLengths[n];
     if (!valid) {
       H[index] = convert::To<MATH, T>(convert::To<T, MATH>(H_prev[index]) * !drop_states);
       C[index] = convert::To<MATH, T>(convert::To<T, MATH>(C_prev[index]) * !drop_states);
@@ -83,7 +83,7 @@ __global__ void LSTMUnitGradientKernel(
     const MATH forget_bias) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) {
     const int n = index / dim;
-    const bool valid = t < seqLengths[n];
+    const bool valid = seqLengths == nullptr || t < seqLengths[n];
     const int d = index % dim;
     const T* X_offset = X + 4 * dim * n;
     T* c_prev_diff = C_prev_diff + index;

--- a/caffe2/python/rnn_cell.py
+++ b/caffe2/python/rnn_cell.py
@@ -364,6 +364,12 @@ class LSTMCell(RNNCell):
         )
         brew.sum(model, [gates_t, input_t], gates_t)
 
+        no_sequence_lengths = seq_lengths is None
+        if no_sequence_lengths:
+            seq_lengths = model.net.ConstantFill(
+                [], self.scope("dummy"), value=0, shape=[1],
+                dtype=core.DataType.INT32)
+
         hidden_t, cell_t = model.net.LSTMUnit(
             [
                 hidden_t_prev,
@@ -375,6 +381,7 @@ class LSTMCell(RNNCell):
             list(self.get_state_names()),
             forget_bias=self.forget_bias,
             drop_states=self.drop_states,
+            no_sequence_lengths=no_sequence_lengths
         )
         model.net.AddExternalOutputs(hidden_t, cell_t)
         if self.memory_optimization:


### PR DESCRIPTION
In this case, each sequence is treated as having a length equal to the
first dimension of the input tensor. This matches the semantics of
ONNX when the sequence length input is left out.

