### PR TITLE
Add operator attaching net observer

### DIFF
--- a/caffe2/observers/CMakeLists.txt
+++ b/caffe2/observers/CMakeLists.txt
@@ -7,4 +7,9 @@ if(USE_OBSERVERS)
 
   set(Caffe2_CPU_SRCS ${Caffe2_CPU_SRCS} ${Caffe2_CONTRIB_OBSERVERS_CPU_SRC})
   set(Caffe2_CPU_SRCS ${Caffe2_CPU_SRCS} PARENT_SCOPE)
+
+  # ---[ CPU test files
+  file(GLOB tmp *_test.cc)
+  set(Caffe2_CPU_TEST_SRCS ${Caffe2_CPU_TEST_SRCS} ${tmp})
+  set(Caffe2_CPU_TEST_SRCS ${Caffe2_CPU_TEST_SRCS} PARENT_SCOPE)
 endif()

--- a/caffe2/observers/operator_attaching_net_observer.h
+++ b/caffe2/observers/operator_attaching_net_observer.h
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "caffe2/core/net.h"
+#include "caffe2/core/observer.h"
+#include "caffe2/core/operator.h"
+
+namespace caffe2 {
+
+// Thin class that attaches the observer to all operators in the net
+template <typename TOpObserver, typename TNetObserver>
+class OperatorAttachingNetObserver : public ObserverBase<NetBase> {
+ public:
+  explicit OperatorAttachingNetObserver(
+      NetBase* subject_,
+      TNetObserver* netObserver)
+      : ObserverBase<NetBase>(subject_) {
+    const auto& operators = subject_->GetOperators();
+    for (auto* op : operators) {
+      unique_ptr<TOpObserver> observer =
+          caffe2::make_unique<TOpObserver>(op, netObserver);
+      const auto* ob = observer.get();
+      op->AttachObserver(std::move(observer));
+      CAFFE_ENFORCE(ob != nullptr);
+      operator_observers_.push_back(ob);
+    }
+  }
+  virtual ~OperatorAttachingNetObserver(){};
+
+ protected:
+  std::vector<const TOpObserver*> operator_observers_;
+};
+
+} // namespace caffe2

--- a/caffe2/observers/operator_attaching_net_observer.h
+++ b/caffe2/observers/operator_attaching_net_observer.h
@@ -32,11 +32,9 @@ class OperatorAttachingNetObserver : public ObserverBase<NetBase> {
       : ObserverBase<NetBase>(subject_) {
     const auto& operators = subject_->GetOperators();
     for (auto* op : operators) {
-      unique_ptr<TOpObserver> observer =
-          caffe2::make_unique<TOpObserver>(op, netObserver);
+      auto observer = caffe2::make_unique<TOpObserver>(op, netObserver);
       const auto* ob = observer.get();
       op->AttachObserver(std::move(observer));
-      CAFFE_ENFORCE(ob != nullptr);
       operator_observers_.push_back(ob);
     }
   }

--- a/caffe2/observers/runcnt_observer.cc
+++ b/caffe2/observers/runcnt_observer.cc
@@ -19,12 +19,7 @@ std::string RunCountNetObserver::debugInfo() {
   return "This operator runs " + caffe2::to_string(cnt_) + " times.";
 }
 
-void RunCountNetObserver::Start() {
-  const auto& operators = subject_->GetOperators();
-  for (auto* op : operators) {
-    op->AttachObserver(caffe2::make_unique<RunCountOperatorObserver>(op, this));
-  }
-}
+void RunCountNetObserver::Start() {}
 
 void RunCountNetObserver::Stop() {}
 

--- a/caffe2/observers/runcnt_observer.h
+++ b/caffe2/observers/runcnt_observer.h
@@ -3,6 +3,7 @@
 #include "caffe2/core/net.h"
 #include "caffe2/core/observer.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/observers/operator_attaching_net_observer.h"
 
 namespace caffe2 {
 
@@ -24,10 +25,15 @@ class RunCountOperatorObserver final : public ObserverBase<OperatorBase> {
   RunCountNetObserver* netObserver_;
 };
 
-class RunCountNetObserver final : public ObserverBase<NetBase> {
+class RunCountNetObserver final : public OperatorAttachingNetObserver<
+                                      RunCountOperatorObserver,
+                                      RunCountNetObserver> {
  public:
   explicit RunCountNetObserver(NetBase* subject_)
-      : ObserverBase<NetBase>(subject_), cnt_(0) {}
+      : OperatorAttachingNetObserver<
+            RunCountOperatorObserver,
+            RunCountNetObserver>(subject_, this),
+        cnt_(0) {}
   ~RunCountNetObserver() {}
 
   std::string debugInfo() override;

--- a/caffe2/observers/time_observer.cc
+++ b/caffe2/observers/time_observer.cc
@@ -19,28 +19,23 @@
 
 namespace caffe2 {
 
-template <>
-void TimeObserverBase<NetBase>::Start() {
-  CAFFE_THROW(
-      "This function is overridden by TimeObserver<NetBase>.\
-              If it was called there is an issue with compilation.");
+void TimeObserver::Start() {
+  start_time_ = timer_.MilliSeconds();
+  ++iterations_;
 }
 
-template <>
-void TimeObserverBase<NetBase>::Stop() {
+void TimeObserver::Stop() {
   double current_run = timer_.MilliSeconds() - start_time_;
   total_time_ += current_run;
   VLOG(1) << "This net iteration took " << current_run << " ms to complete.\n";
 }
 
-template <>
-void TimeObserverBase<OperatorBase>::Start() {
+void TimeOperatorObserver::Start() {
   start_time_ = timer_.MilliSeconds();
   ++iterations_;
 }
 
-template <>
-void TimeObserverBase<OperatorBase>::Stop() {
+void TimeOperatorObserver::Stop() {
   double current_run = timer_.MilliSeconds() - start_time_;
   total_time_ += current_run;
   VLOG(1) << "This operator iteration took " << current_run

--- a/caffe2/observers/time_observer_test.cc
+++ b/caffe2/observers/time_observer_test.cc
@@ -74,7 +74,7 @@ TEST(TimeObserverTest, Test3Seconds) {
   ws.CreateBlob("in");
   NetDef net_def;
   unique_ptr<NetBase> net(CreateNetTestHelper(&ws));
-  unique_ptr<TimeObserver> net_ob = make_unique<TimeObserver>(net.get());
+  auto net_ob = caffe2::make_unique<TimeObserver>(net.get());
   const auto* ob = net_ob.get();
   net->AttachObserver(std::move(net_ob));
   net->Run();

--- a/caffe2/observers/time_observer_test.cc
+++ b/caffe2/observers/time_observer_test.cc
@@ -67,17 +67,16 @@ unique_ptr<NetBase> CreateNetTestHelper(Workspace* ws) {
 
   return CreateNet(net_def, ws);
 }
-}
+} // namespace
 
 TEST(TimeObserverTest, Test3Seconds) {
   Workspace ws;
   ws.CreateBlob("in");
   NetDef net_def;
   unique_ptr<NetBase> net(CreateNetTestHelper(&ws));
-  unique_ptr<TimeObserver<NetBase>> net_ob =
-      make_unique<TimeObserver<NetBase>>(net.get());
-  const auto* ob = dynamic_cast_if_rtti<const TimeObserver<NetBase>*>(
-      net->AttachObserver(std::move(net_ob)));
+  unique_ptr<TimeObserver> net_ob = make_unique<TimeObserver>(net.get());
+  const auto* ob = net_ob.get();
+  net->AttachObserver(std::move(net_ob));
   net->Run();
   CAFFE_ENFORCE(ob);
   LOG(INFO) << "av time children: " << ob->average_time_children();
@@ -87,4 +86,4 @@ TEST(TimeObserverTest, Test3Seconds) {
   CAFFE_ENFORCE(ob->average_time() > 6000);
   CAFFE_ENFORCE(ob->average_time() < 6500);
 }
-}
+} // namespace caffe2

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -266,7 +266,7 @@ void addObjectMethods(py::module& m) {
       .def(
           "average_time",
           [](ObserverBase<NetBase>* ob) {
-            auto* cast_ob = dynamic_cast_if_rtti<TimeObserver<NetBase>*>(ob);
+            auto* cast_ob = dynamic_cast_if_rtti<TimeObserver*>(ob);
             CAFFE_ENFORCE(
                 cast_ob, "Observer does not implement this function.");
             return cast_ob->average_time();
@@ -274,7 +274,7 @@ void addObjectMethods(py::module& m) {
       .def(
           "average_time_children",
           [](ObserverBase<NetBase>* ob) {
-            auto* cast_ob = dynamic_cast_if_rtti<TimeObserver<NetBase>*>(ob);
+            auto* cast_ob = dynamic_cast_if_rtti<TimeObserver*>(ob);
             CAFFE_ENFORCE(
                 cast_ob, "Observer does not implement this function.");
             return cast_ob->average_time_children();
@@ -884,13 +884,12 @@ void addGlobalMethods(py::module& m) {
         NetBase* net = gWorkspace->GetNet(net_name);
         const Observable<NetBase>::Observer* observer = nullptr;
 
-#define REGISTER_PYTHON_EXPOSED_OBSERVER(ob_type)        \
-  {                                                      \
-    if (observer_type.compare(#ob_type) == 0) {          \
-      unique_ptr<ob_type<NetBase>> net_ob =              \
-          make_unique<ob_type<NetBase>>(net);            \
-      observer = net->AttachObserver(std::move(net_ob)); \
-    }                                                    \
+#define REGISTER_PYTHON_EXPOSED_OBSERVER(ob_type)             \
+  {                                                           \
+    if (observer_type.compare(#ob_type) == 0) {               \
+      unique_ptr<ob_type> net_ob = make_unique<ob_type>(net); \
+      observer = net->AttachObserver(std::move(net_ob));      \
+    }                                                         \
   }
 
         REGISTER_PYTHON_EXPOSED_OBSERVER(TimeObserver);


### PR DESCRIPTION
Commonly, net observers attach operator observers at construction. This diff separates the logic into a base class to inherit from.