### PR TITLE
Update onnx version for onnx-caffe2 test

### DIFF
--- a/docker/jenkins/common/install_python.sh
+++ b/docker/jenkins/common/install_python.sh
@@ -129,13 +129,17 @@ pip install -U setuptools
 # defaults installs the most recent networkx version, so we install this lower
 # version explicitly before scikit-image pulls it in as a dependency
 pip install networkx==2.0
+
+# We need a fixed version of onnx which is newer than current release to test 
+# onnx-caffe2 
+pip install --no-cache-dir -v git+https://github.com/onnx/onnx.git@a43f015
+
 pip install --no-cache-dir \
     click \
     future \
     hypothesis \
     jupyter \
     numpy \
-    onnx \
     protobuf \
     pytest \
     scipy==0.19.1 \


### PR DESCRIPTION
We recently added `onnx.optimize` from onnx-caffe2 to onnx. So we need a newer version of onnx to run the tests add in https://github.com/caffe2/caffe2/pull/1921. 