### PR TITLE
include errno.h into text_file_reader_utils.cc

### DIFF
--- a/caffe2/operators/text_file_reader_utils.cc
+++ b/caffe2/operators/text_file_reader_utils.cc
@@ -16,6 +16,7 @@
 
 #include "caffe2/operators/text_file_reader_utils.h"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <cstring>
 #include <sstream>


### PR DESCRIPTION
text_file_reader_utils.cc miss errno.h, will cause compile failed:

> [ 41%] Building CXX object caffe2/CMakeFiles/caffe2.dir/operators/text_file_reader_utils.cc.o
/home/ckt/github/caffe2/caffe2/operators/text_file_reader_utils.cc: In constructor 'caffe2::FileReader::FileReader(const string&, size_t)':
/home/ckt/github/caffe2/caffe2/operators/text_file_reader_utils.cc:102:72: error: 'errno' was not declared in this scope
         "Error opening file for reading: " + std::string(std::strerror(errno)) +
                                                                        ^
/home/ckt/github/caffe2/caffe2/operators/text_file_reader_utils.cc: In member function 'virtual void caffe2::FileReader::reset()':
/home/ckt/github/caffe2/caffe2/operators/text_file_reader_utils.cc:110:68: error: 'errno' was not declared in this scope
         "Error reseting file cursor: " + std::string(std::strerror(errno)));
                                                                    ^
/home/ckt/github/caffe2/caffe2/operators/text_file_reader_utils.cc: In member function 'virtual void caffe2::FileReader::operator()(caffe2::CharRange&)':
/home/ckt/github/caffe2/caffe2/operators/text_file_reader_utils.cc:125:60: error: 'errno' was not declared in this scope
         "Error reading file: " + std::string(std::strerror(errno)));

This submit add errno.h into text_file_reader_utils.cc.

I built it with:
`scripts/build_android.sh`
My Host is Ubuntu 14.04, NDK is android-ndk-r16b.