### PR TITLE
Add onnx as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -61,3 +61,6 @@
 [submodule "third_party/python-six"]
 	path = third_party/python-six
 	url = https://github.com/benjaminp/six.git
+[submodule "third_party/onnx"]
+	path = third_party/onnx
+	url = https://github.com/onnx/onnx.git


### PR DESCRIPTION
Adding onnx as third_party for better integration, especially on C++ level. 

ONNX version is pinned at https://github.com/onnx/onnx/commit/c894dd753eab0d14c8a512dd21501ac932dc8040. 