### PR TITLE
Bump minimum CMake version to 3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 #cmake_policy(SET CMP0022 NEW)
 #cmake_policy(SET CMP0023 NEW)
 
@@ -111,9 +111,10 @@ if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.8.0
 endif()
 
 # ---[ Build flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 11)
 if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O2 -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -fPIC")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing")
   # Eigen fails to build with some versions, so convert this to a warning
   # Details at http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1459

--- a/cmake/External/nccl.cmake
+++ b/cmake/External/nccl.cmake
@@ -20,32 +20,18 @@ if (NOT __NCCL_INCLUDED)
     set(NCCL_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${NCCL_EXTRA_COMPILER_FLAGS})
     set(NCCL_C_FLAGS ${CMAKE_C_FLAGS} ${NCCL_EXTRA_COMPILER_FLAGS})
 
-    if(${CMAKE_VERSION} VERSION_LESS "3.2")
-      ExternalProject_Add(nccl_external
-        SOURCE_DIR ${nccl_PREFIX}
-        BUILD_IN_SOURCE 1
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND
-          make
-          "CXX=${CMAKE_CXX_COMPILER}"
-          "CUDA_HOME=${CUDA_TOOLKIT_ROOT_DIR}"
-          "NVCC=${CUDA_NVCC_EXECUTABLE}"
-        INSTALL_COMMAND ""
-        )
-    else()
-      ExternalProject_Add(nccl_external
-        SOURCE_DIR ${nccl_PREFIX}
-        BUILD_IN_SOURCE 1
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND
-          make
-          "CXX=${CMAKE_CXX_COMPILER}"
-          "CUDA_HOME=${CUDA_TOOLKIT_ROOT_DIR}"
-          "NVCC=${CUDA_NVCC_EXECUTABLE}"
-        BUILD_BYPRODUCTS "${nccl_PREFIX}/build/lib/libnccl_static.a"
-        INSTALL_COMMAND ""
-        )
-    endif()
+    ExternalProject_Add(nccl_external
+      SOURCE_DIR ${nccl_PREFIX}
+      BUILD_IN_SOURCE 1
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND
+        make
+        "CXX=${CMAKE_CXX_COMPILER}"
+        "CUDA_HOME=${CUDA_TOOLKIT_ROOT_DIR}"
+        "NVCC=${CUDA_NVCC_EXECUTABLE}"
+      BUILD_BYPRODUCTS "${nccl_PREFIX}/build/lib/libnccl_static.a"
+      INSTALL_COMMAND ""
+      )
 
     set(NCCL_FOUND TRUE)
     add_library(__caffe2_nccl INTERFACE)

--- a/cmake/Modules_CUDA_fix/FindCUDA.cmake
+++ b/cmake/Modules_CUDA_fix/FindCUDA.cmake
@@ -1284,11 +1284,6 @@ macro(CUDA_WRAP_SRCS cuda_target format generated_files)
     set(_target_is_phony false)
   endif()
 
-  # If CMake doesn't support separable compilation, complain
-  if(CUDA_SEPARABLE_COMPILATION AND CMAKE_VERSION VERSION_LESS "2.8.10.1")
-    message(SEND_ERROR "CUDA_SEPARABLE_COMPILATION isn't supported for CMake versions less than 2.8.10.1")
-  endif()
-
   # Set up all the command line flags here, so that they can be overridden on a per target basis.
 
   set(nvcc_flags "")


### PR DESCRIPTION
CMake 3.2 is required to properly track dependencies in projects imported as `ExternalProject_Add` (`BUILD_BYPRODUCTS` parameter).
Users on Ubuntu 14.04 LTS would need to install and use `cmake3` package for configurations. Users of other popular distributions generally have a recent enough CMake package.

