### PR TITLE
Async exception propagation in DAGNetBase, improved python operator backtrace

### DIFF
--- a/caffe2/core/net_dag.h
+++ b/caffe2/core/net_dag.h
@@ -68,6 +68,7 @@ class DAGNetBase : public NetBase {
   bool DoRunAsync() override;
 
   virtual bool RunAt(int chain_id, const std::vector<int>& chain) = 0;
+  void HandleException(int operator_idx, const std::string& exception_str);
 
   vector<dag_utils::OperatorNode> operator_nodes_;
   vector<OperatorBase*> operators_;
@@ -79,6 +80,11 @@ class DAGNetBase : public NetBase {
   int remaining_ops_;
 
   bool success_;
+  // Use an atomic to guard caught_exception_ so it is written to only once
+  std::atomic<bool> caught_exception_yet_;
+#ifdef CAFFE2_USE_EXCEPTION_PTR
+  std::exception_ptr caught_exception_;
+#endif // CAFFE2_USE_EXCEPTION_PTR
   int iter_;
   std::mutex remaining_ops_mutex_;
   std::condition_variable cv_;

--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -2781,18 +2781,18 @@ def _extract_stacktrace():
     The reason for file system access avoidance is that
     if code is located on an NFS, file access might be slow
 
-    Function returns a list of tuples (file_name, line_number)
+    Function returns a list of tuples (file_name, line_number, function)
     '''
 
-    current_file_name = __name__.replace('.', '/') + ".py"
     result = []
-    frame = sys._getframe(1)
+    # Ignore top 3 layers of stack: this function, _CreateAndAddToSelf, and
+    # whatever calls _CreateAndAddToSelf (either __getattr__ or Python)
+    frame = sys._getframe(3)
     # We just go down the frame stack in a loop
     while frame:
-        if current_file_name not in frame.f_code.co_filename:
-            # Its important to extract information from the frame here
-            # as frame's current line most probably will change later.
-            result.append((frame.f_code.co_filename, frame.f_lineno))
+        # Its important to extract information from the frame here
+        # as frame's current line most probably will change later.
+        result.append((frame.f_code.co_filename, frame.f_lineno, frame.f_code.co_name))
         frame = frame.f_back
     return result
 

--- a/caffe2/python/core_test.py
+++ b/caffe2/python/core_test.py
@@ -412,54 +412,71 @@ class TestExtractPredictorNet(test_util.TestCase):
 
 
 class TestOperatorTraceback(test_util.TestCase):
+    def op_name_check(self, net, cf, line, func):
+        net.PopulateProtoWithFileName()
+        filename = getframeinfo(cf).filename
+        self.assertEqual(net.Proto().op[0].name, '{}:{}:{}'.format(
+            filename, line, func))
+
     def test_operator_constructor_traceback(self):
         net = core.Net("test")
         a, b = net.AddExternalInput("a", "b")
         net.Mul([a, b], "c"); cf = currentframe(); line = cf.f_lineno
+        func = cf.f_code.co_name
         with self.assertRaises(Exception):
             workspace.RunNetOnce(net)
         with self.assertRaises(Exception):
             workspace.CreateNet(net)
-        self.op_name_check(net, cf, line)
-
-    def op_name_check(self, net, cf, line):
-        net.PopulateProtoWithFileName()
-        filename = getframeinfo(cf).filename
-        self.assertEqual(net.Proto().op[0].name, '{}:{}'.format(filename, line))
+        self.op_name_check(net, cf, line, func)
 
     def test_operator_runtime_traceback(self):
         net = core.Net("test")
         a = net.AddExternalInput("a")
         workspace.blobs[a] = np.array([1, 2, 3], dtype=np.float32)
         net.Split(a, ["b", "c"], axis=0); cf = currentframe(); line = cf.f_lineno
+        func = cf.f_code.co_name
         with self.assertRaises(Exception):
             workspace.RunNetOnce(net)
         workspace.CreateNet(net)
         with self.assertRaises(Exception):
             workspace.RunNet(net)
-        self.op_name_check(net, cf, line)
+        self.op_name_check(net, cf, line, func)
 
     def test_c_workspace_constructor(self):
         net = core.Net("test")
         a, b = net.AddExternalInput("a", "b")
         net.Mul([a, b], "c"); cf = currentframe(); line = cf.f_lineno
+        func = cf.f_code.co_name
         ws = workspace.C.Workspace()
         with self.assertRaises(Exception):
             ws.run(net)
         with self.assertRaises(Exception):
             ws.create_net(net)
-        self.op_name_check(net, cf, line)
+        self.op_name_check(net, cf, line, func)
 
     def test_c_workspace_runtime(self):
         net = core.Net("test")
         a = net.AddExternalInput("a")
         net.Split(a, ["b", "c"], axis=0); cf = currentframe(); line = cf.f_lineno
+        func = cf.f_code.co_name
         ws = workspace.C.Workspace()
         ws.create_blob(str(a)).feed(np.array([1, 2, 3], dtype=np.float32))
         ws.create_net(net)
         with self.assertRaises(Exception):
             ws.run(net)
-        self.op_name_check(net, cf, line)
+        self.op_name_check(net, cf, line, func)
+
+    def test_async_exception_handling(self):
+        net = core.Net("test")
+        net.Proto().type = 'dag'  # this runs operators on background threads
+        a = net.AddExternalInput("a")
+        net.Split(a, ["b", "c"], axis=0); cf = currentframe(); line = cf.f_lineno
+        func = cf.f_code.co_name
+        workspace.FeedBlob(a, np.array([1, 2, 3], dtype=np.float32))
+        with self.assertRaises(Exception) as enforceNotMet:
+            workspace.RunNetOnce(net)
+        self.assertIn('enforce fail', str(enforceNotMet.exception))
+        self.op_name_check(net, cf, line, func)
 
 
 class TestCreatePlan(test_util.TestCase):

--- a/caffe2/python/workspace.py
+++ b/caffe2/python/workspace.py
@@ -193,11 +193,14 @@ def CallWithExceptionIntercept(func, op_id_fetcher, net_name, *args, **kwargs):
     except Exception:
         op_id = op_id_fetcher()
         net_tracebacks = operator_tracebacks.get(net_name, None)
-        print("Traceback for operator {} in network {}".format(op_id, net_name))
+        print('Original python traceback for operator {} in network `{}` in '
+              'exception above (most recent call last):'.format(
+                  op_id, net_name))
         if net_tracebacks and op_id in net_tracebacks:
             tb = net_tracebacks[op_id]
-            for line in tb:
-                print(':'.join(map(str, line)))
+            for line in reversed(tb):
+                print('  File "{}", line {}, in {}'.format(
+                    line[0], line[1], line[2]))
         raise
 
 


### PR DESCRIPTION
Add exception handling & re-throwing to worker threads of DAGNetBase. 
Improve backtrace printing in python workspace code to be more consistent with python stack traces.
Add unit test for async net executor throwing exceptions.

Approved by iliacher and andrewdye in D7093208.