### PR TITLE
add aarch64 android complile method to doc

### DIFF
--- a/_docs/getting-started/android.md
+++ b/_docs/getting-started/android.md
@@ -22,9 +22,18 @@ git clone --recursive https://github.com/caffe2/caffe2.git
 
 ## Run the Build Script
 
+If you want to build Caffe2 for Android with armeabi-v7a ABI:
+
 ```
 cd caffe2
 ./scripts/build_android.sh
+```
+
+Or if you want to build Caffe2 for Android with arm64-v8a ABI:
+
+```
+cd caffe2
+./scripts/build_android.sh -DANDROID_ABI=arm64-v8a -DANDROID_TOOLCHAIN=clang
 ```
 
 <block class="android prebuilt docker" />


### PR DESCRIPTION
The install doc doesn't intro how to compile 64-bit Caffe2 for android.

@Maratyszcza please help me to review this.
Thanks.