### PR TITLE
Modifications to improve readability of prof_dag

### DIFF
--- a/caffe2/contrib/prof/prof_dag_net.cc
+++ b/caffe2/contrib/prof/prof_dag_net.cc
@@ -26,7 +26,7 @@ namespace caffe2 {
 ProfDAGNet::ProfDAGNet(
     const std::shared_ptr<const NetDef>& net_def,
     Workspace* ws)
-    : DAGNetBase(net_def, ws), time_per_op_(operator_nodes_.size()) {
+    : DAGNetBase(net_def, ws), time_per_op_total_(operator_nodes_.size()) {
   VLOG(1) << "Constructing ProfDAGNet " << name_;
 }
 
@@ -70,30 +70,31 @@ bool ProfDAGNet::DoRunAsync() {
   }
 
   CAFFE_ENFORCE(
-      time_per_op_.size() == operator_nodes_.size(),
+      time_per_op_total_.size() == operator_nodes_.size(),
       "Data collected for ",
-      time_per_op_.size(),
+      time_per_op_total_.size(),
       " ops, expected ",
       operator_nodes_.size(),
       " ops.");
 
-  // create a copy and later collect the differences
-  vector<Stats> time_per_op_run(time_per_op_);
+  // Create a copy of cumulative stats before the run so we can
+  // later collect the difference
+  vector<Stats> time_per_op_pre_run(time_per_op_total_);
   bool success = DAGNetBase::DoRunAsync();
 
-  // aggregate this run's stats per operator type
+  // Aggregate this run's stats per operator type
   CaffeMap<string, float> time_per_op_type_run;
   for (int idx = 0; idx < operator_nodes_.size(); idx++) {
     const auto& node = operator_nodes_[idx];
     const string& op_type = node.operator_->debug_def().type();
     time_per_op_type_run[op_type] +=
-        time_per_op_[idx].sum - time_per_op_run[idx].sum;
-    time_per_op_type_[op_type].cnt += 1;
+        time_per_op_total_[idx].sum - time_per_op_pre_run[idx].sum;
+    time_per_op_type_total_[op_type].cnt += 1;
   }
 
   for (const auto& item : time_per_op_type_run) {
-    time_per_op_type_[item.first].sum += item.second;
-    time_per_op_type_[item.first].sqrsum += item.second * item.second;
+    time_per_op_type_total_[item.first].sum += item.second;
+    time_per_op_type_total_[item.first].sqrsum += item.second * item.second;
   }
 
   return success;
@@ -111,7 +112,7 @@ ProfDAGProto ProfDAGNet::ProtoMsg(std::pair<std::string, Stats> op_stat) const {
 
 ProfDAGProtos ProfDAGNet::GetOperatorStats() {
   ProfDAGProtos prof_dag_protos;
-  for (auto& item : time_per_op_type_) {
+  for (auto& item : time_per_op_type_total_) {
     auto buf = prof_dag_protos.add_stats();
     buf->CopyFrom(ProtoMsg(item));
   }
@@ -122,9 +123,9 @@ ProfDAGProtos ProfDAGNet::GetOperatorStats() {
 // is formatted as a map: (netName__opIndex__opType, cost)
 ProfDAGProtos ProfDAGNet::GetPerOperatorCost() {
   CAFFE_ENFORCE(
-      time_per_op_.size() == operator_nodes_.size(),
+      time_per_op_total_.size() == operator_nodes_.size(),
       "Data collected for ",
-      time_per_op_.size(),
+      time_per_op_total_.size(),
       " ops, expected ",
       operator_nodes_.size(),
       " ops.");
@@ -139,7 +140,7 @@ ProfDAGProtos ProfDAGNet::GetPerOperatorCost() {
     std::string op_output_name =
         name_ + "___" + to_string(idx) + "___" + op_type;
     std::pair<std::string, Stats> op_stat =
-        std::pair<std::string, Stats>(op_output_name, time_per_op_[idx]);
+        std::pair<std::string, Stats>(op_output_name, time_per_op_total_[idx]);
     buf->CopyFrom(ProtoMsg(op_stat));
   }
   return prof_dag_protos;
@@ -159,14 +160,14 @@ bool ProfDAGNet::RunAt(int /* unused */, const std::vector<int>& chain) {
       float spent = timer.MilliSeconds();
 
       CAFFE_ENFORCE(
-          time_per_op_.size() > idx,
+          time_per_op_total_.size() > idx,
           "Expecting ",
-          time_per_op_.size(),
+          time_per_op_total_.size(),
           " ops, but op #",
           idx,
           " was given.");
-      time_per_op_[idx].sum += spent;
-      time_per_op_[idx].sqrsum += spent * spent;
+      time_per_op_total_[idx].sum += spent;
+      time_per_op_total_[idx].sqrsum += spent * spent;
     }
   }
   return success;
@@ -174,15 +175,17 @@ bool ProfDAGNet::RunAt(int /* unused */, const std::vector<int>& chain) {
 
 void ProfDAGNet::PrintStats() {
   CAFFE_ENFORCE(
-      time_per_op_.size() == operator_nodes_.size(),
+      time_per_op_total_.size() == operator_nodes_.size(),
       "Data collected for ",
-      time_per_op_.size(),
+      time_per_op_total_.size(),
       " ops, expected ",
       operator_nodes_.size(),
       " ops.");
 
   CAFFE_ENFORCE(runs_ > 1, "# of runs: ", runs_, ", expected > 1.");
   int measured_runs = runs_ - 1;
+
+  LOG(INFO) << "Measured operators over " << measured_runs << " net runs.";
 
   for (int idx = 0; idx < operator_nodes_.size(); idx++) {
     const auto& op = operator_nodes_[idx].operator_;
@@ -192,20 +195,20 @@ void ProfDAGNet::PrintStats() {
         ? def.name()
         : (op->OutputSize() ? def.output(0) : "NO_OUTPUT");
 
-    float mean = time_per_op_[idx].sum / measured_runs;
+    float mean = time_per_op_total_[idx].sum / measured_runs;
     float stddev =
-        std::sqrt(time_per_op_[idx].sqrsum / measured_runs - mean * mean);
+        std::sqrt(time_per_op_total_[idx].sqrsum / measured_runs - mean * mean);
     VLOG(1) << "Op #" << idx << " (" << print_name << ", " << op_type << ") "
-            << mean << " ms/iter (" << stddev << " ms/iter)";
+            << mean << " ms/run (" << stddev << " ms/run)";
   }
 
-  LOG(INFO) << "Time per operator type:";
-  for (const auto& item : time_per_op_type_) {
+  LOG(INFO) << "Mean time in operator per run (stddev):";
+  for (const auto& item : time_per_op_type_total_) {
     float mean = item.second.sum / measured_runs;
     float stddev = std::sqrt(item.second.sqrsum / measured_runs - mean * mean);
-    LOG(INFO) << std::setw(10) << std::setfill(' ') << mean << " ms/iter ("
-              << std::setw(10) << std::setfill(' ') << stddev << " ms/iter) "
-              << " Count per iter: " << (item.second.cnt / measured_runs)
+    LOG(INFO) << std::setw(10) << std::setfill(' ') << mean << " ms/run ("
+              << std::setw(10) << std::setfill(' ') << stddev << " ms/run) "
+              << " Op count per run: " << (item.second.cnt / measured_runs)
               << "  " << item.first;
   }
 }

--- a/caffe2/contrib/prof/prof_dag_net.h
+++ b/caffe2/contrib/prof/prof_dag_net.h
@@ -53,8 +53,10 @@ class ProfDAGNet : public DAGNetBase {
   void PrintStats();
   void ValidateOpTensorDevices();
   ProfDAGProto ProtoMsg(std::pair<std::string, Stats> op_stat) const;
-  std::vector<Stats> time_per_op_;
-  CaffeMap<std::string, Stats> time_per_op_type_;
+  // Cumulative sum and sum squared time spent per operator instance in net.
+  std::vector<Stats> time_per_op_total_;
+  // Cumulative sum and sum squared time spent per unique operator type.
+  CaffeMap<std::string, Stats> time_per_op_type_total_;
   int runs_ = 0;
 };
 


### PR DESCRIPTION
Cleaned up output of ProfDAGNet (net_type='prof_dag') to be more explicit about run count, op counts per run, and mean vs std dev.
Cleaned up code & comments.

Already reviewed by dongli and xdwang.