### PR TITLE
Enable OpenGL build

### DIFF
--- a/binaries/CMakeLists.txt
+++ b/binaries/CMakeLists.txt
@@ -46,12 +46,9 @@ endif()
 
 if (USE_OBSERVERS)
   caffe2_binary_target("caffe2_benchmark.cc")
-if (USE_MOBILE_OPENGL)
-  add_definitions("-DMOBILE_OPENGL_BACKEND")
-endif()
-if (NOT ANDROID)
-  target_link_libraries(caffe2_benchmark ${Caffe2_DEPENDENCY_LIBS})
-endif()
+  if (USE_MOBILE_OPENGL)
+    add_definitions("-DMOBILE_OPENGL_BACKEND")
+  endif()
 endif()
 
 # ---[ tutorials

--- a/binaries/CMakeLists.txt
+++ b/binaries/CMakeLists.txt
@@ -46,6 +46,12 @@ endif()
 
 if (USE_OBSERVERS)
   caffe2_binary_target("caffe2_benchmark.cc")
+if (USE_MOBILE_OPENGL)
+  add_definitions("-DMOBILE_OPENGL_BACKEND")
+endif()
+if (NOT ANDROID)
+  target_link_libraries(caffe2_benchmark ${Caffe2_DEPENDENCY_LIBS})
+endif()
 endif()
 
 # ---[ tutorials

--- a/binaries/caffe2_benchmark.cc
+++ b/binaries/caffe2_benchmark.cc
@@ -11,8 +11,10 @@
 #include "caffe2/utils/string_utils.h"
 #include "observers/observer_config.h"
 
+#if MOBILE_OPENGL_BACKEND
 #if CAFFE2_MOBILE && (CAFFE2_ANDROID || CAFFE2_IOS)
 #include "caffe2/mobile/contrib/opengl/core/rewrite_net.h"
+#endif
 #endif
 
 CAFFE2_DEFINE_string(
@@ -179,6 +181,7 @@ int main(int argc, char** argv) {
 
   if (caffe2::FLAGS_backend != "builtin") {
     if (caffe2::FLAGS_backend == "opengl") {
+#if MOBILE_OPENGL_BACKEND
 #if CAFFE2_MOBILE && (CAFFE2_ANDROID || CAFFE2_IOS)
       caffe2::NetDef opengl_net_def;
       if (caffe2::tryConvertToOpenGL(init_net_def, net_def, &opengl_net_def)) {
@@ -192,8 +195,7 @@ int main(int argc, char** argv) {
         LOG(ERROR)
           << "Net cannot be converted to OpenGL format, use original model instead";
       }
-#else
-      LOG(ERROR) << "OpenGL build can only be used in mobile platform";
+#endif
 #endif
     } else {
       std::string engine = caffe2::FLAGS_backend == "nnpack" ? "NNPACK" :

--- a/caffe2/mobile/contrib/opengl/core/GLTexture.cc
+++ b/caffe2/mobile/contrib/opengl/core/GLTexture.cc
@@ -6,28 +6,6 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/timer.h"
 
-#if CAFFE2_ANDROID && defined(__ARM_NEON__)
-
-#include "../android/AndroidGLContext.h"
-
-// https://community.arm.com/thread/10002
-void arm_memcpy(volatile unsigned char* dst, volatile unsigned char* src, int sz) {
-  if (sz & 63) {
-    sz = (sz & -64) + 64;
-  }
-
-  asm volatile(
-      "NEONCopyPLD: \n"
-      " VLDM %[src]!,{d0-d7} \n"
-      " VSTM %[dst]!,{d0-d7} \n"
-      " SUBS %[sz],%[sz],#0x40 \n"
-      " BGT NEONCopyPLD \n"
-      : [dst] "+r"(dst), [src] "+r"(src), [sz] "+r"(sz)
-      :
-      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "cc", "memory");
-}
-#endif
-
 const GLTexture::Type GLTexture::FP16 = {GL_RGBA16F, GL_RGBA, GL_HALF_FLOAT};
 const GLTexture::Type GLTexture::UI8 = {GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE};
 const GLTexture::Type GLTexture::FP16_COMPAT = {GL_RG32UI, GL_RG_INTEGER, GL_UNSIGNED_INT};

--- a/caffe2/mobile/contrib/opengl/core/arm_neon_support.h
+++ b/caffe2/mobile/contrib/opengl/core/arm_neon_support.h
@@ -3,7 +3,10 @@
 
 #include "caffe2/core/common.h"
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
+#if !defined(__ARM_NEON__)
+#define __ARM_NEON__ 1
+#endif
 #if CAFFE2_IOS
 #include "arm_neon.h"
 #elif CAFFE2_ANDROID

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -214,6 +214,13 @@ if (IOS)
   add_definitions("-Wno-deprecated-declarations")
 endif()
 
+if (ANDROID AND USE_MOBILE_OPENGL)
+  if (CMAKE_COMPILER_IS_GNUCXX)
+    add_definitions("-mfp16-format=ieee")
+    add_definitions("-mfpu=neon-fp16")
+  endif()
+endif()
+
 # ---[ If we are building with ACL, we will enable neon-fp16.
 if(USE_ACL)
   if (CMAKE_SYSTEM_PROCESSOR MATCHES "^armv")


### PR DESCRIPTION
with these small patches, we can build
arm64-v8a with clang: e.g.,  `scripts/build_android.sh -DBUILD_BINARY=ON -DBUILD_TEST=ON -DUSE_MOBILE_OPENGL=ON -DBUILD_OBSERVERS=ON -DANDROID_TOOLCHAIN=clang -DUSE_ARM64=ON` 
armeabi-v7a with gcc: e.g., `scripts/build_android.sh -DBUILD_BINARY=ON  -DBUILD_TEST=ON -DUSE_MOBILE_OPENGL=ON -DBUILD_OBSERVERS=ON`

And run `caffe2_benchmark` on Android device with something like `./caffe2_benchmark --backend=opengl ...`
