### PR TITLE
Check if system has protobuf package when it already has protoc command

### DIFF
--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -114,9 +114,9 @@ else()
         google/protobuf/service.h
         PATHS ${_PROTOBUF_INSTALL_PREFIX}/include
         NO_DEFAULT_PATH)
+      find_package(Protobuf)
     endif()
 
-    find_package(Protobuf)
   endif()
 endif()
 


### PR DESCRIPTION
When system has protobuf package but hasn't protoc, cmake will be success:

> -- ******** Summary ********
-- General:
--   CMake version         : 3.5.1
--   CMake command         : /usr/bin/cmake
--   Git version           : v0.8.1-967-g27d12d8-dirty
--   System                : Linux
--   C++ compiler          : /usr/bin/c++
--   C++ compiler version  : 5.4.0
--   Protobuf compiler     : PROTOBUF_PROTOC_EXECUTABLE-NOTFOUND
--   Protobuf include path : /usr/include
--   Protobuf libraries    : optimized;/usr/lib/x86_64-linux-gnu/libprotobuf.so;debug;/usr/lib/x86_64-linux-gnu/libprotobuf.so;-lpthread
...

Then make will be failed.
This submit make it to check protobuf package only when protoc has been found.

This pull request is a clone of [1781](https://github.com/caffe2/caffe2/pull/1781), that pull request closed by mistake.