### PR TITLE
Fix useless opset_import in onnx

### DIFF
--- a/caffe2/python/onnx/frontend.py
+++ b/caffe2/python/onnx/frontend.py
@@ -51,7 +51,7 @@ class Caffe2Frontend(object):
     # ONNX makes a BC breaking change to semantics of operators, having this set
     # to an accurate number will prevent our models form exporting.  However,
     # we should strive to keep this up-to-date as much as possible.
-    _target_opset_version = 3
+    target_opset_version = 3
 
     _renamed_operators = {
         'SpatialBN': 'BatchNormalization',
@@ -585,7 +585,7 @@ class Caffe2Frontend(object):
     def caffe2_net_to_onnx_model(cls, *args, **kwargs):
         opset_id = OperatorSetIdProto()
         opset_id.domain = ''  # ONNX default domain
-        opset_id.version = cls._target_opset_version
+        opset_id.version = cls.target_opset_version
         model = make_model(cls.caffe2_net_to_onnx_graph(*args, **kwargs), opset_imports=[opset_id])
         checker.check_model(model)
         return model

--- a/caffe2/python/onnx/frontend.py
+++ b/caffe2/python/onnx/frontend.py
@@ -584,7 +584,7 @@ class Caffe2Frontend(object):
     @classmethod
     def caffe2_net_to_onnx_model(cls, *args, **kwargs):
         opset_id = OperatorSetIdProto()
-        opset_id.domain = ''  # ONNX
+        opset_id.domain = ''  # ONNX default domain
         opset_id.version = cls._target_opset_version
         model = make_model(cls.caffe2_net_to_onnx_graph(*args, **kwargs), opset_imports=[opset_id])
         checker.check_model(model)

--- a/caffe2/python/onnx/frontend.py
+++ b/caffe2/python/onnx/frontend.py
@@ -583,11 +583,10 @@ class Caffe2Frontend(object):
 
     @classmethod
     def caffe2_net_to_onnx_model(cls, *args, **kwargs):
-        model = make_model(cls.caffe2_net_to_onnx_graph(*args, **kwargs))
         opset_id = OperatorSetIdProto()
         opset_id.domain = ''  # ONNX
         opset_id.version = cls._target_opset_version
-        model.opset_import.extend([opset_id])
+        model = make_model(cls.caffe2_net_to_onnx_graph(*args, **kwargs), opset_imports=[opset_id])
         checker.check_model(model)
         return model
 

--- a/caffe2/python/onnx/frontend.py
+++ b/caffe2/python/onnx/frontend.py
@@ -36,10 +36,10 @@ from caffe2.proto import caffe2_legacy_pb2
 from enum import Enum
 from onnx import (defs, checker, helper, numpy_helper, mapping,
                   ModelProto, GraphProto, NodeProto, AttributeProto, TensorProto, OperatorSetIdProto)
-from onnx.helper import make_tensor, make_tensor_value_info, make_attribute
+from onnx.helper import make_tensor, make_tensor_value_info, make_attribute, make_model
 import numpy as np
 
-from caffe2.python.onnx.helper import make_model, c2_native_run_net, dummy_name
+from caffe2.python.onnx.helper import c2_native_run_net, dummy_name
 from caffe2.python.onnx.error import Unsupported
 
 logging.basicConfig(level=logging.INFO)
@@ -586,7 +586,10 @@ class Caffe2Frontend(object):
         opset_id = OperatorSetIdProto()
         opset_id.domain = ''  # ONNX default domain
         opset_id.version = cls.target_opset_version
-        model = make_model(cls.caffe2_net_to_onnx_graph(*args, **kwargs), opset_imports=[opset_id])
+        model = make_model(cls.caffe2_net_to_onnx_graph(*args, **kwargs),
+                           opset_imports=[opset_id],  # current supported opset version
+                           producer_name='onnx-caffe2',  # producer name
+                           )
         checker.check_model(model)
         return model
 

--- a/caffe2/python/onnx/helper.py
+++ b/caffe2/python/onnx/helper.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from caffe2.proto import caffe2_pb2
-from onnx import helper, OperatorSetIdProto
 from onnx.backend.base import namedtupledict
 
 from caffe2.python.onnx.workspace import Workspace
@@ -54,17 +53,6 @@ class _DummyNameFactory(object):
                     return name
 
 dummy_name = _DummyNameFactory.dummy_name
-
-
-def make_model(graph, **kwargs):
-    kwargs.setdefault('producer_name', 'onnx-caffe2')
-    if 'opset_imports' not in kwargs:
-        from caffe2.python.onnx.frontend import Caffe2Frontend
-        opset_id = OperatorSetIdProto()
-        opset_id.domain = ''  # ONNX default domain
-        opset_id.version = Caffe2Frontend.target_opset_version
-        kwargs['opset_imports'] = [opset_id]
-    return helper.make_model(graph=graph, **kwargs)
 
 
 def c2_native_run_op(op_def, inputs):

--- a/caffe2/python/onnx/helper.py
+++ b/caffe2/python/onnx/helper.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from caffe2.proto import caffe2_pb2
-from onnx import helper
+from onnx import helper, OperatorSetIdProto
 from onnx.backend.base import namedtupledict
 
 from caffe2.python.onnx.workspace import Workspace
@@ -58,6 +58,10 @@ dummy_name = _DummyNameFactory.dummy_name
 
 def make_model(graph, **kwargs):
     kwargs.setdefault('producer_name', 'onnx-caffe2')
+    opset_id = OperatorSetIdProto()
+    opset_id.domain = ''  # ONNX default domain
+    opset_id.version = 1
+    kwargs.setdefault('opset_imports', [opset_id])
     return helper.make_model(graph=graph, **kwargs)
 
 

--- a/caffe2/python/onnx/helper.py
+++ b/caffe2/python/onnx/helper.py
@@ -58,10 +58,12 @@ dummy_name = _DummyNameFactory.dummy_name
 
 def make_model(graph, **kwargs):
     kwargs.setdefault('producer_name', 'onnx-caffe2')
-    opset_id = OperatorSetIdProto()
-    opset_id.domain = ''  # ONNX default domain
-    opset_id.version = 1
-    kwargs.setdefault('opset_imports', [opset_id])
+    if 'opset_imports' not in kwargs:
+        from caffe2.python.onnx.frontend import Caffe2Frontend
+        opset_id = OperatorSetIdProto()
+        opset_id.domain = ''  # ONNX default domain
+        opset_id.version = Caffe2Frontend.target_opset_version
+        kwargs['opset_imports'] = [opset_id]
     return helper.make_model(graph=graph, **kwargs)
 
 

--- a/caffe2/python/onnx/tests/c2_ref_test.py
+++ b/caffe2/python/onnx/tests/c2_ref_test.py
@@ -29,8 +29,8 @@ from caffe2.python import core
 from caffe2.proto import caffe2_pb2
 
 import onnx
-from onnx.helper import make_node, make_graph, make_tensor, make_tensor_value_info
-from caffe2.python.onnx.helper import make_model, c2_native_run_net, c2_native_run_op
+from onnx.helper import make_node, make_graph, make_tensor, make_tensor_value_info, make_model
+from caffe2.python.onnx.helper import c2_native_run_net, c2_native_run_op
 
 from onnx import defs, mapping
 import caffe2.python.onnx.frontend as c2_onnx
@@ -66,7 +66,7 @@ class TestCaffe2Basic(TestCase):
             name="test",
             inputs=[make_tensor_value_info("X", onnx.TensorProto.FLOAT, [3, 2])],
             outputs=[make_tensor_value_info("X", onnx.TensorProto.FLOAT, [3, 2])])
-        c2_rep = c2.prepare(make_model(graph_def))
+        c2_rep = c2.prepare(make_model(graph_def, producer_name='caffe2-ref-test'))
         output = c2_rep.run({"X": X})
         np.testing.assert_almost_equal(output.X, Y_ref)
 
@@ -85,7 +85,7 @@ class TestCaffe2Basic(TestCase):
             name="test",
             inputs=[make_tensor_value_info("X", onnx.TensorProto.FLOAT, [3, 2])],
             outputs=[make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [3, 2])])
-        c2_rep = c2.prepare(make_model(graph_def))
+        c2_rep = c2.prepare(make_model(graph_def, producer_name='caffe2-ref-test'))
         output = c2_rep.run(X)
         np.testing.assert_almost_equal(output.Y, Y_ref)
 
@@ -119,7 +119,7 @@ class TestCaffe2Basic(TestCase):
             return 1 / (1 + np.exp(-x))
 
         W_ref = -sigmoid(np.tanh((X + Y) * weight))
-        c2_rep = c2.prepare(make_model(graph_def))
+        c2_rep = c2.prepare(make_model(graph_def, producer_name='caffe2-ref-test'))
         output = c2_rep.run({"X": X, "Y": Y})
         np.testing.assert_almost_equal(output["W3"], W_ref)
 

--- a/caffe2/python/onnx/tests/conversion_test.py
+++ b/caffe2/python/onnx/tests/conversion_test.py
@@ -31,10 +31,9 @@ from caffe2.python.model_helper import ModelHelper
 from click.testing import CliRunner
 import numpy as np
 from onnx import helper, ModelProto, TensorProto
-from caffe2.python.onnx.helper import make_model, c2_native_run_net
+from caffe2.python.onnx.helper import dummy_name, c2_native_run_net
 
 from caffe2.python.onnx.bin.conversion import caffe2_to_onnx, onnx_to_caffe2
-from caffe2.python.onnx.helper import dummy_name
 import caffe2.python.onnx.backend as c2
 from caffe2.python.onnx.tests.test_utils import TestCase
 
@@ -129,7 +128,7 @@ class TestConversion(TestCase):
                                             TensorProto.FLOAT,
                                             [3, 2],
                                             np.zeros((3, 2)).flatten().astype(float))])
-        model_def = make_model(graph_def, producer_name='onnx-to-caffe2-test')
+        model_def = helper.make_model(graph_def, producer_name='onnx-to-caffe2-test')
         onnx_model.write(model_def.SerializeToString())
         onnx_model.flush()
 


### PR DESCRIPTION
Fix the multiple opset_import introduced by the Caffe2==>ONNX converter.