### PR TITLE
Add eigen version check

### DIFF
--- a/caffe2/operators/conv_op_eigen.cc
+++ b/caffe2/operators/conv_op_eigen.cc
@@ -18,6 +18,12 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/operators/conv_pool_op_base.h"
 
+#include "Eigen/Core"
+
+#if !EIGEN_VERSION_AT_LEAST(3, 3, 0)
+#error "Caffe2 requires Eigen to be at least 3.3.0.";
+#endif
+
 #include "unsupported/Eigen/CXX11/Tensor"
 
 namespace caffe2 {


### PR DESCRIPTION
From an internal discussion we found a case where the unsupported/ header is not found and the error message was cryptic. This makes it more explicit that we require 3.3.0+ eigen version.