### PR TITLE
Install onnx by using the onnx inside caffe2

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -16,7 +16,7 @@ if [ -n "${SCCACHE_BUCKET}" ]; then
   fi
 
   # Setup wrapper scripts
-  for compiler in cc c++ gcc g++; do
+  for compiler in cc c++ gcc g++ x86_64-linux-gnu-gcc; do
     (
       echo "#!/bin/sh"
       echo "exec $SCCACHE $(which $compiler) \"\$@\""
@@ -35,6 +35,7 @@ if [ -z "${SCCACHE}" ] && which ccache > /dev/null; then
   ln -sf "$(which ccache)" ./ccache/c++
   ln -sf "$(which ccache)" ./ccache/gcc
   ln -sf "$(which ccache)" ./ccache/g++
+  ln -sf "$(which ccache)" ./ccache/x86_64-linux-gnu-gcc
   export CCACHE_WRAPPER_DIR="$PWD/ccache"
   export PATH="$CCACHE_WRAPPER_DIR:$PATH"
 fi

--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -109,6 +109,10 @@ else
   exit 1
 fi
 
+# Install ONNX into a local directory
+ONNX_INSTALL_PATH="/usr/local/onnx"
+pip install "${ROOT_DIR}/third_party/onnx" -t "${ONNX_INSTALL_PATH}"
+
 # Symlink the caffe2 base python path into the system python path,
 # so that we can import caffe2 without having to change $PYTHONPATH.
 # Run in a subshell to contain environment set by /etc/os-release.
@@ -128,12 +132,14 @@ if [ -n "${JENKINS_URL}" ]; then
     if [[ "$ID_LIKE" == *debian* ]]; then
       python_path="/usr/local/lib/$(python_version)/dist-packages"
       sudo ln -sf "${INSTALL_PREFIX}/caffe2" "${python_path}"
+      sudo ln -sf "${ONNX_INSTALL_PATH}/onnx" "${python_path}"
     fi
 
     # RHEL/CentOS
     if [[ "$ID_LIKE" == *rhel* ]]; then
       python_path="/usr/lib64/$(python_version)/site-packages/"
       sudo ln -sf "${INSTALL_PREFIX}/caffe2" "${python_path}"
+      sudo ln -sf "${ONNX_INSTALL_PATH}/onnx" "${python_path}"
     fi
 
     # /etc/ld.so.conf.d is used on both Debian and RHEL

--- a/docker/jenkins/common/install_python.sh
+++ b/docker/jenkins/common/install_python.sh
@@ -130,10 +130,6 @@ pip install -U setuptools
 # version explicitly before scikit-image pulls it in as a dependency
 pip install networkx==2.0
 
-# We need a fixed version of onnx which is newer than current release to test 
-# onnx-caffe2 
-pip install --no-cache-dir -v git+https://github.com/onnx/onnx.git@cc9b6e6
-
 pip install --no-cache-dir \
     click \
     future \


### PR DESCRIPTION
Per discussion in https://github.com/caffe2/caffe2/pull/1998, we want to install the onnx inside caffe2/third_party/onnx. 

Need to kick off Jenkins and see if this actually works. 