### PR TITLE
Fix caffe_add_whole_archive_flag in cmake

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -132,7 +132,7 @@ endfunction()
 ##############################################################################
 # Helper function to add whole_archive flag around a library.
 function(caffe_add_whole_archive_flag lib output_var)
-  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+  if(APPLE)
     set(${output_var} -Wl,-force_load,$<TARGET_FILE:${lib}> PARENT_SCOPE)
   elseif(MSVC)
     # In MSVC, we will add whole archive in default.


### PR DESCRIPTION
During link time, `-Wl,...` will pass the arguments down to system specific linker. It doesn't matter whether we call `clang` or `g++`. However, the flags will passed to different linker depending on the platform. See https://cxwangyi.wordpress.com/2012/01/20/using-clang-linker-on-different-platforms/. 