### PR TITLE
Add dependency Python packages for onnx-caffe2

### DIFF
--- a/docker/jenkins/common/install_python.sh
+++ b/docker/jenkins/common/install_python.sh
@@ -137,7 +137,6 @@ pip install --no-cache-dir \
     numpy \
     onnx \
     protobuf \
-    psutil \
     pytest \
     scipy==0.19.1 \
     scikit-image \

--- a/docker/jenkins/common/install_python.sh
+++ b/docker/jenkins/common/install_python.sh
@@ -141,4 +141,5 @@ pip install --no-cache-dir \
     pytest \
     scipy==0.19.1 \
     scikit-image \
+    tabulate \
     virtualenv

--- a/docker/jenkins/common/install_python.sh
+++ b/docker/jenkins/common/install_python.sh
@@ -130,11 +130,14 @@ pip install -U setuptools
 # version explicitly before scikit-image pulls it in as a dependency
 pip install networkx==2.0
 pip install --no-cache-dir \
+    click \
     future \
     hypothesis \
     jupyter \
     numpy \
+    onnx \
     protobuf \
+    psutil \
     pytest \
     scipy==0.19.1 \
     scikit-image \


### PR DESCRIPTION
onnx-caffe2 requires some more Python packages in order to run its tests. 