### PR TITLE
Fixed CAFFE2_API decoration for caffe2/proto when building static libraries

### DIFF
--- a/caffe2/proto/CMakeLists.txt
+++ b/caffe2/proto/CMakeLists.txt
@@ -6,7 +6,12 @@ caffe2_protobuf_generate_cpp_py(Caffe2_PROTO_SRCS Caffe2_PROTO_HEADERS Caffe2_PR
 
 add_library(Caffe2_PROTO OBJECT ${Caffe2_PROTO_HEADERS} ${Caffe2_PROTO_SRCS})
 if (MSVC)
+  if(BUILD_SHARED_LIBS)
+    set(Caffe2_API_DEFINE "-DCAFFE2_API=__declspec(dllexport)")
+  else()
+    set(Caffe2_API_DEFINE "-DCAFFE2_API=")
+  endif()
   target_compile_definitions(
-      Caffe2_PROTO PRIVATE "-DCAFFE2_API=__declspec(dllexport)")
+      Caffe2_PROTO PRIVATE ${Caffe2_API_DEFINE})
 endif()
 install(FILES ${Caffe2_PROTO_HEADERS} DESTINATION include/caffe2/proto)


### PR DESCRIPTION
This was forgotten in #1854.

cc @Yangqing 

