### PR TITLE
Fail fast in pytest

### DIFF
--- a/.jenkins/test.sh
+++ b/.jenkins/test.sh
@@ -105,6 +105,7 @@ fi
 echo "Running Python tests.."
 "$PYTHON" \
   -m pytest \
+  -x \
   -v \
   --junit-xml="$TEST_DIR/python/result.xml" \
   --ignore "$CAFFE2_PYPATH/python/test/executor_test.py" \


### PR DESCRIPTION
Pytest usage: https://docs.pytest.org/en/latest/usage.html#stopping-after-the-first-or-n-failures

Trying to mark the test as failed upon first pytest failure. Benefits:
- Same computation resource.
- Failed test always show at the bottom so that you don't need to scroll up to find them. 
Cons:
- If there are multiple failed tests and you rely on CI to flush them out, it will take more iterations. 