### PR TITLE
Fix all the broken tests from adding debug info

### DIFF
--- a/caffe2/python/core_gradients_test.py
+++ b/caffe2/python/core_gradients_test.py
@@ -100,6 +100,13 @@ def AddNogradient(op, g_output):
 
 
 class TestGradientCalculation(test_util.TestCase):
+    def assertOperatorListEqual(self, operatorDefList1, operatorDefList2):
+        for op in operatorDefList1:
+            op.debug_info = ""
+        for op in operatorDefList2:
+            op.debug_info = ""
+        self.assertEqual(operatorDefList1, operatorDefList2)
+
     @given(device_option=st.sampled_from([
         None,
         core.DeviceOption(caffe2_pb2.CUDA, 1)]))
@@ -120,7 +127,7 @@ class TestGradientCalculation(test_util.TestCase):
                 op.device_option.CopyFrom(device_option)
         gradients, _ = GradientRegistry.GetBackwardPass(
             operators, {'out': 'out_grad'})
-        self.assertEqual(gradients, desired_grad_operators)
+        self.assertOperatorListEqual(gradients, desired_grad_operators)
 
     def testDirectImplicitGradientSource(self):
         operators = [
@@ -134,9 +141,11 @@ class TestGradientCalculation(test_util.TestCase):
                 'DirectGradient', 'out_autogen_grad', 'hidden_grad'),
             CreateOperator('DirectGradient', 'hidden_grad', 'in_grad'),
         ]
+        for op in desired_grad_operators:
+            op.debug_info = ""
         gradients, _ = GradientRegistry.GetBackwardPass(
             operators, ['out'])
-        self.assertEqual(gradients, desired_grad_operators)
+        self.assertOperatorListEqual(gradients, desired_grad_operators)
 
     def testDoesNotGenerateUnnecessaryGradients(self):
         operators = [
@@ -146,9 +155,11 @@ class TestGradientCalculation(test_util.TestCase):
         desired_grad_operators = [
             CreateOperator('DirectGradient', 'hidden_grad', 'in_grad'),
         ]
+        for op in desired_grad_operators:
+            op.debug_info = ""
         gradients, _ = GradientRegistry.GetBackwardPass(
             operators, {'hidden': 'hidden_grad'})
-        self.assertEqual(gradients, desired_grad_operators)
+        self.assertOperatorListEqual(gradients, desired_grad_operators)
 
     def testDirectButNoOutputGradientGiven(self):
         operators = [
@@ -157,7 +168,7 @@ class TestGradientCalculation(test_util.TestCase):
         ]
         gradients, _ = GradientRegistry.GetBackwardPass(
             operators, {})
-        self.assertEqual(gradients, [])
+        self.assertOperatorListEqual(gradients, [])
 
     def testDirectInPlace(self):
         operators = [
@@ -170,7 +181,7 @@ class TestGradientCalculation(test_util.TestCase):
         ]
         gradients, _ = GradientRegistry.GetBackwardPass(
             operators, {'out': 'out_grad'})
-        self.assertEqual(gradients, desired_grad_operators)
+        self.assertOperatorListEqual(gradients, desired_grad_operators)
 
     def testVersionMismatch(self):
         operators = [
@@ -206,7 +217,7 @@ class TestGradientCalculation(test_util.TestCase):
         ]
         gradients, _ = GradientRegistry.GetBackwardPass(
             operators, {'sink': 'sink_grad'})
-        self.assertEqual(gradients, desired_grad_operators)
+        self.assertOperatorListEqual(gradients, desired_grad_operators)
 
     def testUseOutputInPlace(self):
         operators = [
@@ -227,7 +238,7 @@ class TestGradientCalculation(test_util.TestCase):
         ]
         gradients, _ = GradientRegistry.GetBackwardPass(
             operators, {'sink': 'sink_grad'})
-        self.assertEqual(gradients, desired_grad_operators)
+        self.assertOperatorListEqual(gradients, desired_grad_operators)
 
     def testUseOutputButOutputHasBeenChanged(self):
         operators = [
@@ -262,7 +273,7 @@ class TestGradientCalculation(test_util.TestCase):
         ]
         gradients, _ = GradientRegistry.GetBackwardPass(
             operators, {'sink': 'sink_grad'})
-        self.assertEqual(gradients, desired_grad_operators)
+        self.assertOperatorListEqual(gradients, desired_grad_operators)
 
     def testUseInputButInputHasBeenChanged(self):
         """Test gradient for the following case:
@@ -322,7 +333,7 @@ class TestGradientCalculation(test_util.TestCase):
                 op.device_option.CopyFrom(device_option)
         gradients, _ = GradientRegistry.GetBackwardPass(
             operators, {"out": "out_grad"})
-        self.assertEqual(gradients, desired_grad_operators)
+        self.assertOperatorListEqual(gradients, desired_grad_operators)
 
     def testMultiUseInputButWithNoGradient(self):
         """Test gradient for the following case:
@@ -348,7 +359,7 @@ class TestGradientCalculation(test_util.TestCase):
         ]
         gradients, _ = GradientRegistry.GetBackwardPass(
             operators, {'out': 'out_grad'})
-        self.assertEqual(gradients, desired_grad_operators)
+        self.assertOperatorListEqual(gradients, desired_grad_operators)
 
     def testMultiUseInputAndMultipleVersions(self):
         """Test gradient for the following case:
@@ -387,7 +398,7 @@ class TestGradientCalculation(test_util.TestCase):
         ]
         gradients, _ = GradientRegistry.GetBackwardPass(
             operators, {'out': 'out_grad'})
-        self.assertEqual(gradients, desired_grad_operators)
+        self.assertOperatorListEqual(gradients, desired_grad_operators)
 
     def testMultiUseInputAndMultipleVersionsBig(self):
         """Test gradient for the following case:
@@ -457,7 +468,7 @@ class TestGradientCalculation(test_util.TestCase):
             operators, {'out': 'out_grad'})
         for s in gradients:
             print(str(s))
-        self.assertEqual(gradients, desired_grad_operators)
+        self.assertOperatorListEqual(gradients, desired_grad_operators)
 
     def testGradientMappingUsingSumOp(self):
         """Since Sum is used in accumulating gradients, we will test if
@@ -493,7 +504,7 @@ class TestGradientCalculation(test_util.TestCase):
             operators, {'loss': 'loss_grad'})
         for s in gradient_ops:
             print(str(s))
-        self.assertEqual(gradient_ops, desired_grad_operators)
+        self.assertOperatorListEqual(gradient_ops, desired_grad_operators)
 
     def testStopGradient(self):
         operators = [
@@ -506,7 +517,7 @@ class TestGradientCalculation(test_util.TestCase):
         ]
         gradients, _ = GradientRegistry.GetBackwardPass(
             operators, {'out': 'out_grad'})
-        self.assertEqual(gradients, desired_grad_operators)
+        self.assertOperatorListEqual(gradients, desired_grad_operators)
 
     def testStopGradientOrphan(self):
         operators = [
@@ -530,7 +541,7 @@ class TestGradientCalculation(test_util.TestCase):
         ]
         gradients, grad_map = GradientRegistry.GetBackwardPass(
             operators, {'out': 'out_grad'})
-        self.assertEqual(gradients, desired_grad_operators)
+        self.assertOperatorListEqual(gradients, desired_grad_operators)
         self.assertEqual(grad_map, {'out': 'out_grad'})
 
     def testStopGradientWithMultiUseOperators(self):
@@ -548,7 +559,7 @@ class TestGradientCalculation(test_util.TestCase):
         ]
         gradients, grad_map = GradientRegistry.GetBackwardPass(
             operators, {'out': 'out_grad'})
-        self.assertEqual(gradients, desired_grad_operators)
+        self.assertOperatorListEqual(gradients, desired_grad_operators)
         self.assertEqual(
             grad_map, {'out': 'out_grad', 'hidden2': 'hidden2_grad',
                        'hidden3': 'hidden3_grad', 'hidden': 'hidden_grad',

--- a/caffe2/python/core_test.py
+++ b/caffe2/python/core_test.py
@@ -259,6 +259,12 @@ class TestCreateOperator(test_util.TestCase):
 
 
 class TestAutoNaming(test_util.TestCase):
+    def assertOperatorListEqual(self, operatorDefList1, operatorDefList2):
+        for op in operatorDefList1:
+            op.debug_info = ""
+        for op in operatorDefList2:
+            op.debug_info = ""
+        self.assertEqual(operatorDefList1, operatorDefList2)
     """
     Test that operators are named with different names, and that automatically
     named blob names don't clash intra or inter networks.
@@ -275,7 +281,7 @@ class TestAutoNaming(test_util.TestCase):
         net_a = create_net()
         net_b = create_net()
         # created net proto is predicatable.
-        self.assertEqual(net_a.Proto().op,
+        self.assertOperatorListEqual(net_a.Proto().op,
                          net_b.Proto().op)
         self.assertEqual(net_a.Proto().op[0].output[0], 'foo/ab')
         self.assertEqual(net_a.Proto().op[1].output[0], 'cd')


### PR DESCRIPTION
The gradient checks use strict equality for the protobuf comparison, which breaks in the face of dynamically added debug information (which will pretty much always be unique).  This modifies those checks to minimally ignore such differences.

fixes breaks in #2008 