### PR TITLE
Use case insensitive names for Doxygen docs.

### DIFF
--- a/docs/.Doxyfile-c
+++ b/docs/.Doxyfile-c
@@ -524,7 +524,7 @@ INTERNAL_DOCS          = NO
 # and Mac users are advised to set this option to NO.
 # The default value is: system dependent.
 
-CASE_SENSE_NAMES       = YES
+CASE_SENSE_NAMES       = NO
 
 # If the HIDE_SCOPE_NAMES tag is set to NO then doxygen will show members with
 # their full class and namespace scopes in the documentation. If set to YES, the

--- a/docs/.Doxyfile-python
+++ b/docs/.Doxyfile-python
@@ -524,7 +524,7 @@ INTERNAL_DOCS          = NO
 # and Mac users are advised to set this option to NO.
 # The default value is: system dependent.
 
-CASE_SENSE_NAMES       = YES
+CASE_SENSE_NAMES       = NO
 
 # If the HIDE_SCOPE_NAMES tag is set to NO then doxygen will show members with
 # their full class and namespace scopes in the documentation. If set to YES, the


### PR DESCRIPTION
* This way we won't have issues across Linux and Mac.
* Also eliminates some weirdness where files with both capitalizations existed.

