### PR TITLE
[tiny] make debug info optional, CAFFE2_DEBUG env variable driven

### DIFF
--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -36,6 +36,7 @@ import pickle
 import numpy as np
 import sys
 import traceback
+import os
 
 # Mac os specific message
 if (sys.platform == 'darwin' and 'leveldb' in C.registered_dbs()):
@@ -322,8 +323,9 @@ def CreateOperator(
     registered with Caffe2.
     """
     operator = caffe2_pb2.OperatorDef()
-    stack = traceback.format_stack()
-    operator.debug_info = "".join(stack[:-1])
+    if (os.environ.get('CAFFE2_DEBUG')):
+        stack = traceback.format_stack()
+        operator.debug_info = "".join(stack[:-1])
 
     operator.type = operator_type
     operator.name = name


### PR DESCRIPTION
This will cause 1) debug info to normally be dropped 2) to allow users to attach debug info with and env variable.
In the future there may be other constructors and this will allow framework authors to have a
consistent mechanism for determining if debug info should be attached.