### PR TITLE
Add ClipByGlobalNorm operator

### DIFF
--- a/caffe2/operators/clip_by_global_norm_op.cc
+++ b/caffe2/operators/clip_by_global_norm_op.cc
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * Copyright (c) 2018, NVIDIA CORPORATION, All rights reserved
+ * Distributed under 2-clause BSD license; see accompanying LICENSE file
+ *
+ **/
+
+#include "caffe2/operators/clip_by_global_norm_op.h"
+
+namespace caffe2 {
+
+template <>
+bool ClipByGlobalNormOp<CPUContext>::RunOnDevice() {
+  if (Input(0).IsType<float>()) {
+    return DoRunWithType<float, float>();
+  } else {
+    LOG(FATAL) << "Unsupported input type";
+  }
+  return true;
+}
+
+template <>
+void ClipByGlobalNormOp<CPUContext>::ClipRatio(
+    const float* sum, float* scaled_clip_ratio) {
+
+  auto global_norm = std::sqrt(*sum) * scale_;
+  auto clip_ratio = clip_norm_ / std::max(global_norm, clip_norm_);
+  *scaled_clip_ratio = clip_ratio * scale_;
+}
+
+REGISTER_CPU_OPERATOR(ClipByGlobalNorm, ClipByGlobalNormOp<CPUContext>);
+
+OPERATOR_SCHEMA(ClipByGlobalNorm)
+    .NumInputs(1, INT_MAX)
+    .NumOutputs(1, INT_MAX)
+    .AllowOneToOneInplace()
+    .SetDoc(R"DOC(
+ClipByGlobalNorm operator clips every element in input tensors so that
+the global norm of all the input tensors becomes at most clip_norm.
+It also multiplies every input element by scale before calculating
+the global norm or clipping the values.
+)DOC")
+    .Arg("clip_norm", "Upper bound on the global norm of input tensors")
+    .Arg("scale", "Scalar used for multiplication")
+    .Arg("output_type", "Datatype of output tensors."
+          "Options are float, float16, input_type."
+          "The latter makes the output datatype the same as inputs'")
+    .Input(
+        0,
+        "inputs",
+        "Input tensors")
+    .Output(
+        0,
+        "outputs",
+        "Output tensors");
+
+}  // namespace caffe2

--- a/caffe2/operators/clip_by_global_norm_op.cu
+++ b/caffe2/operators/clip_by_global_norm_op.cu
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * Copyright (c) 2018, NVIDIA CORPORATION, All rights reserved
+ * Distributed under 2-clause BSD license; see accompanying LICENSE file
+ *
+ **/
+
+#include "caffe2/core/context_gpu.h"
+#include "caffe2/operators/clip_by_global_norm_op.h"
+
+namespace caffe2 {
+
+namespace {
+__global__ void ClipRatioKernel_ClipByGlobalNormOp(
+    const float* sum,
+    float* scaled_clip_ratio,
+    float scale,
+    float clip_norm) {
+
+  if (threadIdx.x == 0) {
+    auto global_norm = sqrt(*sum) * scale;
+    auto clip_ratio = clip_norm / fmax(global_norm, clip_norm);
+    *scaled_clip_ratio = clip_ratio * scale;
+  }
+}
+}
+
+template <>
+bool ClipByGlobalNormOp<CUDAContext>::RunOnDevice() {
+  if (Input(0).IsType<float>()) {
+    return DoRunWithType<float, float>();
+  } else if ((Input(0).IsType<float16>()) &&
+        (this->output_type_ == "float16" || this->output_type_ == "input_type")) {
+    return DoRunWithType<float16, float16>();
+  } else if ((Input(0).IsType<float16>()) && (this->output_type_ == "float")) {
+    return DoRunWithType<float16, float>();
+  } else {
+    LOG(FATAL) << "Unsupported input/output types";
+  }
+  return true;
+}
+
+template <>
+void ClipByGlobalNormOp<CUDAContext>::ClipRatio(
+    const float* sum, float* scaled_clip_ratio) {
+
+  ClipRatioKernel_ClipByGlobalNormOp<<<1, 1, 0, context_.cuda_stream()>>>(
+    sum, scaled_clip_ratio, scale_, clip_norm_);
+}
+
+REGISTER_CUDA_OPERATOR(ClipByGlobalNorm, ClipByGlobalNormOp<CUDAContext>);
+}  // namespace caffe2

--- a/caffe2/operators/clip_by_global_norm_op.h
+++ b/caffe2/operators/clip_by_global_norm_op.h
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * Copyright (c) 2018, NVIDIA CORPORATION, All rights reserved
+ * Distributed under 2-clause BSD license; see accompanying LICENSE file
+ *
+ **/
+
+#ifndef CAFFE2_OPERATORS_CLIP_BY_GLOBAL_NORM_OP_H_
+#define CAFFE2_OPERATORS_CLIP_BY_GLOBAL_NORM_OP_H_
+
+#include <limits>
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <class Context>
+class ClipByGlobalNormOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  ClipByGlobalNormOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws) {
+    clip_norm_ = OperatorBase::GetSingleArgument<float>("clip_norm", -1.0);
+    CAFFE_ENFORCE_GE(clip_norm_, 0);
+    scale_ = OperatorBase::GetSingleArgument<float>("scale", 1.0);
+    output_type_ = OperatorBase::GetSingleArgument<string>("output_type", "input_type");
+    CAFFE_ENFORCE(
+        (output_type_ == "float") ||
+        (output_type_ == "float16") ||
+        (output_type_ == "input_type"));
+
+    CAFFE_ENFORCE_GT(InputSize(), 0);
+    CAFFE_ENFORCE_GT(OutputSize(), 0);
+    CAFFE_ENFORCE_EQ(InputSize(), OutputSize());
+  }
+
+  bool RunOnDevice() override;
+
+  template<typename IN_TYPE, typename OUT_TYPE>
+  bool DoRunWithType() {
+    for (auto i = 1; i < InputSize(); i++) {
+      CAFFE_ENFORCE(Input(i).template IsType<IN_TYPE>());
+    }
+    // Store the SumSqr of each tensor in acc
+    Tensor<Context> acc;
+    acc.Resize(InputSize());
+    auto acc_data = acc.template mutable_data<float>();
+    for (auto i = 0; i < InputSize(); ++i) {
+      auto& X = Input(i);
+      math::SumSqr<IN_TYPE, Context, float>(
+        X.size(),
+        X.template data<IN_TYPE>(),
+        &acc_data[i],
+        &context_,
+        &scratch_);
+    }
+
+    Tensor<Context> sum;
+    sum.Resize(1);
+    auto sum_data = sum.template mutable_data<float>();
+    math::Sum<float, Context>(
+        InputSize(), acc_data, sum_data, &context_, &scratch_);
+    Tensor<Context> scaled_clip_ratio;
+    scaled_clip_ratio.Resize(1);
+    ClipRatio(sum_data, scaled_clip_ratio.template mutable_data<float>());
+
+    for (auto i = 0; i < InputSize(); ++i) {
+      auto& X = Input(i);
+      auto* Y = Output(i);
+      Y->ResizeLike(X);
+      math::Scale<IN_TYPE, Context, OUT_TYPE>(
+        X.size(),
+        scaled_clip_ratio.template data<float>(),
+        X.template data<IN_TYPE>(),
+        Y->template mutable_data<OUT_TYPE>(),
+        &context_);
+    }
+
+    return true;
+  }
+
+ private:
+  void ClipRatio(const float* sum, float* scaled_clip_ratio);
+
+ protected:
+  float clip_norm_;
+  float scale_;
+  string output_type_;
+  Tensor<Context> scratch_;
+};
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_CLIP_BY_GLOBAL_NORM_OP_H_

--- a/caffe2/python/hypothesis_test_util.py
+++ b/caffe2/python/hypothesis_test_util.py
@@ -249,14 +249,27 @@ def sparse_lengths_tensor(**kwargs):
     return sparse_segmented_tensor(segment_generator=lengths, **kwargs)
 
 
-def tensors(n, min_dim=1, max_dim=4, dtype=np.float32, elements=None, **kwargs):
-    dims_ = st.lists(dims(**kwargs), min_size=min_dim, max_size=max_dim)
-    return dims_.flatmap(
-        lambda dims: st.lists(
-            arrays(dims, dtype, elements),
-            min_size=n,
-            max_size=n))
+def tensors(min_n=1, max_n=None,
+            min_dim=1, max_dim=4,
+            varying_shape=False,
+            dtype=np.float32,
+            elements=None,
+            **kwargs):
+    """
+    If varying_shape then the tensors will have different shapes.
 
+    """
+    dims_ = st.lists(dims(**kwargs), min_size=min_dim, max_size=max_dim)
+    arrays_list = lambda dims: st.lists(
+      arrays(dims, dtype, elements),
+      min_size=min_n,
+      max_size=max_n if max_n != None else min_n)
+
+    if varying_shape:
+        return arrays_list(dims_)
+    else:
+        return dims_.flatmap(
+            lambda dims: arrays_list(dims))
 
 def tensors1d(n, min_len=1, max_len=64, dtype=np.float32, elements=None):
     return tensors(
@@ -350,7 +363,7 @@ class HypothesisTestCase(test_util.TestCase):
 
         Usage example:
 
-            @given(inputs=hu.tensors(n=2), in_place=st.booleans(), **hu.gcs)
+            @given(inputs=hu.tensors(min_n=2), in_place=st.booleans(), **hu.gcs)
             def test_sum(self, inputs, in_place, gc, dc):
                 op = core.CreateOperator("Sum", ["X1", "X2"],
                                                 ["Y" if not in_place else "X1"])
@@ -386,7 +399,7 @@ class HypothesisTestCase(test_util.TestCase):
 
         Usage example:
 
-            @given(inputs=hu.tensors(n=2), in_place=st.booleans(), **hu.gcs)
+            @given(inputs=hu.tensors(min_n=2), in_place=st.booleans(), **hu.gcs)
             def test_sum(self, inputs, in_place, gc, dc):
                 op = core.CreateOperator("Sum", ["X1", "X2"],
                                                 ["Y" if not in_place else "X1"])

--- a/caffe2/python/model_helper.py
+++ b/caffe2/python/model_helper.py
@@ -48,6 +48,7 @@ _known_working_ops = [
     "AveragedLoss",
     "Cast",
     "Checkpoint",
+    "ClipByGlobalNorm",
     "ConstantFill",
     "Copy",
     "CopyGPUToCPU",

--- a/caffe2/python/operator_test/adagrad_test.py
+++ b/caffe2/python/operator_test/adagrad_test.py
@@ -55,7 +55,7 @@ class TestAdagrad(hu.HypothesisTestCase):
         param_out = param_in + grad_adj
         return (param_out, mom_out)
 
-    @given(inputs=hu.tensors(n=3),
+    @given(inputs=hu.tensors(min_n=3),
            lr=st.floats(min_value=0.01, max_value=0.99,
                         allow_nan=False, allow_infinity=False),
            epsilon=st.floats(min_value=0.01, max_value=0.99,
@@ -81,7 +81,7 @@ class TestAdagrad(hu.HypothesisTestCase):
     # Suppress filter_too_much health check.
     # Likely caused by `assume` call falling through too often.
     @settings(suppress_health_check=[HealthCheck.filter_too_much])
-    @given(inputs=hu.tensors(n=3),
+    @given(inputs=hu.tensors(min_n=3),
            lr=st.floats(min_value=0.01, max_value=0.99,
                         allow_nan=False, allow_infinity=False),
            epsilon=st.floats(min_value=0.01, max_value=0.99,
@@ -149,7 +149,7 @@ class TestAdagrad(hu.HypothesisTestCase):
                 ref_sparse
             )
 
-    @given(inputs=hu.tensors(n=2),
+    @given(inputs=hu.tensors(min_n=2),
            lr=st.floats(min_value=0.01, max_value=0.99,
                         allow_nan=False, allow_infinity=False),
            epsilon=st.floats(min_value=0.01, max_value=0.99,
@@ -200,7 +200,7 @@ class TestAdagrad(hu.HypothesisTestCase):
     # Suppress filter_too_much health check.
     # Likely caused by `assume` call falling through too often.
     @settings(suppress_health_check=[HealthCheck.filter_too_much])
-    @given(inputs=hu.tensors(n=2),
+    @given(inputs=hu.tensors(min_n=2),
            lr=st.floats(min_value=0.01, max_value=0.99,
                         allow_nan=False, allow_infinity=False),
            epsilon=st.floats(min_value=0.01, max_value=0.99,
@@ -259,7 +259,7 @@ class TestAdagrad(hu.HypothesisTestCase):
             [param, momentum, indices, grad, lr],
             ref_row_wise_sparse)
 
-    @given(inputs=hu.tensors(n=1),
+    @given(inputs=hu.tensors(min_n=1),
            lr=st.floats(min_value=0.01, max_value=0.99,
                         allow_nan=False, allow_infinity=False),
            epsilon=st.floats(min_value=0.01, max_value=0.99,

--- a/caffe2/python/operator_test/adam_test.py
+++ b/caffe2/python/operator_test/adam_test.py
@@ -56,7 +56,7 @@ class TestAdam(hu.HypothesisTestCase):
         return (param_out, mom1_out, mom2_out)
 
 
-    @given(inputs=hu.tensors(n=4),
+    @given(inputs=hu.tensors(min_n=4),
            ITER=st.integers(min_value=0, max_value=10000),
            LR=st.floats(min_value=0.01, max_value=0.99,
                         allow_nan=False, allow_infinity=False),
@@ -89,7 +89,7 @@ class TestAdam(hu.HypothesisTestCase):
                 beta1=beta1, beta2=beta2, epsilon=epsilon),
             input_device_options=input_device_options)
 
-    @given(inputs=hu.tensors(n=4),
+    @given(inputs=hu.tensors(min_n=4),
            ITER=st.integers(min_value=0, max_value=10000),
            LR=st.floats(min_value=0.01, max_value=0.99,
                         allow_nan=False, allow_infinity=False),

--- a/caffe2/python/operator_test/clip_by_global_norm_test.py
+++ b/caffe2/python/operator_test/clip_by_global_norm_test.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2016-present, Facebook, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+
+# Copyright (c) 2018, NVIDIA CORPORATION, All rights reserved
+# Distributed under 2-clause BSD license; see accompanying LICENSE file
+##############################################################################
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+import math
+
+from hypothesis import assume, given, settings
+import hypothesis.strategies as st
+
+from caffe2.proto import caffe2_pb2
+from caffe2.python import core
+import caffe2.python.hypothesis_test_util as hu
+
+
+class TestClipByGlobalNorm(hu.HypothesisTestCase):
+    @staticmethod
+    def _dtype_conversion(X, dtype, gc, dc):
+        """ClipByGradientNormOp only supports fp16 with CUDA."""
+        if dtype == np.float16:
+            assume(gc.device_type == caffe2_pb2.CUDA)
+            dc = [d for d in dc if d.device_type == caffe2_pb2.CUDA]
+            X = [x.astype(dtype) for x in X]
+        return X, dc
+
+
+    @given(X=hu.tensors(max_n=10, varying_shape=True),
+           clip_norm=st.floats(min_value=1.0, max_value=10.0),
+           scale=st.floats(min_value=1.0/1024, max_value=2.0),
+           inplace=st.booleans(),
+           dtype=st.sampled_from([np.float32, np.float16]),
+           **hu.gcs)
+    @settings(max_examples=30)
+    def test_clip_by_global_norm(self, X, clip_norm, scale, inplace, dtype, gc, dc):
+
+        def clip_by_global_norm_ref(*inputs):
+            X_scaled = [np.dot(x, scale) for x in inputs]
+            norm_sqr = lambda x: np.sum(np.square(x))
+            global_norm = math.sqrt(sum([norm_sqr(x.astype(np.float32)) for x in X_scaled])) 
+            clip_ratio = clip_norm / max(global_norm, clip_norm)
+            X_clipped = [np.dot(x.astype(np.float32), clip_ratio) for x in X_scaled]
+            return X_clipped
+
+        inputs = ["X_{}".format(i) for i in range(len(X))]
+        outputs = ["Y_{}".format(i) for i in range(len(X))] \
+            if not inplace else inputs
+        op = core.CreateOperator(
+            "ClipByGlobalNorm",
+            inputs, outputs,
+            clip_norm=clip_norm,
+            scale=scale)
+
+        X, dc = self._dtype_conversion(X, dtype, gc, dc)
+        atol=1e-8 if dtype==np.float32 else 1e-3
+        self.assertReferenceChecks(gc, op, X, clip_by_global_norm_ref, atol=atol)
+        # Check over multiple devices
+        self.assertDeviceChecks(dc, op, X, [i for i in range(len(X))])
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()

--- a/caffe2/python/operator_test/distance_op_test.py
+++ b/caffe2/python/operator_test/distance_op_test.py
@@ -47,7 +47,7 @@ class DistanceTest(hu.HypothesisTestCase):
         self.assertGradientChecks(gc, cos_op, [X, Y], 1, [0],
                                   stepsize=1e-2, threshold=1e-2)
 
-    @given(inputs=hu.tensors(n=2,
+    @given(inputs=hu.tensors(min_n=2,
                              min_dim=1,
                              max_dim=2,
                              dtype=np.float32),

--- a/caffe2/python/operator_test/layer_norm_op_test.py
+++ b/caffe2/python/operator_test/layer_norm_op_test.py
@@ -26,7 +26,7 @@ import numpy as np
 from caffe2.python.model_helper import ModelHelper
 
 class TestLayerNormOp(hu.HypothesisTestCase):
-    @given(X=hu.tensors(n=1), **hu.gcs)
+    @given(X=hu.tensors(min_n=1), **hu.gcs)
     def test_layer_norm_grad_op(self, X, gc, dc):
         X = X[0]
         if len(X.shape) == 1:
@@ -97,7 +97,7 @@ class TestLayerNormOp(hu.HypothesisTestCase):
             outputs_to_check=[0],
         )
 
-    @given(X=hu.tensors(n=1), **hu.gcs)
+    @given(X=hu.tensors(min_n=1), **hu.gcs)
     def test_layer_norm_op(self, X, gc, dc):
         X = X[0]
         if len(X.shape) == 1:
@@ -139,7 +139,7 @@ class TestLayerNormOp(hu.HypothesisTestCase):
             outputs_to_check=[0, 1, 2],
         )
 
-    @given(X=hu.tensors(n=1), **hu.gcs)
+    @given(X=hu.tensors(min_n=1), **hu.gcs)
     def test_layer_norm_brew_wrapper(self, X, gc, dc):
         X = X[0]
         if len(X.shape) == 1:

--- a/caffe2/python/operator_test/lpnorm_op_test.py
+++ b/caffe2/python/operator_test/lpnorm_op_test.py
@@ -25,7 +25,7 @@ from hypothesis import given
 
 
 class LpnormTest(hu.HypothesisTestCase):
-    @given(inputs=hu.tensors(n=1,
+    @given(inputs=hu.tensors(min_n=1,
                              min_dim=1,
                              max_dim=3,
                              dtype=np.float32),

--- a/caffe2/python/operator_test/momentum_sgd_test.py
+++ b/caffe2/python/operator_test/momentum_sgd_test.py
@@ -85,7 +85,7 @@ class TestMomentumSGD(hu.HypothesisTestCase):
         )
 
     @given(
-        inputs=hu.tensors(n=3),
+        inputs=hu.tensors(min_n=3),
         momentum=st.floats(min_value=0.1, max_value=0.9),
         nesterov=st.booleans(),
         lr=st.floats(min_value=0.1, max_value=0.9),

--- a/caffe2/python/optimizer_test_util.py
+++ b/caffe2/python/optimizer_test_util.py
@@ -192,7 +192,10 @@ class LRModificationTestBase(object):
     def test_global_norm_based_gradient_clipping(self):
         max_gradient_norm = 1.0
         model, perfect_model, data, label = self._createDense()
-        opt = self.build_optimizer(model, max_gradient_norm=max_gradient_norm)
+        opt = self.build_optimizer(
+            model,
+            max_gradient_norm=max_gradient_norm,
+            clip_using_lr_multiplier=True)
 
         params = []
         for param in model.GetParams(top_scope=True):
@@ -250,4 +253,4 @@ class LRModificationTestBase(object):
         # lr_multiplier. Here, we have both lr_injector and norm_ratio that
         # affect the lr_multiplier
         workspace.RunNet(model.net.Proto().name)
-        self.assertEqual(workspace.FetchBlob('lr_multiplier'), 0)
+        self.assertEqual(workspace.FetchBlob(opt._lr_multiplier), 0)

--- a/caffe2/python/python_op_test.py
+++ b/caffe2/python/python_op_test.py
@@ -190,7 +190,8 @@ class PythonOpTest(hu.HypothesisTestCase):
         self.assertGradientChecks(gc, op, [x], 0, [0])
         self.assertDeviceChecks(dc, op, [x], [0])
 
-    @given(inputs=hu.tensors(n=2), **hu.gcs)
+    @given(inputs=hu.tensors(min_n=2),
+           **hu.gcs)
     def test_gradient_multiple(self, inputs, gc, dc):
         (x1, x2) = inputs
 
@@ -216,7 +217,8 @@ class PythonOpTest(hu.HypothesisTestCase):
             self.assertGradientChecks(gc, op, [x1, x2], idx, [0, 1])
         self.assertDeviceChecks(dc, op, [x1, x2], [0, 1])
 
-    @given(inputs=hu.tensors(n=3), **hu.gcs)
+    @given(inputs=hu.tensors(min_n=3),
+           **hu.gcs)
     def test_gradient_multiple_with_indices(self, inputs, gc, dc):
         (x1, x2, x3) = inputs
 

--- a/caffe2/utils/math.h
+++ b/caffe2/utils/math.h
@@ -311,16 +311,16 @@ template <typename T, class Context>
 void Dot(const int N, const T* a, const T* b, T* y, Context* context);
 
 // Sum of vector x, and writes the result to a single value y.
-template <typename T, class Context>
-void Sum(const int N, const T* x, T* y, Context* context,
+template <typename IN_TYPE, class Context, typename OUT_TYPE = IN_TYPE>
+void Sum(const int N, const IN_TYPE* x, OUT_TYPE* y, Context* context,
          Tensor<Context>* scratch_ptr = nullptr);
 
 // Sum of squares of vector x, and writes the result to a single value y.
-template <typename T, class Context>
+template <typename IN_TYPE, class Context, typename OUT_TYPE = IN_TYPE>
 void SumSqr(
     const int N,
-    const T* x,
-    T* y,
+    const IN_TYPE* x,
+    OUT_TYPE* y,
     Context* context,
     Tensor<Context>* scratch_ptr = nullptr);
 
@@ -330,14 +330,14 @@ template <typename T, class Context>
 void Select(const int N, const int D, const T* x, const int* idx, T* y,
             Context* context);
 
-template <typename T, class Context>
-void Scale(const int N, const float alpha, const T* x, T* y, Context* context);
+template <typename IN_TYPE, class Context, typename OUT_TYPE = IN_TYPE>
+void Scale(const int N, const float alpha, const IN_TYPE* x, OUT_TYPE* y, Context* context);
 
 // Different from the Scale function above, if alpha is passed in
 // as a pointer, we will assume that it lives on the Context device,
 // for example on GPU.
-template <typename T, class Context>
-void Scale(const int N, const float* alpha, const T* x, T* y, Context* context);
+template <typename IN_TYPE, class Context, typename OUT_TYPE = IN_TYPE>
+void Scale(const int N, const float* alpha, const IN_TYPE* x, OUT_TYPE* y, Context* context);
 
 template <typename T, class Context>
 void Axpy(const int N, const float alpha, const T* x, T* y, Context* context);

--- a/caffe2/utils/math_gpu.cu
+++ b/caffe2/utils/math_gpu.cu
@@ -1019,8 +1019,8 @@ void Dot<float16, CUDAContext>(
 // may interfere with NCCL and create a deadlock. Hence we are using a custom
 // reduction here.
 #define SUM_KERNEL_NTHREADS 128
-template <typename T>
-__global__ void SumKernel(const int N, const T* X, T* Y, bool square) {
+template <typename IN_TYPE, typename OUT_TYPE>
+__global__ void SumKernel(const int N, const IN_TYPE* X, OUT_TYPE* Y, bool square) {
   const int idx = threadIdx.x;
   __shared__ float reduction_buffer[SUM_KERNEL_NTHREADS];
 
@@ -1030,11 +1030,11 @@ __global__ void SumKernel(const int N, const T* X, T* Y, bool square) {
   // N -> 128
   if (!square) {
     for (int i = idx; i < N; i += SUM_KERNEL_NTHREADS) {
-      reduction_buffer[idx] += convert::To<T, float>(X[i]);
+      reduction_buffer[idx] += convert::To<IN_TYPE, float>(X[i]);
     }
   } else {
     for (int i = idx; i < N; i += SUM_KERNEL_NTHREADS) {
-      float Xi = convert::To<T, float>(X[i]);
+      float Xi = convert::To<IN_TYPE, float>(X[i]);
       reduction_buffer[idx] += Xi * Xi;
     }
   }
@@ -1053,7 +1053,7 @@ __global__ void SumKernel(const int N, const T* X, T* Y, bool square) {
     for (int i = 0; i < 32; ++i) {
       tmp += reduction_buffer[i];
     }
-    *Y = convert::To<float, T>(tmp);
+    *Y = convert::To<float, OUT_TYPE>(tmp);
   }
 }
 
@@ -1122,17 +1122,17 @@ struct FloatTransform {
 };
 } // namespace
 
-#define CAFFE2_MATH_SUM_FUNC(T)                                           \
+#define CAFFE2_MATH_SUM_FUNC(IN_TYPE, OUT_TYPE)                                           \
   template <>                                                             \
-  void Sum<T, CUDAContext>(                                               \
+  void Sum<IN_TYPE, CUDAContext, OUT_TYPE>(                                               \
       const int N,                                                        \
-      const T* x,                                                         \
-      T* y,                                                               \
+      const IN_TYPE* x,                                                         \
+      OUT_TYPE* y,                                                               \
       CUDAContext* context,                                               \
       Tensor<CUDAContext>* scratch_ptr) {                                 \
     if (scratch_ptr && N > DEVICE_REDUCE_SIZE_THRESHOLD) {                \
-      FloatTransform<T> transform;                                        \
-      cub::TransformInputIterator<float, FloatTransform<T>, const T*> it( \
+      FloatTransform<IN_TYPE> transform;                                        \
+      cub::TransformInputIterator<float, FloatTransform<IN_TYPE>, const IN_TYPE*> it( \
           x, transform);                                                  \
       float* sum = nullptr;                                               \
       SumFloatIter(N, it, sum, context, scratch_ptr);                     \
@@ -1143,7 +1143,8 @@ struct FloatTransform {
     }                                                                     \
   }
 
-CAFFE2_MATH_SUM_FUNC(float16)
+CAFFE2_MATH_SUM_FUNC(float16, float16)
+CAFFE2_MATH_SUM_FUNC(float16, float)
 #undef CAFFE2_MATH_SUM_FUNC
 
 namespace {
@@ -1173,17 +1174,17 @@ void SumSqr<float, CUDAContext>(
   }
 }
 
-#define CAFFE2_MATH_SUMSQR_FUNC(T)                                      \
+#define CAFFE2_MATH_SUMSQR_FUNC(IN_TYPE, OUT_TYPE)                                      \
   template <>                                                           \
-  void SumSqr<T, CUDAContext>(                                          \
+  void SumSqr<IN_TYPE, CUDAContext, OUT_TYPE>(                                          \
       const int N,                                                      \
-      const T* x,                                                       \
-      T* y,                                                             \
+      const IN_TYPE* x,                                                       \
+      OUT_TYPE* y,                                                             \
       CUDAContext* context,                                             \
       Tensor<CUDAContext>* scratch_ptr) {                               \
     if (scratch_ptr && N > DEVICE_REDUCE_SIZE_THRESHOLD) {              \
-      FloatTransform<T> float_transform;                                \
-      cub::TransformInputIterator<float, FloatTransform<T>, const T*>   \
+      FloatTransform<IN_TYPE> float_transform;                                \
+      cub::TransformInputIterator<float, FloatTransform<IN_TYPE>, const IN_TYPE*>   \
           float_it(x, float_transform);                                 \
       SqrTransform<float> sqr_transform;                                \
       cub::TransformInputIterator<                                      \
@@ -1200,7 +1201,8 @@ void SumSqr<float, CUDAContext>(
     }                                                                   \
   }
 
-CAFFE2_MATH_SUMSQR_FUNC(float16)
+CAFFE2_MATH_SUMSQR_FUNC(float16, float)
+CAFFE2_MATH_SUMSQR_FUNC(float16, float16)
 #undef CAFFE2_MATH_SUMSQR_FUNC
 #undef DEVICE_REDUCE_SIZE_THRESHOLD
 
@@ -1238,19 +1240,18 @@ void Select<float16, CUDAContext>(
 }
 
 namespace {
-template <typename T>
-__global__ void ScaleKernel(const int n, const float alpha, const T* x, T* y) {
+template <typename IN_TYPE, typename OUT_TYPE>
+__global__ void ScaleKernel(const int n, const float alpha, const IN_TYPE* x, OUT_TYPE* y) {
   CUDA_1D_KERNEL_LOOP(i, n) {
-    // y[i] = convert::To<float,T>(convert::To<T, float>(x[i]) * alpha);
-    y[i] = convert::Get<T>(convert::Get<float>(x[i]) * alpha);
+    y[i] = convert::Get<OUT_TYPE>(convert::Get<float>(x[i]) * alpha);
   }
 }
 
-template <typename T>
+template <typename IN_TYPE, typename OUT_TYPE>
 __global__ void
-ScaleKernelDeviceAlpha(const int n, const float* alpha, const T* x, T* y) {
+ScaleKernelDeviceAlpha(const int n, const float* alpha, const IN_TYPE* x, OUT_TYPE* y) {
   CUDA_1D_KERNEL_LOOP(i, n) {
-    y[i] = x[i] * (*alpha);
+    y[i] = convert::Get<OUT_TYPE>(convert::Get<float>(x[i]) * (*alpha));
   }
 }
 
@@ -1297,8 +1298,11 @@ void Scale<float, CUDAContext>(
     const float* x,
     float* y,
     CUDAContext* context) {
-  ScaleKernel<float><<<CAFFE_GET_BLOCKS(n), CAFFE_CUDA_NUM_THREADS,
-                       0, context->cuda_stream()>>>(n, alpha, x, y);
+  ScaleKernel<float, float>
+      <<<CAFFE_GET_BLOCKS(n),
+         CAFFE_CUDA_NUM_THREADS,
+         0,
+         context->cuda_stream()>>>(n, alpha, x, y);
 }
 
 template <>
@@ -1308,20 +1312,36 @@ void Scale<float16, CUDAContext>(
     const float16* x,
     float16* y,
     CUDAContext* context) {
-  ScaleKernel<float16><<<
-      CAFFE_GET_BLOCKS(n),
-      CAFFE_CUDA_NUM_THREADS,
-      0,
-      context->cuda_stream()>>>(n, alpha, x, y);
+  ScaleKernel<float16, float16>
+      <<<CAFFE_GET_BLOCKS(n),
+         CAFFE_CUDA_NUM_THREADS,
+         0,
+         context->cuda_stream()>>>(n, alpha, x, y);
+}
+
+template <>
+void Scale<float16, CUDAContext, float>(
+    const int n,
+    const float alpha,
+    const float16* x,
+    float* y,
+    CUDAContext* context) {
+  ScaleKernel<float16, float>
+      <<<CAFFE_GET_BLOCKS(n),
+         CAFFE_CUDA_NUM_THREADS,
+         0,
+         context->cuda_stream()>>>(n, alpha, x, y);
 }
 
 template <>
 void Scale<float, CUDAContext>(
     const int n, const float* alpha, const float *x, float* y,
     CUDAContext* context) {
-  ScaleKernelDeviceAlpha<float><<<
-      CAFFE_GET_BLOCKS(n), CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(
-          n, alpha, x, y);
+  ScaleKernelDeviceAlpha<float, float>
+      <<<CAFFE_GET_BLOCKS(n),
+         CAFFE_CUDA_NUM_THREADS,
+         0,
+         context->cuda_stream()>>>(n, alpha, x, y);
 }
 
 template <>
@@ -1331,11 +1351,25 @@ void Scale<float16, CUDAContext>(
     const float16* x,
     float16* y,
     CUDAContext* context) {
-  ScaleKernelDeviceAlpha<float16><<<
-      CAFFE_GET_BLOCKS(n),
-      CAFFE_CUDA_NUM_THREADS,
-      0,
-      context->cuda_stream()>>>(n, alpha, x, y);
+  ScaleKernelDeviceAlpha<float16, float16>
+      <<<CAFFE_GET_BLOCKS(n),
+         CAFFE_CUDA_NUM_THREADS,
+         0,
+         context->cuda_stream()>>>(n, alpha, x, y);
+}
+
+template <>
+void Scale<float16, CUDAContext, float>(
+    const int n,
+    const float* alpha,
+    const float16* x,
+    float* y,
+    CUDAContext* context) {
+  ScaleKernelDeviceAlpha<float16, float>
+      <<<CAFFE_GET_BLOCKS(n),
+         CAFFE_CUDA_NUM_THREADS,
+         0,
+         context->cuda_stream()>>>(n, alpha, x, y);
 }
 
 template <>


### PR DESCRIPTION
- Improve `hu.tensors` arguments.
- Use ClipByGlobalNormOp in optimizer.py
- Support FP16 in ClipByGlobalNorm
- Use scratch space in SumSqr to improve perf for large sizes.
- Add arg clip_using_lr_multiplier to optimizers so that we can use the old method as well.
