### PR TITLE
Fix the pybin11_state_gpu.so linking issue

### DIFF
--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -20,7 +20,7 @@ macro(caffe2_interface_library SRC DST)
       # Assume everything else is like gcc
       target_link_libraries(
           ${DST} INTERFACE
-          -Wl,--whole-archive $<TARGET_FILE:${SRC}> -Wl,--no-whole-archive)
+          "-Wl,--whole-archive $<TARGET_FILE:${SRC}> -Wl,--no-whole-archive")
     endif()
     # Link all interface link libraries of the src target as well.
     # For static library, we need to explicitly depend on all the libraries


### PR DESCRIPTION
Problem: not really do the static linking on libcaffe2.a and libcaffe2_gpu.a against pybind11_state_gpu.so when we enable static linking.

Solution: Use double quotes to enforce the order.

Thanks @Yangqing 