### PR TITLE
Changed Mnist Ipython tutorial

### DIFF
--- a/caffe2/python/tutorials/MNIST.ipynb
+++ b/caffe2/python/tutorials/MNIST.ipynb
@@ -188,13 +188,9 @@
    "source": [
     "def AddInput(model, batch_size, db, db_type):\n",
     "    # load the data\n",
-    "    data_uint8, label = brew.db_input(\n",
-    "        model,\n",
-    "        blobs_out=[\"data_uint8\", \"label\"],\n",
-    "        batch_size=batch_size,\n",
-    "        db=db,\n",
-    "        db_type=db_type,\n",
-    "    )\n",
+    "    data_uint8, label = model.TensorProtosDBInput(\n",
+    "        [], [\"data_uint8\", \"label\"], batch_size=batch_size,\n",
+    "        db=db, db_type=db_type)\n",
     "    # cast the data to float\n",
     "    data = model.Cast(data_uint8, \"data\", to=core.DataType.FLOAT)\n",
     "    # scale data from [0,255] down to [0,1]\n",
@@ -969,7 +965,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,

--- a/caffe2/python/tutorials/py_gen/MNIST.py
+++ b/caffe2/python/tutorials/py_gen/MNIST.py
@@ -136,13 +136,9 @@ print("workspace root folder:" + root_folder)
 
 def AddInput(model, batch_size, db, db_type):
     # load the data
-    data_uint8, label = brew.db_input(
-        model,
-        blobs_out=["data_uint8", "label"],
-        batch_size=batch_size,
-        db=db,
-        db_type=db_type,
-    )
+    data_uint8, label = model.TensorProtosDBInput(
+        [], ["data_uint8", "label"], batch_size=batch_size,
+        db=db, db_type=db_type)
     # cast the data to float
     data = model.Cast(data_uint8, "data", to=core.DataType.FLOAT)
     # scale data from [0,255] down to [0,1]


### PR DESCRIPTION
Earlier code:
In the function, AddInput, 
```
data_uint8, label = brew.db_input(
        model,
        blobs_out=["data_uint8", "label"],
        batch_size=batch_size,
        db=db,
        db_type=db_type,
    )
```
brew has no member db_input. So, changed it according to the code mentioned here: https://caffe2.ai/docs/tutorial-MNIST.html

```
def AddInput(model, batch_size, db, db_type):
    # load the data
    data_uint8, label = model.TensorProtosDBInput(
        [], ["data_uint8", "label"], batch_size=batch_size,
        db=db, db_type=db_type)
    # cast the data to float
    data = model.Cast(data_uint8, "data", to=core.DataType.FLOAT)
    # scale data from [0,255] down to [0,1]
    data = model.Scale(data, data, scale=float(1./256))
    # don't need the gradient for the backward pass
    data = model.StopGradient(data, data)
    return data, label
```


