### PR TITLE
Skip system Python if Anaconda is used

### DIFF
--- a/docker/jenkins/build.sh
+++ b/docker/jenkins/build.sh
@@ -23,10 +23,10 @@ valid_images=(
   py2-android-ubuntu16.04
 
   # Builds for Anaconda
-  py2-conda-ubuntu16.04
-  py2-conda-cuda9.0-cudnn7-ubuntu16.04
-  py3-conda-ubuntu16.04
-  py3-conda-cuda9.0-cudnn7-ubuntu16.04
+  conda2-ubuntu16.04
+  conda2-cuda9.0-cudnn7-ubuntu16.04
+  conda3-ubuntu16.04
+  conda3-cuda9.0-cudnn7-ubuntu16.04
 )
 
 image="$1"
@@ -51,7 +51,9 @@ else
   exit 1
 fi
 
-PYTHON_VERSION="$(echo "${image}" | perl -n -e'/py(\d+(\.\d+)?)/ && print $1')"
+if [[ "$image" == py* ]]; then
+  PYTHON_VERSION="$(echo "${image}" | perl -n -e'/py(\d+(\.\d+)?)/ && print $1')"
+fi
 
 if [[ "$image" == *cuda* ]]; then
   CUDA_VERSION="$(echo "${image}" | perl -n -e'/cuda(\d+\.\d+)/ && print $1')"

--- a/docker/jenkins/centos-cuda/Dockerfile
+++ b/docker/jenkins/centos-cuda/Dockerfile
@@ -15,7 +15,8 @@ RUN bash ./install_ccache.sh && rm install_ccache.sh
 # Install Python
 ARG PYTHON_VERSION
 ADD ./install_python.sh install_python.sh
-RUN bash ./install_python.sh && rm install_python.sh
+RUN if [ -n "${PYTHON_VERSION}" ]; then bash ./install_python.sh; fi
+RUN rm install_python.sh
 
 # (optional) Add Jenkins user
 ARG JENKINS

--- a/docker/jenkins/centos/Dockerfile
+++ b/docker/jenkins/centos/Dockerfile
@@ -13,7 +13,8 @@ RUN bash ./install_ccache.sh && rm install_ccache.sh
 # Install Python
 ARG PYTHON_VERSION
 ADD ./install_python.sh install_python.sh
-RUN bash ./install_python.sh && rm install_python.sh
+RUN if [ -n "${PYTHON_VERSION}" ]; then bash ./install_python.sh; fi
+RUN rm install_python.sh
 
 # (optional) Add Jenkins user
 ARG JENKINS

--- a/docker/jenkins/ubuntu-cuda/Dockerfile
+++ b/docker/jenkins/ubuntu-cuda/Dockerfile
@@ -15,7 +15,8 @@ RUN bash ./install_ccache.sh && rm install_ccache.sh
 # Install Python
 ARG PYTHON_VERSION
 ADD ./install_python.sh install_python.sh
-RUN bash ./install_python.sh && rm install_python.sh
+RUN if [ -n "${PYTHON_VERSION}" ]; then bash ./install_python.sh; fi
+RUN rm install_python.sh
 
 # Install Anaconda
 ARG ANACONDA_VERSION

--- a/docker/jenkins/ubuntu/Dockerfile
+++ b/docker/jenkins/ubuntu/Dockerfile
@@ -13,7 +13,8 @@ RUN bash ./install_ccache.sh && rm install_ccache.sh
 # Install Python
 ARG PYTHON_VERSION
 ADD ./install_python.sh install_python.sh
-RUN bash ./install_python.sh && rm install_python.sh
+RUN if [ -n "${PYTHON_VERSION}" ]; then bash ./install_python.sh; fi
+RUN rm install_python.sh
 
 # Install Anaconda
 ARG ANACONDA_VERSION


### PR DESCRIPTION
We don't care about a particular system Python when building Anaconda images.

Rebasing later to remove the sccache change once it is merged (#1952).