### PR TITLE
Fix for finding protobuf on windows

### DIFF
--- a/caffe/proto/CMakeLists.txt
+++ b/caffe/proto/CMakeLists.txt
@@ -6,7 +6,12 @@ caffe2_protobuf_generate_cpp_py(Caffe_PROTO_SRCS Caffe_PROTO_HEADERS Caffe_PROTO
 
 add_library(Caffe_PROTO OBJECT ${Caffe_PROTO_HEADERS} ${Caffe_PROTO_SRCS})
 if (MSVC)
+  if(BUILD_SHARED_LIBS)
+    set(Caffe2_API_DEFINE "-DCAFFE2_API=__declspec(dllexport)")
+  else()
+    set(Caffe2_API_DEFINE "-DCAFFE2_API=")
+  endif()
   target_compile_definitions(
-      Caffe_PROTO PRIVATE "-DCAFFE2_API=__declspec(dllexport)")
+      Caffe_PROTO PRIVATE ${Caffe2_API_DEFINE})
 endif()
 install(FILES ${Caffe_PROTO_HEADERS} DESTINATION include/caffe/proto)

--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -55,6 +55,13 @@ endfunction()
 #
 if (WIN32)
   find_package(Protobuf NO_MODULE)
+  if(Protobuf_FOUND OR PROTOBUF_FOUND)
+    set(PROTOBUF_LIBRARIES protobuf::libprotobuf)
+    get_target_property(_protobuf_include_dir protobuf::libprotobuf
+                        INTERFACE_INCLUDE_DIRECTORIES)
+    set(PROTOBUF_INCLUDE_DIRS ${_protobuf_include_dir})
+    add_definitions(-DPROTOBUF_USE_DLLS)
+  endif()
 elseif (ANDROID OR IOS)
   custom_protobuf_find()
   # Unfortunately, new protobuf does not support libprotoc and protoc


### PR DESCRIPTION
On windows when using a prebuilt version of protobuf (such as provided by vcpkg) we need to set the PROTOBUF_LIBRARIES and PROTOBUF_INCLUDE_DIRS manually.

The CAFFE2_API decoration should only be defined to dllexport when building shared libs.