### PR TITLE
Explicitly require listing additional libraries if a binary needs things beyond Caffe2_MAIN_LIBS

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -102,7 +102,6 @@ if(USE_CUDA)
 
   target_include_directories(
       caffe2_gpu INTERFACE $<INSTALL_INTERFACE:include>)
-  add_dependencies(caffe2_gpu Caffe2_PROTO)
   target_link_libraries(
       caffe2_gpu PUBLIC caffe2 ${Caffe2_PUBLIC_CUDA_DEPENDENCY_LIBS})
   target_link_libraries(

--- a/caffe2/binaries/CMakeLists.txt
+++ b/caffe2/binaries/CMakeLists.txt
@@ -1,6 +1,5 @@
 caffe2_binary_target("convert_caffe_image_db.cc")
 caffe2_binary_target("convert_db.cc")
-caffe2_binary_target("db_throughput.cc")
 caffe2_binary_target("make_cifar_db.cc")
 caffe2_binary_target("make_mnist_db.cc")
 caffe2_binary_target("predictor_verifier.cc")
@@ -8,6 +7,11 @@ caffe2_binary_target("print_registered_core_operators.cc")
 caffe2_binary_target("run_plan.cc")
 caffe2_binary_target("speed_benchmark.cc")
 caffe2_binary_target("split_db.cc")
+
+if (USE_THREADS)
+  caffe2_binary_target("db_throughput.cc")
+  target_link_libraries(db_throughput ${CMAKE_THREAD_LIBS_INIT})
+endif()
 
 if (USE_CUDA)
   caffe2_binary_target("inspect_gpus.cc")
@@ -23,18 +27,24 @@ endif()
 
 if (USE_ZMQ)
   caffe2_binary_target("zmq_feeder.cc")
+  target_link_libraries(zmq_feeder ${ZMQ_LIBRARIES})
 endif()
 
 if(USE_MPI)
   caffe2_binary_target("run_plan_mpi.cc")
+  target_link_libraries(run_plan_mpi ${MPI_CXX_LIBRARIES})
 endif()
 
 if (USE_OPENCV AND USE_LEVELDB)
   caffe2_binary_target("convert_encoded_to_raw_leveldb.cc")
+  target_link_libraries(
+      convert_encoded_to_raw_leveldb
+      ${OpenCV_LIBS} ${LevelDB_LIBRARIES} ${Snappy_LIBRARIES})
 endif()
 
 if (USE_OPENCV)
   caffe2_binary_target("make_image_db.cc")
+  target_link_libraries(make_image_db ${OpenCV_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
 # ---[ tutorials

--- a/caffe2/share/contrib/binaries/caffe2_benchmark/CMakeLists.txt
+++ b/caffe2/share/contrib/binaries/caffe2_benchmark/CMakeLists.txt
@@ -1,1 +1,3 @@
 caffe2_binary_target("caffe2_benchmark.cc")
+caffe2_interface_library(Caffe2_CPU_OBSERVER Caffe2_CPU_OBSERVER_LINK)
+target_link_libraries(caffe2_benchmark ${Caffe2_CPU_OBSERVER_LINK})

--- a/cmake/Caffe2Config.cmake.in
+++ b/cmake/Caffe2Config.cmake.in
@@ -81,9 +81,14 @@ endif()
 include ("${CMAKE_CURRENT_LIST_DIR}/Caffe2Targets.cmake")
 
 # Interface libraries, that allows one to build proper link flags.
+# We will also define a helper variable, Caffe2_MAIN_LIBS, that resolves to
+# the main caffe2 libraries in cases of cuda presence / absence.
 caffe2_interface_library(caffe2 caffe2_library)
 if (@USE_CUDA@)
   caffe2_interface_library(caffe2_gpu caffe2_gpu_library)
+  set(Caffe2_MAIN_LIBS caffe2_library caffe2_gpu_library)
+else()
+  set(Caffe2_MAIN_LIBS caffe2_library)
 endif()
 
 # include directory.

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -329,11 +329,10 @@ if(USE_CUDA)
   include(cmake/public/cuda.cmake)
   if(CAFFE2_FOUND_CUDA)
     # A helper variable recording the list of Caffe2 dependent librareis
-    # caffe2::cuda is dealt with separately, due to CUDA_ADD_LIBRARY
+    # caffe2::cudart is dealt with separately, due to CUDA_ADD_LIBRARY
     # design reason (it adds CUDA_LIBRARIES itself).
     set(Caffe2_PUBLIC_CUDA_DEPENDENCY_LIBS
-        caffe2::cudart caffe2::curand
-        caffe2::cublas caffe2::cudnn caffe2::nvrtc)
+        caffe2::cuda caffe2::curand caffe2::cublas caffe2::cudnn caffe2::nvrtc)
   else()
     message(WARNING
         "Not compiling with CUDA. Suppress this warning with "

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -144,40 +144,6 @@ function(caffe_autogen_init_py_files)
   endforeach()
 endfunction()
 
-##############################################################################
-# Creating a Caffe2 binary target with sources specified with relative path.
-# Usage:
-#   caffe2_binary_target(target_name_or_src <src1> [<src2>] [<src3>] ...)
-# If only target_name_or_src is specified, this target is build with one single
-# source file and the target name is autogen from the filename. Otherwise, the
-# target name is given by the first argument and the rest are the source files
-# to build the target.
-function(caffe2_binary_target target_name_or_src)
-  if (${ARGN})
-    set(__target ${target_name_or_src})
-    prepend(__srcs "${CMAKE_CURRENT_SOURCE_DIR}/" "${ARGN}")
-  else()
-    get_filename_component(__target ${target_name_or_src} NAME_WE)
-    prepend(__srcs "${CMAKE_CURRENT_SOURCE_DIR}/" "${target_name_or_src}")
-  endif()
-  add_executable(${__target} ${__srcs})
-  target_link_libraries(${__target} ${Caffe2_MAIN_LIBS})
-  # For binaries, some of the code actually directly call the dependent
-  # libraries even if they are not part of the public dependency libs. As a
-  # result, we will explicitly link the test against the Caffe2 dependency
-  # libs. This should be changed in a future cleanup.
-  if (ANDROID)
-    # ${Caffe2_DEPENDENCY_LIBS}) will break -DBUILD_BINARY
-  else()
-    target_link_libraries(${__target} ${Caffe2_DEPENDENCY_LIBS})
-  endif()
-  if (USE_CUDA)
-    target_link_libraries(${__target} ${Caffe2_CUDA_DEPENDENCY_LIBS})   
-  endif()
-  install(TARGETS ${__target} DESTINATION bin)
-endfunction()
-
-
 ###
 # Removes common indentation from a block of text to produce code suitable for
 # setting to `python -c`, or using with pycmd. This allows multiline code to be

--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -70,3 +70,25 @@ macro(caffe2_interface_library SRC DST)
     INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
     $<TARGET_PROPERTY:${SRC},INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>)
 endmacro()
+
+
+##############################################################################
+# Creating a Caffe2 binary target with sources specified with relative path.
+# Usage:
+#   caffe2_binary_target(target_name_or_src <src1> [<src2>] [<src3>] ...)
+# If only target_name_or_src is specified, this target is build with one single
+# source file and the target name is autogen from the filename. Otherwise, the
+# target name is given by the first argument and the rest are the source files
+# to build the target.
+function(caffe2_binary_target target_name_or_src)
+  if (${ARGN})
+    set(__target ${target_name_or_src})
+    prepend(__srcs "${CMAKE_CURRENT_SOURCE_DIR}/" "${ARGN}")
+  else()
+    get_filename_component(__target ${target_name_or_src} NAME_WE)
+    prepend(__srcs "${CMAKE_CURRENT_SOURCE_DIR}/" "${target_name_or_src}")
+  endif()
+  add_executable(${__target} ${__srcs})
+  target_link_libraries(${__target} ${Caffe2_MAIN_LIBS})
+  install(TARGETS ${__target} DESTINATION bin)
+endfunction()


### PR DESCRIPTION
This is part of the effort to clean up the Caffe2 cmake interface: for binaries that are dependent on Caffe2, we explicitly require them to link against additional libraries that are beyond libcaffe2.so and libcaffe2_gpu.so.