### PR TITLE
Avoid having two protobuf on ubuntu14.04

### DIFF
--- a/docker/jenkins/common/install_base.sh
+++ b/docker/jenkins/common/install_base.sh
@@ -48,11 +48,11 @@ install_ubuntu() {
   # Ubuntu 14.04 ships with protobuf 2.5, but ONNX needs protobuf >= 2.6
   # so we install that here if on 14.04
   if [[ "$UBUNTU_VERSION" == 14.04 ]]; then
-      install_protobuf_26
+    install_protobuf_26
   else
-      apt-get install -y --no-install-recommends \
-              libprotobuf-dev \
-              protobuf-compiler
+    apt-get install -y --no-install-recommends \
+            libprotobuf-dev \
+            protobuf-compiler
   fi
 
   # Cleanup

--- a/docker/jenkins/common/install_base.sh
+++ b/docker/jenkins/common/install_base.sh
@@ -41,16 +41,18 @@ install_ubuntu() {
           libleveldb-dev \
           liblmdb-dev \
           libopencv-dev \
-          libprotobuf-dev \
           libpthread-stubs0-dev \
           libsnappy-dev \
-          protobuf-compiler \
           sudo
 
   # Ubuntu 14.04 ships with protobuf 2.5, but ONNX needs protobuf >= 2.6
   # so we install that here if on 14.04
   if [[ "$UBUNTU_VERSION" == 14.04 ]]; then
-    install_protobuf_26
+      install_protobuf_26
+  else
+      apt-get install -y --no-install-recommends \
+              libprotobuf-dev \
+              protobuf-compiler
   fi
 
   # Cleanup


### PR DESCRIPTION
cc @yinghai 

On ubuntu14.04, the protobuf installed by system package manager is of version 2.5.0 and will be placed at:
/usr/lib/x86_64-linux-gnu/libprotobuf.so.8

The one we install from source will be put at:
/usr/local/lib/libprotobuf.so.9