### PR TITLE
Fix build with ComputeLibrary on ARM64

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -442,15 +442,6 @@ if (USE_ACL)
     if (CMAKE_SYSTEM_PROCESSOR MATCHES "^armv")
       # 32-bit ARM (armv7, armv7-a, armv7l, etc)
       set(ACL_ARCH "armv7a")
-      # Compilers for 32-bit ARM need extra flags to enable NEON-FP16
-      add_definitions("-mfpu=neon-fp16")
-
-      include(CheckCCompilerFlag)
-      CHECK_C_COMPILER_FLAG(
-          -mfp16-format=ieee CAFFE2_COMPILER_SUPPORTS_FP16_FORMAT)
-      if (CAFFE2_COMPILER_SUPPORTS_FP16_FORMAT)
-        add_definitions("-mfp16-format=ieee")
-      endif()
     elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
       # 64-bit ARM
       set(ACL_ARCH "arm64-v8a")

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -175,12 +175,18 @@ endif()
 
 # ---[ If we are building with ACL, we will enable neon-fp16.
 if(USE_ACL)
-  if(NOT USE_ARM64)
+  if (CMAKE_SYSTEM_PROCESSOR MATCHES "^armv")
+    # 32-bit ARM (armv7, armv7-a, armv7l, etc)
+    set(ACL_ARCH "armv7a")
+    # Compilers for 32-bit ARM need extra flags to enable NEON-FP16
     add_definitions("-mfpu=neon-fp16")
-  endif()
-  CHECK_C_COMPILER_FLAG(-mfp16-format=ieee CAFFE2_COMPILER_SUPPORTS_FP16_FORMAT)
-  if(CAFFE2_COMPILER_SUPPORTS_FP16_FORMAT)
-    add_definitions("-mfp16-format=ieee")
+
+    include(CheckCCompilerFlag)
+    CHECK_C_COMPILER_FLAG(
+        -mfp16-format=ieee CAFFE2_COMPILER_SUPPORTS_FP16_FORMAT)
+    if (CAFFE2_COMPILER_SUPPORTS_FP16_FORMAT)
+      add_definitions("-mfp16-format=ieee")
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
ARM64 build with ACL was refactored in #2067, but #2066 accidentally reverted some of the changes. This PR brings them back.