### PR TITLE
Skip Cast ONNX backend test, which is not supported in Float16 case

### DIFF
--- a/caffe2/python/onnx/tests/onnx_backend_test.py
+++ b/caffe2/python/onnx/tests/onnx_backend_test.py
@@ -35,7 +35,8 @@ backend_test = onnx.backend.test.BackendTest(c2, __name__)
 
 backend_test.exclude(r'(test_ceil|test_floor'  # Does not support Ceil and Floor.
                      '|test_hardsigmoid|test_pow'  # Does not support Hardsigmoid and Pow.
-                     '|test_mean|test_hardmax)')  # Does not support Mean and Hardmax.
+                     '|test_mean|test_hardmax'  # Does not support Mean and Hardmax.
+                     '|test_cast.*FLOAT16.*)')  # Does not support Cast on Float16.
 
 # Skip vgg to speed up CI
 if 'JENKINS_URL' in os.environ:


### PR DESCRIPTION
Float16 casting is not supported yet.