### PR TITLE
add opencv dependencies to caffe2

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -207,7 +207,7 @@ endif()
 # ---[ OpenCV
 if(USE_OPENCV)
   # OpenCV 3
-  find_package(OpenCV QUIET COMPONENTS core highgui imgproc imgcodecs)
+  find_package(OpenCV QUIET COMPONENTS core highgui imgproc imgcodecs videoio video)
   if(NOT OpenCV_FOUND)
     # OpenCV 2
     find_package(OpenCV QUIET COMPONENTS core highgui imgproc)


### PR DESCRIPTION
The video input op requires additional opencv packages. This is to add them to
cmake so that it can build

