### PR TITLE
Use Ninja build system when available

### DIFF
--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -48,6 +48,11 @@ cd $BUILD_ROOT
 
 CMAKE_ARGS=()
 
+# If Ninja is installed, prefer it to Make
+if [ -x "$(command -v ninja)" ]; then
+  CMAKE_ARGS+=("-GNinja")
+fi
+
 # Use locally built protoc because we'll build libprotobuf for the
 # target architecture and need an exact version match.
 CMAKE_ARGS+=("-DCAFFE2_CUSTOM_PROTOC_EXECUTABLE=$CAFFE2_ROOT/build_host_protoc/bin/protoc")

--- a/scripts/build_host_protoc.sh
+++ b/scripts/build_host_protoc.sh
@@ -22,6 +22,11 @@ CMAKE_ARGS=()
 CMAKE_ARGS+=("-DCMAKE_INSTALL_PREFIX=$BUILD_ROOT")
 CMAKE_ARGS+=("-Dprotobuf_BUILD_TESTS=OFF")
 
+# If Ninja is installed, prefer it to Make
+if [ -x "$(command -v ninja)" ]; then
+  CMAKE_ARGS+=("-GNinja")
+fi
+
 while true; do
     case "$1" in
         --other-flags)
@@ -45,7 +50,7 @@ fi
 cmake "$CAFFE2_ROOT/third_party/protobuf/cmake" ${CMAKE_ARGS[@]}
 
 if [ "$(uname)" == 'Darwin' ]; then
-  make "-j$(sysctl -n hw.ncpu)" install
+  cmake --build . -- "-j$(sysctl -n hw.ncpu)" install
 else
-  make "-j$(nproc)" install
+  cmake --build . -- "-j$(nproc)" install
 fi

--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -11,6 +11,11 @@ CAFFE2_ROOT="$( cd "$(dirname "$0")"/.. ; pwd -P)"
 
 CMAKE_ARGS=()
 
+# If Ninja is installed, prefer it to Make
+if [ -x "$(command -v ninja)" ]; then
+  CMAKE_ARGS+=("-GNinja")
+fi
+
 # Use ccache if available (this path is where Homebrew installs ccache symlinks)
 if [ "$(uname)" == 'Darwin' ]; then
   CCACHE_WRAPPER_PATH=/usr/local/opt/ccache/libexec

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ tests_require = []
 ################################################################################
 
 assert find_executable('cmake'), 'Could not find "cmake" executable!'
-assert find_executable('make'), 'Could not find "make" executable!'
+assert find_executable('ninja') or find_executable('make'), \
+    'Could not find neither "ninja" nor "make" executable!'
 
 ################################################################################
 # utils functions
@@ -99,11 +100,12 @@ class cmake_build(Caffe2Command):
     environment variable. E.g. to build without cuda support run:
         `CMAKE_ARGS=-DUSE_CUDA=Off python setup.py build`
 
-    The number of CPUs used by `make` can be specified by passing `-j<ncpus>`
-    to `setup.py build`.  By default all CPUs are used.
+    The number of CPUs used by `make`/`ninja` can be specified by passing
+    `-j<ncpus>` to `setup.py build`.  By default all CPUs are used.
     """
     user_options = [
-        (str('jobs='), str('j'), str('Specifies the number of jobs to use with make'))
+        (str('jobs='), str('j'),
+            str('Specifies the number of jobs to use with make or ninja'))
     ]
 
     built = False
@@ -141,7 +143,7 @@ class cmake_build(Caffe2Command):
             cmake_args.append(TOP_DIR)
             subprocess.check_call(cmake_args)
 
-            build_args = [find_executable('make')]
+            build_args = [find_executable('ninja') or find_executable('make')]
             # control the number of concurrent jobs
             if self.jobs is not None:
                 build_args.extend(['-j', str(self.jobs)])


### PR DESCRIPTION
When Ninja is installed, use it instead of Make for native builds and for Android cross-builds.
Ninja is faster and generates less output in the terminal on successful builds.
