### PR TITLE
Increase lower bound of values for values in div test

### DIFF
--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -203,7 +203,7 @@ class TestOperators(hu.HypothesisTestCase):
             return (x / y, )
 
         def non_zero(x):
-            return abs(x) > 10e-5
+            return abs(x) > 1e-2
 
         def div_dtypes():
             return st.sampled_from([np.float32, np.float64])


### PR DESCRIPTION
This should translate to an 1% error margin. The gradient checker uses a .5% threshold.