### PR TITLE
Doc refresher, mostly to ubuntu and tutorial installations

### DIFF
--- a/_docs/getting-started/mac.md
+++ b/_docs/getting-started/mac.md
@@ -37,28 +37,10 @@ conda install -y \
     mkl \
     mkl-include \
     numpy \
+    opencv \
     protobuf \
     snappy \
     six
-
-# (Optional) these packages are needed for some of the ipython jupyter notebook
-# tutorials, but not for base Caffe2
-conda install -y --channel https://conda.anaconda.org/conda-forge \
-    flask \
-    graphviz \
-    hypothesis \
-    jupyter \
-    leveldb \
-    lmdb \
-    matplotlib \
-    pydot \
-    pyyaml \
-    requests \
-    scikit-image \
-    scipy \
-    tornado \
-    unzip \
-    zeromq
 
 # Clone Caffe2
 cd ~ && git clone --recursive https://github.com/caffe2/caffe2.git && cd caffe2
@@ -84,31 +66,26 @@ Follow these instructions if you want to build Caffe2 without Anaconda. Make sur
 
 ```bash
 brew install \
-automake \
-cmake \
-git \
-glog \
-protobuf \
-python
+    automake \
+    cmake \
+    git \
+    glog \
+    protobuf \
+    python
 ```
 
 ```bash
 sudo -H pip install \
-flask \
-future \
-glog \
-jupyter \
-matplotlib \
-numpy \
-protobuf \
-pydot \
-python-gflags \
-pyyaml \
-scikit-image \
-scipy \
-setuptools \
-six \
-tornado
+    future \
+    glog \
+    numpy \
+    protobuf \
+    pydot \
+    python-gflags \
+    pyyaml \
+    scikit-image \
+    setuptools \
+    six
 ```
 
 ### Clone and Build
@@ -264,6 +241,14 @@ malloc error | If you are using homebrew leveldb on a Mac, you might see an erro
 {{ outro | markdownify }}
 
 <block class="mac prebuilt" />
+
+### Anaconda package
+
+```bash
+conda install -c caffe2 caffe2
+```
+
+Packages exist for both Python 2.7 and 3.6. At this time all packages are built with MKL, without GPU support.
 
 ### Prebuilt Caffe2 Python Wheel
 

--- a/_docs/getting-started/outro.md
+++ b/_docs/getting-started/outro.md
@@ -65,18 +65,17 @@ Strictly speaking, the core dependencies above are all you need to run the core 
 ----|-----
 There are also various Python libraries that will be valuable in your experience with Caffe2. Many of these are required to run the tutorials. |
 [Flask](http://flask.pocoo.org/) |
-[Graphviz](http://www.graphviz.org/) |
+[Graphviz](http://www.graphviz.org/) | Used for plotting in the Jupyter Notebook Tutorials
 [Hypothesis](https://hypothesis.readthedocs.io/) |
-[Jupyter](https://ipython.org/) | for the Jupyter Notebook
+[Jupyter](https://ipython.org/) | Used for some some interactive tutorials
 [LevelDB](https://github.com/google/leveldb) |
 [lmdb](https://lmdb.readthedocs.io/en/release/) |
-[Matplotlib](http://matplotlib.org/) |
-[Pydot](https://pypi.python.org/pypi/pydot) |
+[Matplotlib](http://matplotlib.org/) | Used for plotting in the Jupyter Notebook Tutorials
+[Pydot](https://pypi.python.org/pypi/pydot) | Used for plotting in the Jupyter Notebook Tutorials
 [Python-nvd3](https://pypi.python.org/pypi/python-nvd3/) |
 [pyyaml](http://pyyaml.org/) |
-[requests](http://docs.python-requests.org/en/master/) |
+[requests](http://docs.python-requests.org/en/master/) | Used in the MNIST tutorial to download the dataset
 [Scikit-Image](http://scikit-image.org/) |
 [SciPy](https://www.scipy.org/) |
 [setuptools](https://pypi.python.org/pypi/setuptools) |
-[Tornado](http://www.tornadoweb.org/en/stable/) |
 [ZeroMQ](http://zeromq.org/) |

--- a/_docs/getting-started/ubuntu.md
+++ b/_docs/getting-started/ubuntu.md
@@ -13,7 +13,9 @@ This build is confirmed for:
 * Ubuntu 14.04
 * Ubuntu 16.04
 
-### Required Dependencies
+> Anaconda users: To build with Anaconda, follow the instructions on the [Mac page](https://caffe2.ai/docs/getting-started.html?platform=mac&configuration=compile#anaconda-install-path).
+
+### Install Dependencies
 
 ```bash
 sudo apt-get update
@@ -22,14 +24,62 @@ sudo apt-get install -y --no-install-recommends \
       cmake \
       git \
       libgoogle-glog-dev \
+      libgtest-dev \
+      libiomp-dev \
+      libleveldb-dev \
+      liblmdb-dev \
+      libopencv-dev \
+      libopenmpi-dev \
+      libsnappy-dev \
       libprotobuf-dev \
+      openmpi-bin \
+      openmpi-doc
       protobuf-compiler \
       python-dev \
       python-pip                          
-sudo pip install numpy protobuf
+sudo pip install \
+      future \
+      numpy \
+      protobuf
 ```
+
+> Note `libgflags2` is for Ubuntu 14.04. `libgflags-dev` is for Ubuntu 16.04.
+
+```bash
+# for Ubuntu 14.04
+sudo apt-get install -y --no-install-recommends libgflags2
+# for Ubuntu 16.04
+sudo apt-get install -y --no-install-recommends libgflags-dev
+```
+
+> If you have a GPU, follow [these additional steps](#install-with-gpu-support) before continuing.
+
+### Clone & Build
+
+```bash
+git clone --recursive https://github.com/caffe2/caffe2.git && cd caffe2
+make && cd build && sudo make install
+```
+
+### Test the Caffe2 Installation
+Run this to see if your Caffe2 installation was successful. 
+
+```bash
+cd ~ && python -c 'from caffe2.python import core' 2>/dev/null && echo "Success" || echo "Failure"
+```
+
+If this fails, then get a better error message by running a Python interpreter in the `caffe2/build` directory and then trying `from caffe2.python import core`.
+
+If this fails with a message about not finding caffe2.python or not finding libcaffe2.so, [check your environment variables](#environment-variables) first.
+
+If you installed with GPU support, test that the GPU build was a success with this command. You will get a test output either way, but it will warn you at the top of the output if CPU was used instead of GPU, along with other errors such as missing libraries.
+
+```bash
+python -m caffe2.python.operator_test.relu_op_test
+```
+
 <block class="ubuntu compile" />
-### Optional GPU Support
+### Install with GPU Support
 
 If you plan to use GPU instead of CPU only, then you should install NVIDIA CUDA 8 and cuDNN v5.1 or v6.0, a GPU-accelerated library of primitives for deep neural networks.
 [NVIDIA's detailed instructions](http://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#ubuntu-installation) or if you're feeling lucky try the quick install set of commands below.
@@ -68,65 +118,6 @@ rm cudnn-8.0-linux-x64-v5.1.tgz && sudo ldconfig
 
 **Version 6.0**
 Visit [NVIDIA's cuDNN download](https://developer.nvidia.com/rdp/cudnn-download) to register and download the archive. Follow the same instructions above switching out for the updated library.
-
-<block class="ubuntu compile" />
-### Optional Dependencies
-
-> Note `libgflags2` is for Ubuntu 14.04. `libgflags-dev` is for Ubuntu 16.04.
-
-```bash
-# for Ubuntu 14.04
-sudo apt-get install -y --no-install-recommends libgflags2
-```
-
-```bash
-# for Ubuntu 16.04
-sudo apt-get install -y --no-install-recommends libgflags-dev
-```
-
-```bash
-# for both Ubuntu 14.04 and 16.04
-sudo apt-get install -y --no-install-recommends \
-      libgtest-dev \
-      libiomp-dev \
-      libleveldb-dev \
-      liblmdb-dev \
-      libopencv-dev \
-      libopenmpi-dev \
-      libsnappy-dev \
-      openmpi-bin \
-      openmpi-doc \
-      python-pydot
-sudo pip install \
-      flask \
-      future \
-      graphviz \
-      hypothesis \
-      jupyter \
-      matplotlib \
-      pydot python-nvd3 \
-      pyyaml \
-      requests \
-      scikit-image \
-      scipy \
-      setuptools \
-      six \
-      tornado
-```
-
-### Clone & Build
-
-```bash
-git clone --recursive https://github.com/caffe2/caffe2.git && cd caffe2
-make && cd build && sudo make install
-python -c 'from caffe2.python import core' 2>/dev/null && echo "Success" || echo "Failure"
-```
-
-Run this command below to test if your GPU build was a success. You will get a test output either way, but it will warn you at the top of the output if CPU was used instead along with other errors like missing libraries.
-
-```bash
-python -m caffe2.python.operator_test.relu_op_test
-```
 
 ### Environment Variables
 
@@ -191,9 +182,13 @@ Build issues | Be warned that installing CUDA and cuDNN will increase the size o
 
 <block class="ubuntu prebuilt" />
 
-### Prebuilt Binaries
+### Anaconda package
 
-** COMING SOON **
+```bash
+conda install -c caffe2 caffe2
+```
+
+Packages exist for both Python 2.7 and 3.6. At this time all packages are built with MKL, without GPU support. Anaconda packages built for CUDA are coming soon.
 
 <block class="ubuntu docker" />
 

--- a/_docs/tutorials.md
+++ b/_docs/tutorials.md
@@ -7,6 +7,42 @@ permalink: /docs/tutorials.html
 
   We'd love to start by saying that we really appreciate your interest in Caffe2, and hope this will be a high-performance framework for your machine learning product uses. Caffe2 is intended to be modular and facilitate fast prototyping of ideas and experiments in deep learning. Given this modularity, note that once you have a model defined, and you are interested in gaining additional performance and scalability, you are able to use pure C++ to deploy such models without having to use Python in your final product. Also, as the community develops enhanced and high-performance modules you are able to easily swap these modules into your Caffe2 project.
 
+## Tutorials Installation
+
+To run the tutorials you will need some third-party libraries, including [ipython-notebooks](http://jupyter.org/install.html) and [matplotlib](http://matplotlib.org/users/installing.html). You can install everything you'll need with the following command.
+
+> Anaconda users: If you're using Anaconda, use `conda install` instead of `pip install`.
+
+```bash
+pip install \
+    flask \
+    graphviz \
+    hypothesis \
+    ipython \
+    jupyter \
+    leveldb \
+    lmdb \
+    matplotlib \
+    notebook \
+    pydot \
+    python-nvd3 \
+    pyyaml \
+    requests \
+    scikit-image \
+    scipy \
+    six \
+    unzip \
+    zeromq
+```
+
+Then run the shell script included in the `caffe2/caffe2/python/tutorials` folder:
+
+```bash
+./start_ipython_notebook.sh
+```
+
+Or you can run `jupyter notebook`, and when your browser opens with your local Jupyter server (default is http://localhost:8888), browse to the Caffe2 repository and look for them in the `caffe2/caffe2/python/tutorials` directory. Opening them this way will launch their interactive features just like the shell script mentioned above. The script has the additional feature of setting your PYTHONPATH environment variable.
+
 ## Pick Your Path
 
 1. [Use a pre-trained neural network off the shelf!](tutorials.html#null__new-to-deep-learning) (Easy)
@@ -139,63 +175,3 @@ One of basic units of computation in Caffe2 are the [Operators](/docs/operators)
 Fantastic idea! Write custom operators and share them with the community! Refer to the guide on writing operators:
 
 * [Guide for creating your own operators](/docs/custom-operators)
-
-## Tutorials Installation
-
-To run the tutorials you'll need Python 2.7, [ipython-notebooks](http://jupyter.org/install.html) and [matplotlib](http://matplotlib.org/users/installing.html), which can be installed on with:
-
-#### Mac OS X via brew & pip
-
-```bash
-brew install matplotlib
-pip install ipython notebook
-pip install scikit-image
-```
-
-#### Anaconda
-
-Anaconda comes with iPython notebook, so you'll only need to install matplotlib.
-
-```bash
-conda install matplotlib
-conda install scikit-image
-```
-
-#### pip
-
-```bash
-pip install matplotlib
-pip install ipython notebook
-pip install scikit-image
-```
-
-Hit it with a hammer you say? Ok, here's a full list for your installation pleasure, and note that you'll want them installed with Python, and in some cases C++ or at the system level, so you might `brew install` as well as `pip install` or `conda install` them:
-
-```bash
-flask \
-graphviz \
-hypothesis \
-jupyter \
-leveldb \
-lmdb \
-matplotlib \
-pydot \
-pyyaml \
-requests \
-scikit-image \
-scipy \
-tornado \
-zeromq
-```
-
-Instructions on how to setup Jupyter Notebook, which is the latest, greatest way to use and create interactive code notebooks (ipynb files) is found at [http://jupyter.org](http://jupyter.org/install.html).
-
-Note: if you've already successfully installed Caffe2 with Anaconda Python, then great news! You already have Jupyter Notebook. Starting it is easy.
-
-Run the shell script included in the `caffe2/caffe2/python/tutorials` folder:
-
-```bash
-./start_ipython_notebook.sh
-```
-
-Or you can run `jupyter notebook`, and when your browser opens with your local Jupyter server (default is http://localhost:8888), browse to the Caffe2 repository and look for them in the `caffe2/caffe2/python/tutorials` directory. Opening them this way will launch their interactive features just like the shell script mentioned above. The script has the additional feature of setting your PYTHONPATH environment variable.


### PR DESCRIPTION
Adds opencv to default requirements.
Removes most optional requirements from mac and ubuntu install pages
Move tutorial install instructions to top of the page
Consolidated separate install commands for mac / ubuntu to single install block in tutorial instructions
Refer to anaconda instructions in ubuntu installation page