### PR TITLE
Fixed issue with dedent utility function when building with python win10

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -163,12 +163,10 @@ function(dedent outvar text)
   else()
     set(_python_exe "${PYTHON_EXECUTABLE}")
   endif()
-  set(_fixup_cmd "import sys; from textwrap import dedent; print(dedent(sys.stdin.read()))")
-  # Use echo to pipe the text to python's stdinput. This prevents us from
-  # needing to worry about any sort of special escaping.
+  set(_fixup_cmd "import sys; from textwrap import dedent; print(dedent(sys.argv[1]));")
+  # Send script through command line arg
   execute_process(
-    COMMAND echo "${text}"
-    COMMAND "${_python_exe}" -c "${_fixup_cmd}"
+	COMMAND "${_python_exe}" -c "${_fixup_cmd} " "${text}"
     RESULT_VARIABLE _dedent_exitcode
     OUTPUT_VARIABLE _dedent_text)
   if(NOT ${_dedent_exitcode} EQUAL 0)


### PR DESCRIPTION
Fix for build issue in dedent utility function when building with python
https://github.com/caffe2/caffe2/issues/2151
It isn't entirely clear to me why we would need to pipe that through std in via the command line vs using the first arg.  Please review and let me know if this can cause any side effects.  Thank you for the review.