### PR TITLE
Add .watchmanconfig to .gitignore so Atom/Watchman won't complain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ caffe2/version.py
 # setup.py intermediates
 .eggs
 caffe2.egg-info
+
+# Atom/Watchman required file
+.watchmanconfig


### PR DESCRIPTION
Internally some people use Atom + watchman for development, and this file is required to be at the root of the repo.