### PR TITLE
Fixes for build errors on Windows with GPU

### DIFF
--- a/caffe2/operators/conv_op_cudnn.cc
+++ b/caffe2/operators/conv_op_cudnn.cc
@@ -183,15 +183,6 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
       int dilation_height = 0;
       int dilation_width = 0;
 
-      CUDNN_ENFORCE(cudnnGetConvolution2dDescriptor(
-          input,
-          &pad_height,
-          &pad_width,
-          &stride_height,
-          &stride_width,
-          &dilation_height,
-          &dilation_width,
-          &mode
 #if CUDNN_VERSION_MIN(6, 0, 0)
       CUDNN_ENFORCE(cudnnGetConvolution2dDescriptor(
           input,

--- a/caffe2/operators/conv_op_cudnn.cc
+++ b/caffe2/operators/conv_op_cudnn.cc
@@ -193,11 +193,43 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
           &dilation_width,
           &mode
 #if CUDNN_VERSION_MIN(6, 0, 0)
-          ,
+      CUDNN_ENFORCE(cudnnGetConvolution2dDescriptor(
+          input,
+          &pad_height,
+          &pad_width,
+          &stride_height,
+          &stride_width,
+          &dilation_height,
+          &dilation_width,
+          &mode,
           &dataType
-#endif
           ));
+#else
+      CUDNN_ENFORCE(cudnnGetConvolution2dDescriptor(
+          input,
+          &pad_height,
+          &pad_width,
+          &stride_height,
+          &stride_width,
+          &dilation_height,
+          &dilation_width,
+          &mode
+          ));
+#endif
 
+#if CUDNN_VERSION_MIN(6, 0, 0)
+      CUDNN_ENFORCE(cudnnSetConvolution2dDescriptor(
+          copy,
+          pad_height,
+          pad_width,
+          stride_height,
+          stride_width,
+          dilation_height,
+          dilation_width,
+          mode,
+          dataType
+          ));
+#else
       CUDNN_ENFORCE(cudnnSetConvolution2dDescriptor(
           copy,
           pad_height,
@@ -207,11 +239,8 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
           dilation_height,
           dilation_width,
           mode
-#if CUDNN_VERSION_MIN(6, 0, 0)
-          ,
-          dataType
-#endif
           ));
+#endif
     } else {
       cudnnConvolutionMode_t mode;
       cudnnDataType_t dataType;
@@ -323,6 +352,19 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
       int dilation_height = 0;
       int dilation_width = 0;
 
+#if CUDNN_VERSION_MIN(6, 0, 0)
+      CUDNN_ENFORCE(cudnnGetConvolution2dDescriptor(
+          conv_desc,
+          &pad_height,
+          &pad_width,
+          &stride_height,
+          &stride_width,
+          &dilation_height,
+          &dilation_width,
+          &mode,
+          &dataType
+          ));
+#else
       CUDNN_ENFORCE(cudnnGetConvolution2dDescriptor(
           conv_desc,
           &pad_height,
@@ -332,12 +374,22 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
           &dilation_height,
           &dilation_width,
           &mode
-#if CUDNN_VERSION_MIN(6, 0, 0)
-          ,
-          &dataType
-#endif
           ));
+#endif
 
+#if CUDNN_VERSION_MIN(6, 0, 0)
+      CUDNN_ENFORCE(cudnnSetConvolution2dDescriptor(
+          conv_desc,
+          pad_height,
+          pad_width,
+          stride_height,
+          stride_width,
+          dilation_height,
+          dilation_width,
+          mode,
+          math
+          ));
+#else
       CUDNN_ENFORCE(cudnnSetConvolution2dDescriptor(
           conv_desc,
           pad_height,
@@ -347,11 +399,8 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
           dilation_height,
           dilation_width,
           mode
-#if CUDNN_VERSION_MIN(6, 0, 0)
-          ,
-          math
-#endif
           ));
+#endif
     } else {
       cudnnConvolutionMode_t mode;
       cudnnDataType_t dataType;

--- a/caffe2/operators/op_utils_cudnn.h
+++ b/caffe2/operators/op_utils_cudnn.h
@@ -63,7 +63,7 @@ inline void LogCuDNNPerfStats(
 // Easier indexing into force_algo_ vector,
 // shared by CudnnConvTransposeOpBase and CudnnConvOpBase to force
 // usage of a particular algortihm instead of searching
-enum { ALGO_FWD = 0, ALGO_WGRAD = 1, ALGO_DGRAD = 2 } algoIndex_t;
+enum { ALGO_FWD = 0, ALGO_WGRAD = 1, ALGO_DGRAD = 2 };
 
 } // namespace caffe2
 

--- a/modules/detectron/softmax_focal_loss_op.cu
+++ b/modules/detectron/softmax_focal_loss_op.cu
@@ -78,7 +78,7 @@ __global__ void SoftmaxFocalLossKernel(
       int offset = a * num_classes;
       int idx = n * (H * W * D) + (offset + label) * (H * W) + y * W + x;
       losses[i] =
-          -(pow(1.0 - Pdata[idx], gamma) *
+          -(pow(1.0f - Pdata[idx], gamma) *
           log(max(Pdata[idx], FLT_MIN))) * z;
     }
   }


### PR DESCRIPTION
- Macros and #ifs don't play well with Visual Studio 2015.
- That algoIndex_t isn't actually used anywhere and causes a "defined twice" error on Windows
- Windows complains about the automatic cast without the 'f'