### PR TITLE
Scope MultiRNN blobs with name as well as layers

### DIFF
--- a/caffe2/python/memonger_test.py
+++ b/caffe2/python/memonger_test.py
@@ -483,10 +483,10 @@ class MemongerTest(hu.HypothesisTestCase):
                 "cell_init_{}".format(i)
             )
             init_blobs.extend([hidden_init, cell_init])
-        model.param_init_net.ConstantFill([], ["input"], shape=[T, 4, 10])
+        input_blob = model.param_init_net.ConstantFill([], ["input"], shape=[T, 4, 10])
         output, last_hidden, _, last_state = rnn_cell.LSTM(
             model=model,
-            input_blob="input",
+            input_blob=input_blob,
             seq_lengths=seq_lengths,
             initial_states=init_blobs,
             dim_in=10,

--- a/caffe2/python/memonger_test.py
+++ b/caffe2/python/memonger_test.py
@@ -483,10 +483,10 @@ class MemongerTest(hu.HypothesisTestCase):
                 "cell_init_{}".format(i)
             )
             init_blobs.extend([hidden_init, cell_init])
-        input_blob = model.param_init_net.ConstantFill([], ["input"], shape=[T, 4, 10])
+        model.param_init_net.ConstantFill([], ["input"], shape=[T, 4, 10])
         output, last_hidden, _, last_state = rnn_cell.LSTM(
             model=model,
-            input_blob=input_blob,
+            input_blob="input",
             seq_lengths=seq_lengths,
             initial_states=init_blobs,
             dim_in=10,

--- a/caffe2/python/rnn_cell.py
+++ b/caffe2/python/rnn_cell.py
@@ -992,7 +992,8 @@ class MultiRNNCell(RNNCell):
         return helper
 
     def prepare_input(self, model, input_blob):
-        return self.cells[0].prepare_input(model, input_blob)
+        with core.NameScope(self.name or ''):
+            return self.cells[0].prepare_input(model, input_blob)
 
     def _apply(
         self,

--- a/caffe2/python/rnn_cell.py
+++ b/caffe2/python/rnn_cell.py
@@ -988,7 +988,7 @@ class MultiRNNCell(RNNCell):
 
     def layer_scoper(self, layer_id):
         def helper(name):
-            return "layer_{}/{}".format(layer_id, name)
+            return "{}/layer_{}/{}".format(self.name, layer_id, name)
         return helper
 
     def prepare_input(self, model, input_blob):
@@ -1557,7 +1557,7 @@ def _LSTM(
             hidden_size=dim_out[i],
             forget_bias=forget_bias,
             memory_optimization=memory_optimization,
-            name=scope,
+            name=scope if num_layers == 1 else None,
             forward_only=forward_only,
             drop_states=drop_states,
             **cell_kwargs

--- a/caffe2/python/rnn_cell.py
+++ b/caffe2/python/rnn_cell.py
@@ -992,6 +992,7 @@ class MultiRNNCell(RNNCell):
         return helper
 
     def prepare_input(self, model, input_blob):
+        input_blob = _RectifyName(input_blob)
         with core.NameScope(self.name or ''):
             return self.cells[0].prepare_input(model, input_blob)
 


### PR DESCRIPTION
Currently state names are scoped only by layer number. This PR adds self.name to the scope, so it becomes like `name/layer_1/state_name`.

Also don't double scope MultiRNN in case of multiple layers if using `rnn_cell.LSTM`.
Currently the scope is applied to both LSTMCell and MultiRNNCell which causes to have scopes like this: `name/layer_1/name/blobname`. This PR changes that to `name/layer_1/blobname`.


