### PR TITLE
FP16 native compute in Conv & ConvGradient op (with CuDNN)

### DIFF
--- a/caffe2/operators/conv_op_cache_cudnn.h
+++ b/caffe2/operators/conv_op_cache_cudnn.h
@@ -25,46 +25,58 @@
 #include "caffe2/core/tensor.h"
 
 namespace caffe2 {
-template <typename T>
+template <typename TAlgorithm>
 class AlgorithmsCache {
  public:
-  T getAlgorithm(
-      const std::vector<TIndex>& bottom,
-      const std::vector<TIndex>& desc,
-      std::function<T()> generatingFunc);
+  // Caches the best algorithm for a given
+  // combination of tensor dimensions & compute data type.
+  //
+  TAlgorithm getAlgorithm(
+      const std::vector<TIndex>& tensorDimensions1,
+      const std::vector<TIndex>& tensorDimensions2,
+      int algorithmFlags, // Differentiate between algorithms with different
+                          // parameters in a generic way
+      std::function<TAlgorithm()> generatingFunc);
 
  private:
-  std::unordered_map<int64_t, T> hash_;
+  std::unordered_map<int64_t, TAlgorithm> hash_;
 };
 
-template <typename T>
-T AlgorithmsCache<T>::getAlgorithm(
-    const std::vector<TIndex>& vec1,
-    const std::vector<TIndex>& vec2,
-    std::function<T()> generatingFunc) {
-  uint64_t seed = 0;
+template <typename TAlgorithm>
+TAlgorithm AlgorithmsCache<TAlgorithm>::getAlgorithm(
+    const std::vector<TIndex>& tensorDimensions1,
+    const std::vector<TIndex>& tensorDimensions2,
+    int algorithmFlags,
+    std::function<TAlgorithm()> generatingFunc) {
+  int64_t seed = 0;
+  // Hash all of the inputs, which we wiill then use to try and look up
+  // a previously discovered algorithm, or fall back to generating a new one.
   std::hash<TIndex> hashFn;
-  for (const auto num : vec1) {
+  for (const auto num : tensorDimensions1) {
     // Copied from boost::hash_combine.
     // Adding 1 to differentiate between first and second vector.
     seed ^= hashFn(num) + 0x9e3779b9 + (seed << 6) + (seed >> 2) + 1;
   }
 
-  for (const auto num : vec2) {
+  for (const auto num : tensorDimensions2) {
     // Copied from boost::hash_combine.
     seed ^= hashFn(num) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
   }
+
+  // Adding 2 to differentiate from previous vectors
+  seed ^= hashFn(algorithmFlags) + 0x9e3779b9 + (seed << 6) + (seed >> 2) + 2;
 
   if (seed == 0) {
     return generatingFunc();
   }
 
   if (hash_.find(seed) == hash_.end()) {
-    T value = generatingFunc();
+    TAlgorithm value = generatingFunc();
     hash_[seed] = value;
   }
 
   return hash_[seed];
 }
-}
+} // namespace caffe2
+
 #endif

--- a/caffe2/operators/conv_op_cache_cudnn_test.cc
+++ b/caffe2/operators/conv_op_cache_cudnn_test.cc
@@ -28,37 +28,50 @@ namespace caffe2 {
 TEST(AlgorithmsCacheTest, CachesCorrectly) {
   AlgorithmsCache<int> cache;
   int result = cache.getAlgorithm(
-      std::vector<TIndex>(1), std::vector<TIndex>(1), []() { return 5; });
+      std::vector<TIndex>(1), std::vector<TIndex>(1), 0, []() { return 5; });
   EXPECT_EQ(result, 5);
 
   int res2 = cache.getAlgorithm(
-      std::vector<TIndex>(1), std::vector<TIndex>(1), []() { return 10; });
+      std::vector<TIndex>(1), std::vector<TIndex>(1), 0, []() { return 10; });
 
   EXPECT_EQ(res2, 5);
-}
-
-TEST(AlgorithmsCacheTest, DoesNotCacheEmptyKeys) {
-  AlgorithmsCache<int> cache;
-  int result = cache.getAlgorithm(
-      std::vector<TIndex>(), std::vector<TIndex>(), []() { return 5; });
-  EXPECT_EQ(result, 5);
-
-  int res2 = cache.getAlgorithm(
-      std::vector<TIndex>(), std::vector<TIndex>(), []() { return 10; });
-
-  EXPECT_EQ(res2, 10);
 }
 
 TEST(AlgorithmsCacheTest, KeysDifferIfOneVectorIsEmpty) {
   AlgorithmsCache<int> cache;
   int result = cache.getAlgorithm(
-      std::vector<TIndex>(1, 10), std::vector<TIndex>(), []() { return 5; });
+      std::vector<TIndex>(1, 10), std::vector<TIndex>(), 0, []() { return 5; });
   EXPECT_EQ(result, 5);
 
   int res2 = cache.getAlgorithm(
-      std::vector<TIndex>(), std::vector<TIndex>(1, 10), []() { return 10; });
+      std::vector<TIndex>(), std::vector<TIndex>(1, 10), 0, []() {
+        return 10;
+      });
 
   EXPECT_EQ(res2, 10);
+}
+
+TEST(AlgorithmsCacheTest, KeysDifferIfFlagsAreDifferent) {
+  AlgorithmsCache<int> cache;
+  int result = cache.getAlgorithm(
+      std::vector<TIndex>{2, 3, 4}, std::vector<TIndex>{5, 6}, 123, []() {
+        return 5;
+      });
+  EXPECT_EQ(result, 5);
+
+  int res2 = cache.getAlgorithm(
+      std::vector<TIndex>{2, 3, 4}, std::vector<TIndex>{5, 6}, 456, []() {
+        return 10;
+      });
+
+  EXPECT_EQ(res2, 10);
+
+  int res3 = cache.getAlgorithm(
+      std::vector<TIndex>{2, 3, 4}, std::vector<TIndex>{5, 6}, 456, []() {
+        return 15;
+      });
+
+  EXPECT_EQ(res3, 10);
 }
 
 } // namespace caffe2

--- a/caffe2/operators/conv_op_cudnn.cc
+++ b/caffe2/operators/conv_op_cudnn.cc
@@ -191,9 +191,11 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
           &stride_width,
           &dilation_height,
           &dilation_width,
-          &mode,
-
-          &dataType));
+          &mode
+#if CUDNN_VERSION_MIN(6, 0, 0)
+          , &dataType
+#endif
+        ));
 
       CUDNN_ENFORCE(cudnnSetConvolution2dDescriptor(
           copy,
@@ -203,8 +205,11 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
           stride_width,
           dilation_height,
           dilation_width,
-          mode,
-          dataType));
+          mode
+#if CUDNN_VERSION_MIN(6, 0, 0)
+          , dataType
+#endif
+        ));
     } else {
       cudnnConvolutionMode_t mode;
       cudnnDataType_t dataType;

--- a/caffe2/operators/conv_op_cudnn.cc
+++ b/caffe2/operators/conv_op_cudnn.cc
@@ -192,6 +192,7 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
           &dilation_height,
           &dilation_width,
           &mode,
+
           &dataType));
 
       CUDNN_ENFORCE(cudnnSetConvolution2dDescriptor(
@@ -287,8 +288,7 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
           stride_w(),
           1,
           1,
-          CUDNN_CROSS_CORRELATION,
-          compute_type_));
+          CUDNN_CROSS_CORRELATION));
     } else {
       vector<int> ones(dilation_.size(), 1);
       CUDNN_ENFORCE(cudnnSetConvolutionNdDescriptor(
@@ -324,8 +324,11 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
           &stride_width,
           &dilation_height,
           &dilation_width,
-          &mode,
-          &dataType));
+          &mode
+#if CUDNN_VERSION_MIN(6, 0, 0)
+          , &dataType
+#endif
+      ));
 
       CUDNN_ENFORCE(cudnnSetConvolution2dDescriptor(
           conv_desc,
@@ -335,8 +338,11 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
           stride_width,
           dilation_height,
           dilation_width,
-          mode,
-          math));
+          mode
+#if CUDNN_VERSION_MIN(6, 0, 0)
+          , math
+#endif
+      ));
     } else {
       cudnnConvolutionMode_t mode;
       cudnnDataType_t dataType;

--- a/caffe2/operators/conv_pool_op_base.h
+++ b/caffe2/operators/conv_pool_op_base.h
@@ -56,6 +56,8 @@ class ConvPoolOpBase : public Operator<Context> {
         dilation_(OperatorBase::GetRepeatedArgument<int>("dilations")),
         stride_(OperatorBase::GetRepeatedArgument<int>("strides")),
         pads_(OperatorBase::GetRepeatedArgument<int>("pads")),
+        float16_compute_(
+            OperatorBase::GetSingleArgument<bool>("float16_compute", false)),
         group_(OperatorBase::GetSingleArgument<int>("group", 1)),
         order_(StringToStorageOrder(
             OperatorBase::GetSingleArgument<string>("order", "NCHW"))),
@@ -570,6 +572,8 @@ class ConvPoolOpBase : public Operator<Context> {
   vector<int> dilation_;
   vector<int> stride_;
   vector<int> pads_;
+
+  bool float16_compute_;
 
   // We need the above parameters to be available for the devices.
   Tensor<Context> kernel_device_;

--- a/caffe2/operators/op_utils_cudnn.h
+++ b/caffe2/operators/op_utils_cudnn.h
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CAFFE2_OPERATORS_CUDNN_OP_UTILS_H_
+#define CAFFE2_OPERATORS_CUDNN_OP_UTILS_H_
+
+#include "caffe2/core/cudnn_wrappers.h"
+
+namespace caffe2 {
+
+// Earlier in the days Caffe sets the default cudnn workspace to 8MB. We bump
+// it up to 64MB in Caffe2, as this enables the use of Winograd in many cases,
+// something very beneficial to more recent CNN models.
+static constexpr size_t kCONV_CUDNN_WORKSPACE_LIMIT_BYTES = 64 * 1024 * 1024;
+
+// Manually specified number of algorithms implemented in CuDNN.
+// This does not have any performance implications, as we will always find the
+// fastest algorithm; setting them to the right number of algorithms will enable
+// us to best report the statistics when doing an exhaustive search, though.
+#if CUDNN_VERSION_MIN(7, 0, 0)
+// Note: Double each of these due to potential
+// tensorcore + non-tensorcore versions
+// which are treated as separate returned algos
+static constexpr size_t kNUM_CUDNN_FWD_ALGS =
+    2 * CUDNN_CONVOLUTION_FWD_ALGO_COUNT;
+static constexpr size_t kNUM_CUDNN_BWD_FILTER_ALGS =
+    2 * CUDNN_CONVOLUTION_BWD_FILTER_ALGO_COUNT;
+static constexpr size_t kNUM_CUDNN_BWD_DATA_ALGS =
+    2 * CUDNN_CONVOLUTION_BWD_DATA_ALGO_COUNT;
+#else
+static constexpr size_t kNUM_CUDNN_FWD_ALGS = 7;
+static constexpr size_t kNUM_CUDNN_BWD_FILTER_ALGS = 4;
+static constexpr size_t kNUM_CUDNN_BWD_DATA_ALGS = 5;
+#endif
+
+namespace {
+template <typename ArrayOfcudnnConvolutionAlgoPerf_t>
+inline void LogCuDNNPerfStats(
+    const ArrayOfcudnnConvolutionAlgoPerf_t& perf_stat,
+    int returned_algo_count) {
+  VLOG(1) << "Perf result: (algo: stat, time, memory)";
+  for (int i = 0; i < returned_algo_count; ++i) {
+    const auto& stat = perf_stat[i];
+    VLOG(1) << stat.algo << ": " << stat.status << " " << stat.time << " "
+            << stat.memory;
+  }
+}
+} // namespace
+
+// Easier indexing into force_algo_ vector,
+// shared by CudnnConvTransposeOpBase and CudnnConvOpBase to force
+// usage of a particular algortihm instead of searching
+enum { ALGO_FWD = 0, ALGO_WGRAD = 1, ALGO_DGRAD = 2 } algoIndex_t;
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_CUDNN_OP_UTILS_H_

--- a/caffe2/python/helpers/conv.py
+++ b/caffe2/python/helpers/conv.py
@@ -42,6 +42,7 @@ def _ConvBase(
     order="NCHW",
     cudnn_exhaustive_search=False,
     ws_nbytes_limit=None,
+    float16_compute=False,
     **kwargs
 ):
     kernels = []
@@ -116,6 +117,10 @@ def _ConvBase(
 
     if transform_inputs is not None:
         transform_inputs(model, blob_out, inputs)
+
+    # Enable float 16 compute kernel (relevant for CUDA)
+    if float16_compute:
+        kwargs['float16_compute'] = True
 
     # For the operator, we no longer need to provide the no_bias field
     # because it can automatically figure this out from the number of


### PR DESCRIPTION
Conv/ConvGradient now support FP16 native compute with CuDNN engine. Previously FP16 inputs would only work with FP32 math (aka pseudo fp16 compute).

Expanded CuDNN exhaustive search to allow finding optimal algorithms for these new compute modes. Will also compare FP32 algos in case they are faster than FP16 for a given input size.

Allow all parts of the Conv Op (forward and backwards pass) to have their own descriptor, allowing each to choose their own optimal algorithm/compute mode.

Migrate some features of ConvOp to ConvTransposeOp for consistency (force_algo - ability to specify a particular algorithm, and tensor core support).

Refactor some shared code used by ConvOp & ConvTransposeOp to new op_utils_cudnn.h file.
Update algorithm cache class to support differentiating on compute type (required for fp16 vs fp32 algo search).

Reviewed & approved by ataei (D5841338)