### PR TITLE
Add doxygen and graphviz to Jenkins docker base.

### DIFF
--- a/docker/jenkins/common/install_base.sh
+++ b/docker/jenkins/common/install_base.sh
@@ -17,7 +17,9 @@ install_ubuntu() {
           ca-certificates \
           cmake \
           curl \
+          doxygen \
           git \
+          graphviz \
           libgoogle-glog-dev \
           libhiredis-dev \
           libiomp-dev \


### PR DESCRIPTION
* This will let us generate documentation on the Jenkins workers.

