### PR TITLE
Update Dependencies.cmake

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -210,7 +210,7 @@ endif()
 # ---[ OpenCV
 if(USE_OPENCV)
   # OpenCV 3
-  find_package(OpenCV QUIET COMPONENTS core highgui imgproc imgcodecs)
+  find_package(OpenCV 3 QUIET COMPONENTS core highgui imgproc imgcodecs)
   if(NOT OpenCV_FOUND)
     # OpenCV 2
     find_package(OpenCV QUIET COMPONENTS core highgui imgproc)


### PR DESCRIPTION
force find_package first to find OpenCV 3 when we have default package OpenCV 2 installed.

When compiled on Ubuntu16.04 with OpenCV 2 installed from apt-get, meanwhile I have installed OpenCV3 compiled from source into /usr/local/. The CMake first is to find OpenCV 2 rather than 3 due to find_package(OpenCV) not specified version, then find the cmake configuration in /usr/share/CMake first to get OpenCV 2 rather than in /usr/local/share/CMake to get OpenCV 3 even if the notation says we need to find OpenCV 3.

So it is better to specify the version of OpenCV in Dependencies.cmake
