### PR TITLE
Remove OpenGL code from benchmark

### DIFF
--- a/caffe2/share/contrib/binaries/caffe2_benchmark/caffe2_benchmark.cc
+++ b/caffe2/share/contrib/binaries/caffe2_benchmark/caffe2_benchmark.cc
@@ -11,15 +11,11 @@
 #include "caffe2/utils/proto_utils.h"
 #include "caffe2/utils/string_utils.h"
 
-#if CAFFE2_MOBILE && (CAFFE2_ANDROID || CAFFE2_IOS)
-#include "caffe2/mobile/contrib/opengl/core/rewrite_net.h"
-#endif
-
 CAFFE2_DEFINE_string(
     backend,
     "default",
     "The backend to use when running the model. The allowed "
-    "backend choices are: default, nnpack, opengl");
+    "backend choices are: default, nnpack");
 CAFFE2_DEFINE_string(
     init_net,
     "",
@@ -173,25 +169,7 @@ int main(int argc, char** argv) {
   // Run main network.
   caffe2::NetDef net_def;
   CAFFE_ENFORCE(ReadProtoFromFile(caffe2::FLAGS_net, &net_def));
-  if (caffe2::FLAGS_backend == "opengl") {
-#if CAFFE2_MOBILE && (CAFFE2_ANDROID || CAFFE2_IOS)
-    caffe2::NetDef opengl_net_def;
-    if (caffe2::tryConvertToOpenGL(init_net_def, net_def, &opengl_net_def)) {
-      net_def = opengl_net_def;
-      if (caffe2::FLAGS_run_individual) {
-        caffe2::FLAGS_run_individual = false;
-        LOG(INFO)
-            << "OpenGL implementation does not support individual operator delay. Run net delay only";
-      }
-    } else {
-      LOG(ERROR)
-          << "Net cannot be converted to OpenGL format, use original model instead";
-    }
-#else
-    LOG(ERROR) << "OpenGL build can only be used in mobile platform";
-#endif
-
-  } else if (caffe2::FLAGS_backend == "nnpack") {
+  if (caffe2::FLAGS_backend == "nnpack") {
     for (int i = 0; i < net_def.op_size(); i++) {
       caffe2::OperatorDef* op_def = net_def.mutable_op(i);
       op_def->set_engine("NNPACK");


### PR DESCRIPTION
OpenGL is no longer built by default. Even after setting flag -DUSE_MOBILE_OPENGL, the build fails. Remove it in the benchmark code so that the benchmark can still be built. 

test plan: build caffe2_benchmark successfully. 