### PR TITLE
Fix Android build with binaries

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -108,16 +108,6 @@ if (Caffe2_EXTERNAL_DEPENDENCIES)
   add_dependencies(caffe2 ${Caffe2_EXTERNAL_DEPENDENCIES})
 endif()
 
-# ---[ On Android, Caffe2 uses cpufeatures library in the thread pool
-if (ANDROID)
-  # ---[ Check if cpufeatures was already imported by NNPACK
-  if (NOT TARGET cpufeatures)
-    include(${CMAKE_SOURCE_DIR}/third_party/android-cmake/AndroidNdkModules.cmake)
-    android_ndk_import_module_cpufeatures()
-  endif()
-  target_link_libraries(caffe2 PRIVATE cpufeatures)
-endif()
-
 # ---[ CUDA library.
 if(USE_CUDA)
   # A hack to deal with cuda library dependencies and modern CMake: the

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -82,6 +82,22 @@ if(USE_NNPACK)
   endif()
 endif()
 
+
+# ---[ On Android, Caffe2 uses cpufeatures library in the thread pool
+if (ANDROID)
+  # ---[ Check if cpufeatures was already imported
+  if (NOT TARGET cpufeatures)
+    add_library(cpufeatures STATIC
+      "${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c")
+    target_include_directories(cpufeatures
+      PUBLIC "${ANDROID_NDK}/sources/android/cpufeatures")
+    target_link_libraries(cpufeatures PRIVATE dl)
+  endif()
+  list(APPEND Caffe2_DEPENDENCY_LIBS $<TARGET_FILE:cpufeatures>)
+  list(APPEND Caffe2_EXTERNAL_DEPENDENCIES cpufeatures)
+  caffe2_include_directories("${ANDROID_NDK}/sources/android/cpufeatures")
+endif()
+
 # ---[ gflags
 if(USE_GFLAGS)
   include(cmake/public/gflags.cmake)


### PR DESCRIPTION
After we removed android-cmake submodule and switched to android.cmake.toolchain from Android NDK, the code that builds cpufeatures dependency is no longer valid. This commit fixes it.

