### PR TITLE
[C2] Support optional lengths input to ReduceFront/Back operators

### DIFF
--- a/caffe2/operators/reduction_front_back_ops.cc
+++ b/caffe2/operators/reduction_front_back_ops.cc
@@ -30,10 +30,12 @@ void SumReduceDimsOp<CPUContext, true, false>::Compute(
     int rows,
     int cols,
     const T* in_data,
+    const int32_t* lengths_data,
     T* out_data) {
   for (int j = 0; j < cols; j++) {
     T sum = in_data[j];
-    for (int i = 1; i < rows; i++) {
+    int length = lengths_data == nullptr ? rows : lengths_data[j];
+    for (int i = 1; i < length; i++) {
       sum += in_data[i * cols + j];
     }
     out_data[j] = sum;
@@ -47,11 +49,13 @@ void SumReduceDimsOp<CPUContext, false, false>::Compute(
     int rows,
     int cols,
     const T* in_data,
+    const int32_t* lengths_data,
     T* out_data) {
   for (int i = 0; i < rows; i++) {
     int offset = i * cols;
     T sum = in_data[offset];
-    for (int j = 1; j < cols; j++) {
+    int length = lengths_data == nullptr ? cols : lengths_data[i];
+    for (int j = 1; j < length; j++) {
       sum += in_data[offset + j];
     }
     out_data[i] = sum;
@@ -65,9 +69,16 @@ void SumReduceDimsGradientOp<CPUContext, true, false>::Compute(
     int rows,
     int cols,
     const T* dYdata,
+    const int* lengths_data,
     T* dXdata) {
   for (int i = 0; i < rows * cols; i++) {
-    dXdata[i] = dYdata[i % cols];
+    int row = i / cols;
+    int col = i % cols;
+    if (lengths_data == nullptr or row < lengths_data[col]) {
+      dXdata[i] = dYdata[col];
+    } else {
+      dXdata[i] = 0;
+    }
   }
 }
 
@@ -78,9 +89,16 @@ void SumReduceDimsGradientOp<CPUContext, false, false>::Compute(
     int rows,
     int cols,
     const T* dYdata,
+    const int* lengths_data,
     T* dXdata) {
   for (int i = 0; i < rows * cols; i++) {
-    dXdata[i] = dYdata[i / cols];
+    int row = i / cols;
+    int col = i % cols;
+    if (lengths_data == nullptr or col < lengths_data[row]) {
+      dXdata[i] = dYdata[row];
+    } else {
+      dXdata[i] = 0;
+    }
   }
 }
 
@@ -92,11 +110,12 @@ REGISTER_CPU_OPERATOR(
 class GetReduceFrontSumGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;
   vector<OperatorDef> GetGradientDefs() override {
+    vector<string> grad_in = {GO(0), I(0)};
+    if (def_.input_size() == 2) {
+      grad_in.push_back(I(1));
+    }
     return SingleGradientDef(
-        "ReduceFrontSumGradient",
-        "",
-        vector<string>{GO(0), I(0)},
-        vector<string>{GI(0)});
+        "ReduceFrontSumGradient", "", grad_in, vector<string>{GI(0)});
   }
 };
 
@@ -110,18 +129,20 @@ REGISTER_CPU_OPERATOR(
 class GetReduceBackSumGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;
   vector<OperatorDef> GetGradientDefs() override {
+    vector<string> grad_in = {GO(0), I(0)};
+    if (def_.input_size() == 2) {
+      grad_in.push_back(I(1));
+    }
     return SingleGradientDef(
-        "ReduceBackSumGradient",
-        "",
-        vector<string>{GO(0), I(0)},
-        vector<string>{GI(0)});
+        "ReduceBackSumGradient", "", grad_in, vector<string>{GI(0)});
   }
 };
 
 REGISTER_GRADIENT(ReduceBackSum, GetReduceBackSumGradient);
 
 #define REDUCTION_OP_SHAPE_INFERENCE(is_front_reducer)                      \
-  CAFFE_ENFORCE_EQ(1, in.size());                                           \
+  CAFFE_ENFORCE_LE(1, in.size());                                           \
+  CAFFE_ENFORCE_GE(2, in.size());                                           \
   ArgumentHelper helper(def);                                               \
   int num_reduce_dims = helper.GetSingleArgument<int>("num_reduce_dim", 1); \
   int start_index = is_front_reducer ? num_reduce_dims : 0;                 \
@@ -135,32 +156,40 @@ REGISTER_GRADIENT(ReduceBackSum, GetReduceBackSumGradient);
       CreateTensorShape(output_shape, in[0].data_type())};
 
 OPERATOR_SCHEMA(ReduceFrontSum)
-    .NumInputs(1)
+    .NumInputs(1, 2)
     .NumOutputs(1)
-    .Arg("num_reduce_dims", "Number of dimensions to reduce")
+    .Arg("num_reduce_dims", "Number of dimensions to reduce.")
     .SetDoc(R"DOC(
 Reduces the input tensor along the first dimension of the input
-tensor by applying 'Sum'
+tensor by applying 'Sum'.  When lengths is given, sum is only computed
+with subsets of elements correspondingly.
 )DOC")
+    .Input(0, "data_in", "(T<D1..., Dn>) Input data.")
+    .Input(1, "lengths", "Num of elements in each sample, should have size
+        D2 x D3 x ... x Dn.")
     .TensorInferenceFunction([](const OperatorDef& def,
                                 const vector<TensorShape>& in) {
       REDUCTION_OP_SHAPE_INFERENCE(true)
     });
-OPERATOR_SCHEMA(ReduceFrontSumGradient).NumInputs(2).NumOutputs(1);
+OPERATOR_SCHEMA(ReduceFrontSumGradient).NumInputs(2, 3).NumOutputs(1);
 
 OPERATOR_SCHEMA(ReduceBackSum)
-    .NumInputs(1)
+    .NumInputs(1, 2)
     .NumOutputs(1)
-    .Arg("num_reduce_dims", "Number of dimensions to reduce")
+    .Arg("num_reduce_dims", "Number of dimensions to reduce.")
     .SetDoc(R"DOC(
 Reduces the input tensor along the last dimension of the
-input tensor by applying 'Sum'
+input tensor by applying 'Sum'.  When lengths is given, sum is only computed
+with subsets of elements correspondingly.
 )DOC")
+    .Input(0, "data_in", "(T<D1..., Dn>) Input data.")
+    .Input(1, "lengths", "Num of elements in each sample, should have size
+        D1 x D2 x ... x D(n-1).")
     .TensorInferenceFunction([](const OperatorDef& def,
                                 const vector<TensorShape>& in) {
       REDUCTION_OP_SHAPE_INFERENCE(false)
     });
-OPERATOR_SCHEMA(ReduceBackSumGradient).NumInputs(2).NumOutputs(1);
+OPERATOR_SCHEMA(ReduceBackSumGradient).NumInputs(2, 3).NumOutputs(1);
 
 /***
   Mean Ops
@@ -173,13 +202,15 @@ void SumReduceDimsOp<CPUContext, true, true>::Compute(
     int rows,
     int cols,
     const T* in_data,
+    const int32_t* lengths_data,
     T* out_data) {
   for (int j = 0; j < cols; j++) {
     T sum = in_data[j];
-    for (int i = 1; i < rows; i++) {
+    int length = lengths_data == nullptr ? rows : lengths_data[j];
+    for (int i = 1; i < length; i++) {
       sum += in_data[i * cols + j];
     }
-    out_data[j] = sum / rows;
+    out_data[j] = sum / length;
   }
 }
 
@@ -190,14 +221,16 @@ void SumReduceDimsOp<CPUContext, false, true>::Compute(
     int rows,
     int cols,
     const T* in_data,
+    const int32_t* lengths_data,
     T* out_data) {
   for (int i = 0; i < rows; i++) {
     int offset = i * cols;
     T sum = in_data[offset];
-    for (int j = 1; j < cols; j++) {
+    int length = lengths_data == nullptr ? cols : lengths_data[i];
+    for (int j = 1; j < length; j++) {
       sum += in_data[offset + j];
     }
-    out_data[i] = sum / cols;
+    out_data[i] = sum / length;
   }
 }
 
@@ -208,9 +241,18 @@ void SumReduceDimsGradientOp<CPUContext, true, true>::Compute(
     int rows,
     int cols,
     const T* dYdata,
+    const int* lengths_data,
     T* dXdata) {
   for (int i = 0; i < rows * cols; i++) {
-    dXdata[i] = dYdata[i % cols] / rows;
+    int row = i / cols;
+    int col = i % cols;
+    if (lengths_data == nullptr) {
+      dXdata[i] = dYdata[col] / rows;
+    } else if (row < lengths_data[col]) {
+      dXdata[i] = dYdata[col] / lengths_data[col];
+    } else {
+      dXdata[i] = 0;
+    }
   }
 }
 
@@ -221,9 +263,18 @@ void SumReduceDimsGradientOp<CPUContext, false, true>::Compute(
     int rows,
     int cols,
     const T* dYdata,
+    const int* lengths_data,
     T* dXdata) {
   for (int i = 0; i < rows * cols; i++) {
-    dXdata[i] = dYdata[i / cols] / cols;
+    int row = i / cols;
+    int col = i % cols;
+    if (lengths_data == nullptr) {
+      dXdata[i] = dYdata[row] / cols;
+    } else if (col < lengths_data[row]) {
+      dXdata[i] = dYdata[row] / lengths_data[row];
+    } else {
+      dXdata[i] = 0;
+    }
   }
 }
 
@@ -235,29 +286,34 @@ REGISTER_CPU_OPERATOR(
 class GetReduceFrontMeanGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;
   vector<OperatorDef> GetGradientDefs() override {
+    vector<string> grad_in = {GO(0), I(0)};
+    if (def_.input_size() == 2) {
+      grad_in.push_back(I(1));
+    }
     return SingleGradientDef(
-        "ReduceFrontMeanGradient",
-        "",
-        vector<string>{GO(0), I(0)},
-        vector<string>{GI(0)});
+        "ReduceFrontMeanGradient", "", grad_in, vector<string>{GI(0)});
   }
 };
 
 REGISTER_GRADIENT(ReduceFrontMean, GetReduceFrontMeanGradient);
 
 OPERATOR_SCHEMA(ReduceFrontMean)
-    .NumInputs(1)
+    .NumInputs(1, 2)
     .NumOutputs(1)
-    .Arg("num_reduce_dims", "Number of dimensions to reduce")
+    .Arg("num_reduce_dims", "Number of dimensions to reduce.")
     .SetDoc(R"DOC(
 Reduces the input tensor along the first dimension of the input
-tensor by applying 'Mean'
+tensor by applying 'Mean'. When lengths is given, mean is only computed
+with subsets of elements correspondingly.
 )DOC")
+    .Input(0, "data_in", "(T<D1..., Dn>) Input data.")
+    .Input(1, "lengths", "Num of elements in each sample, should have size
+        D2 x D3 x ... x Dn.")
     .TensorInferenceFunction([](const OperatorDef& def,
                                 const vector<TensorShape>& in) {
       REDUCTION_OP_SHAPE_INFERENCE(true)
     });
-OPERATOR_SCHEMA(ReduceFrontMeanGradient).NumInputs(2).NumOutputs(1);
+OPERATOR_SCHEMA(ReduceFrontMeanGradient).NumInputs(2, 3).NumOutputs(1);
 
 REGISTER_CPU_OPERATOR(ReduceBackMean, SumReduceDimsOp<CPUContext, false, true>);
 REGISTER_CPU_OPERATOR(
@@ -267,29 +323,34 @@ REGISTER_CPU_OPERATOR(
 class GetReduceBackMeanGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;
   vector<OperatorDef> GetGradientDefs() override {
+    vector<string> grad_in = {GO(0), I(0)};
+    if (def_.input_size() == 2) {
+      grad_in.push_back(I(1));
+    }
     return SingleGradientDef(
-        "ReduceBackMeanGradient",
-        "",
-        vector<string>{GO(0), I(0)},
-        vector<string>{GI(0)});
+        "ReduceBackMeanGradient", "", grad_in, vector<string>{GI(0)});
   }
 };
 
 REGISTER_GRADIENT(ReduceBackMean, GetReduceBackMeanGradient);
 
 OPERATOR_SCHEMA(ReduceBackMean)
-    .NumInputs(1)
+    .NumInputs(1, 2)
     .NumOutputs(1)
-    .Arg("num_reduce_dims", "Number of dimensions to reduce")
+    .Arg("num_reduce_dims", "Number of dimensions to reduce.")
     .SetDoc(R"DOC(
-Reduces the input tensor along the last dimension of the
-input tensor by applying 'Mean'
+Reduces the input tensor along the last dimension of the input
+tensor by applying 'Mean'. When lengths is given, mean is only computed
+with subsets of elements correspondingly.
 )DOC")
+    .Input(0, "data_in", "(T<D1..., Dn>) Input data.")
+    .Input(1, "lengths", "Num of elements in each sample, should have size
+        D1 x D2 x ... x D(n-1).")
     .TensorInferenceFunction([](const OperatorDef& def,
                                 const vector<TensorShape>& in) {
       REDUCTION_OP_SHAPE_INFERENCE(false)
     });
-OPERATOR_SCHEMA(ReduceBackMeanGradient).NumInputs(2).NumOutputs(1);
+OPERATOR_SCHEMA(ReduceBackMeanGradient).NumInputs(2, 3).NumOutputs(1);
 
 /***
   Max Ops
@@ -301,10 +362,12 @@ void MaxReduceDimsOp<float, CPUContext, true>::Compute(
     int rows,
     int cols,
     const float* data,
+    const int32_t* lengths_data,
     float* out_data) {
   for (int i = 0; i < cols; i++) {
     float mx = data[i];
-    for (int j = 1; j < rows; j++) {
+    int length = lengths_data == nullptr ? rows : lengths_data[i];
+    for (int j = 1; j < length; j++) {
       mx = std::max(mx, data[j * cols + i]);
     }
     out_data[i] = mx;
@@ -317,10 +380,12 @@ void MaxReduceDimsOp<float, CPUContext, false>::Compute(
     int rows,
     int cols,
     const float* data,
+    const int32_t* lengths_data,
     float* out_data) {
   for (int i = 0; i < rows; i++) {
     float mx = data[i * cols];
-    for (int j = 1; j < cols; j++) {
+    int length = lengths_data == nullptr ? cols : lengths_data[i];
+    for (int j = 1; j < length; j++) {
       mx = std::max(mx, data[i * cols + j]);
     }
     out_data[i] = mx;
@@ -335,11 +400,17 @@ void MaxReduceDimsGradientOp<float, CPUContext, true>::Compute(
     const float* dYdata,
     const float* Xdata,
     const float* Ydata,
+    const int32_t* lengths_data,
     float* dXdata) {
   int len = cols * rows;
   for (int i = 0; i < len; i++) {
     int col = i % cols;
-    dXdata[i] = Xdata[i] == Ydata[col] ? dYdata[col] : 0.0f;
+    int row = i / cols;
+    if (lengths_data != nullptr && row >= lengths_data[col]) {
+      dXdata[i] = 0.0f;
+    } else {
+      dXdata[i] = Xdata[i] == Ydata[col] ? dYdata[col] : 0.0f;
+    }
   }
 }
 
@@ -351,11 +422,17 @@ void MaxReduceDimsGradientOp<float, CPUContext, false>::Compute(
     const float* dYdata,
     const float* Xdata,
     const float* Ydata,
+    const int32_t* lengths_data,
     float* dXdata) {
   int len = cols * rows;
   for (int i = 0; i < len; i++) {
     int row = i / cols;
-    dXdata[i] = Xdata[i] == Ydata[row] ? dYdata[row] : 0.0f;
+    int col = i % cols;
+    if (lengths_data == nullptr || col < lengths_data[row]) {
+      dXdata[i] = Xdata[i] == Ydata[row] ? dYdata[row] : 0.0f;
+    } else {
+      dXdata[i] = 0.0f;
+    }
   }
 }
 
@@ -372,11 +449,12 @@ REGISTER_CPU_OPERATOR(
 class GetReduceFrontMaxGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;
   vector<OperatorDef> GetGradientDefs() override {
+    vector<string> grad_in = {GO(0), I(0), O(0)};
+    if (def_.input_size() == 2) {
+      grad_in.push_back(I(1));
+    }
     return SingleGradientDef(
-        "ReduceFrontMaxGradient",
-        "",
-        vector<string>{GO(0), I(0), O(0)},
-        vector<string>{GI(0)});
+        "ReduceFrontMaxGradient", "", grad_in, vector<string>{GI(0)});
   }
 };
 
@@ -385,43 +463,52 @@ REGISTER_GRADIENT(ReduceFrontMax, GetReduceFrontMaxGradient);
 class GetReduceBackMaxGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;
   vector<OperatorDef> GetGradientDefs() override {
+    vector<string> grad_in = {GO(0), I(0), O(0)};
+    if (def_.input_size() == 2) {
+      grad_in.push_back(I(1));
+    }
     return SingleGradientDef(
-        "ReduceBackMaxGradient",
-        "",
-        vector<string>{GO(0), I(0), O(0)},
-        vector<string>{GI(0)});
+        "ReduceBackMaxGradient", "", grad_in, vector<string>{GI(0)});
   }
 };
 
 REGISTER_GRADIENT(ReduceBackMax, GetReduceBackMaxGradient);
 
 OPERATOR_SCHEMA(ReduceFrontMax)
-    .NumInputs(1)
+    .NumInputs(1, 2)
     .NumOutputs(1)
     .Arg("num_reduce_dims", "Number of dimensions to reduce")
     .SetDoc(R"DOC(
 Reduces the input tensor along the first dimension of the input
-tensor by applying 'Max'
+tensor by applying 'Max'. When lengths is given, max is only computed
+with subsets of elements correspondingly.
 )DOC")
+    .Input(0, "data_in", "(T<D1..., Dn>) Input data.")
+    .Input(1, "lengths", "Num of elements in each sample, should have size
+        D2 x D3 ... x Dn.")
     .TensorInferenceFunction([](const OperatorDef& def,
                                 const vector<TensorShape>& in) {
       REDUCTION_OP_SHAPE_INFERENCE(true)
     });
-OPERATOR_SCHEMA(ReduceFrontMaxGradient).NumInputs(3).NumOutputs(1);
+OPERATOR_SCHEMA(ReduceFrontMaxGradient).NumInputs(3, 4).NumOutputs(1);
 
 OPERATOR_SCHEMA(ReduceBackMax)
-    .NumInputs(1)
+    .NumInputs(1, 2)
     .NumOutputs(1)
     .Arg("num_reduce_dims", "Number of dimensions to reduce")
     .SetDoc(R"DOC(
 Reduces the input tensor along the last dimension of the
-input tensor by applying 'Max'
+input tensor by applying 'Max'. When lengths is given, max is only computed
+with subsets of elements correspondingly.
 )DOC")
+    .Input(0, "data_in", "(T<D1..., Dn>) Input data.")
+    .Input(1, "lengths", "Num of elements in each sample, should have size
+        D1 x D2 x ... x D(n-1).")
     .TensorInferenceFunction([](const OperatorDef& def,
                                 const vector<TensorShape>& in) {
       REDUCTION_OP_SHAPE_INFERENCE(false)
     });
-OPERATOR_SCHEMA(ReduceBackMaxGradient).NumInputs(3).NumOutputs(1);
+OPERATOR_SCHEMA(ReduceBackMaxGradient).NumInputs(3, 4).NumOutputs(1);
 
 #undef REDUCTION_OP_SHAPE_INFERENCE
 

--- a/caffe2/operators/reduction_front_back_ops.cu
+++ b/caffe2/operators/reduction_front_back_ops.cu
@@ -21,70 +21,90 @@
 namespace caffe2 {
 
 namespace {
-template <typename T>
+template <typename T, bool NORMALIZE>
 __global__ void columnwise_fill_kernel(
     const int rows,
     const int cols,
-    const float alpha,
     const T* dY,
+    const int* lengths,
     T* dX) {
   CUDA_1D_KERNEL_LOOP(i, rows * cols) {
-    dX[i] = dY[i % cols] * alpha;
+    int row = i / cols;
+    int col = i % cols;
+    if (lengths == nullptr) {
+      dX[i] = NORMALIZE ? dY[col] / rows : dY[col];
+    } else if (row < lengths[col]) {
+      dX[i] = NORMALIZE ? dY[col] / lengths[col] : dY[col];
+    } else {
+      dX[i] = 0;
+    }
   }
 }
 
-template <typename T>
+template <typename T, bool NORMALIZE>
 __global__ void rowwise_fill_kernel(
     const int rows,
     const int cols,
-    const float alpha,
     const T* dY,
+    const int* lengths,
     T* dX) {
   CUDA_1D_KERNEL_LOOP(i, rows * cols) {
-    dX[i] = dY[i / cols] * alpha;
+    int row = i / cols;
+    int col = i % cols;
+    if (lengths == nullptr) {
+      dX[i] = NORMALIZE ? dY[row] / cols : dY[row];
+    } else if (col < lengths[row]) {
+      dX[i] = NORMALIZE ? dY[row] / lengths[row] : dY[row];
+    } else {
+      dX[i] = 0;
+    }
   }
 }
 
-template <typename T>
+template <typename T, bool NORMALIZE>
 __global__ void rowwise_sum_kernel(
     const int rows,
     const int cols,
-    const float alpha,
     const T* data,
+    const int* lengths,
     T* out) {
   typedef cub::BlockReduce<float, CAFFE_CUDA_NUM_THREADS> BlockReduce;
   __shared__ typename BlockReduce::TempStorage temp_storage;
   for (int rowIndex = blockIdx.x; rowIndex < rows; rowIndex += gridDim.x) {
     T sum = 0;
     const int rowOffset = rowIndex * cols;
-    for (int colIndex = threadIdx.x; colIndex < cols; colIndex += blockDim.x) {
+    const int length = lengths == nullptr ? cols : lengths[rowIndex];
+    for (int colIndex = threadIdx.x; colIndex < length;
+         colIndex += blockDim.x) {
       sum += data[rowOffset + colIndex];
     }
     sum = BlockReduce(temp_storage).Reduce(sum, cub::Sum());
     if (threadIdx.x == 0) {
-      out[rowIndex] = alpha * sum;
+      out[rowIndex] = NORMALIZE ? sum / length : sum;
     }
     __syncthreads();
   }
 }
 
-template <typename T>
+template <typename T, bool NORMALIZE>
 __global__ void columnwise_sum_kernel(
     const int rows,
     const int cols,
-    const float alpha,
     const T* data,
+    const int* lengths,
     T* out) {
   typedef cub::BlockReduce<float, CAFFE_CUDA_NUM_THREADS> BlockReduce;
   __shared__ typename BlockReduce::TempStorage temp_storage;
   for (int colIndex = blockIdx.x; colIndex < cols; colIndex += gridDim.x) {
     T sum = 0;
-    for (int rowIndex = threadIdx.x; rowIndex < rows; rowIndex += blockDim.x) {
+    const int length = lengths == nullptr ? rows : lengths[colIndex];
+    for (int rowIndex = threadIdx.x; rowIndex < length;
+         rowIndex += blockDim.x) {
       sum += data[rowIndex * cols + colIndex];
     }
     sum = BlockReduce(temp_storage).Reduce(sum, cub::Sum());
     if (threadIdx.x == 0) {
-      out[colIndex] = alpha * sum;
+      out[colIndex] = NORMALIZE ? sum / length : sum;
     }
     __syncthreads();
   }
@@ -103,12 +123,13 @@ void SumReduceDimsOp<CUDAContext, true, false>::Compute(
     int rows,
     int cols,
     const T* in_data,
+    const int* lengths_data,
     T* out_data) {
-  columnwise_sum_kernel<T>
+  columnwise_sum_kernel<T, false>
       <<<std::min(cols, CAFFE_MAXIMUM_NUM_BLOCKS),
          CAFFE_CUDA_NUM_THREADS,
          0,
-         context_.cuda_stream()>>>(rows, cols, 1.0, in_data, out_data);
+         context_.cuda_stream()>>>(rows, cols, in_data, lengths_data, out_data);
 }
 
 // ReduceBackSum: rowwise sum
@@ -118,12 +139,13 @@ void SumReduceDimsOp<CUDAContext, false, false>::Compute(
     int rows,
     int cols,
     const T* in_data,
+    const int* lengths_data,
     T* out_data) {
-  rowwise_sum_kernel<T>
+  rowwise_sum_kernel<T, false>
       <<<std::min(rows, CAFFE_MAXIMUM_NUM_BLOCKS),
          CAFFE_CUDA_NUM_THREADS,
          0,
-         context_.cuda_stream()>>>(rows, cols, 1.0, in_data, out_data);
+         context_.cuda_stream()>>>(rows, cols, in_data, lengths_data, out_data);
 }
 
 // ReduceFrontSumGradient
@@ -133,12 +155,13 @@ void SumReduceDimsGradientOp<CUDAContext, true, false>::Compute(
     int rows,
     int cols,
     const T* dYdata,
+    const int* lengths_data,
     T* dXdata) {
-  columnwise_fill_kernel<T>
+  columnwise_fill_kernel<T, false>
       <<<CAFFE_GET_BLOCKS(rows * cols),
          CAFFE_CUDA_NUM_THREADS,
          0,
-         context_.cuda_stream()>>>(rows, cols, 1.0, dYdata, dXdata);
+         context_.cuda_stream()>>>(rows, cols, dYdata, lengths_data, dXdata);
 }
 
 // ReduceBackSumGradient
@@ -148,12 +171,13 @@ void SumReduceDimsGradientOp<CUDAContext, false, false>::Compute(
     int rows,
     int cols,
     const T* dYdata,
+    const int* lengths_data,
     T* dXdata) {
-  rowwise_fill_kernel<T>
+  rowwise_fill_kernel<T, false>
       <<<CAFFE_GET_BLOCKS(rows * cols),
          CAFFE_CUDA_NUM_THREADS,
          0,
-         context_.cuda_stream()>>>(rows, cols, 1.0, dYdata, dXdata);
+         context_.cuda_stream()>>>(rows, cols, dYdata, lengths_data, dXdata);
 }
 
 REGISTER_CUDA_OPERATOR(
@@ -181,12 +205,13 @@ void SumReduceDimsOp<CUDAContext, true, true>::Compute(
     int rows,
     int cols,
     const T* in_data,
+    const int* lengths_data,
     T* out_data) {
-  columnwise_sum_kernel<<<
-      std::min(cols, CAFFE_MAXIMUM_NUM_BLOCKS),
-      CAFFE_CUDA_NUM_THREADS,
-      0,
-      context_.cuda_stream()>>>(rows, cols, 1.0 / rows, in_data, out_data);
+  columnwise_sum_kernel<T, true>
+      <<<std::min(cols, CAFFE_MAXIMUM_NUM_BLOCKS),
+         CAFFE_CUDA_NUM_THREADS,
+         0,
+         context_.cuda_stream()>>>(rows, cols, in_data, lengths_data, out_data);
 }
 
 // ReduceBackMean: rowwise mean
@@ -196,12 +221,13 @@ void SumReduceDimsOp<CUDAContext, false, true>::Compute(
     int rows,
     int cols,
     const T* in_data,
+    const int* lengths_data,
     T* out_data) {
-  rowwise_sum_kernel<<<
-      std::min(rows, CAFFE_MAXIMUM_NUM_BLOCKS),
-      CAFFE_CUDA_NUM_THREADS,
-      0,
-      context_.cuda_stream()>>>(rows, cols, 1.0 / cols, in_data, out_data);
+  rowwise_sum_kernel<T, true>
+      <<<std::min(rows, CAFFE_MAXIMUM_NUM_BLOCKS),
+         CAFFE_CUDA_NUM_THREADS,
+         0,
+         context_.cuda_stream()>>>(rows, cols, in_data, lengths_data, out_data);
 }
 
 // ReduceFrontMeanGradient
@@ -211,12 +237,13 @@ void SumReduceDimsGradientOp<CUDAContext, true, true>::Compute(
     int rows,
     int cols,
     const T* dYdata,
+    const int* lengths_data,
     T* dXdata) {
-  columnwise_fill_kernel<T>
+  columnwise_fill_kernel<T, true>
       <<<CAFFE_GET_BLOCKS(rows * cols),
          CAFFE_CUDA_NUM_THREADS,
          0,
-         context_.cuda_stream()>>>(rows, cols, 1.0 / rows, dYdata, dXdata);
+         context_.cuda_stream()>>>(rows, cols, dYdata, lengths_data, dXdata);
 }
 
 // ReduceBackMeanGradient
@@ -226,12 +253,13 @@ void SumReduceDimsGradientOp<CUDAContext, false, true>::Compute(
     int rows,
     int cols,
     const T* dYdata,
+    const int* lengths_data,
     T* dXdata) {
-  rowwise_fill_kernel<T>
+  rowwise_fill_kernel<T, true>
       <<<CAFFE_GET_BLOCKS(rows * cols),
          CAFFE_CUDA_NUM_THREADS,
          0,
-         context_.cuda_stream()>>>(rows, cols, 1.0 / cols, dYdata, dXdata);
+         context_.cuda_stream()>>>(rows, cols, dYdata, lengths_data, dXdata);
 }
 
 REGISTER_CUDA_OPERATOR(
@@ -258,12 +286,15 @@ __global__ void columnwise_max_kernel(
     const int rows,
     const int cols,
     const float* data,
+    const int* lengths,
     float* out) {
   typedef cub::BlockReduce<float, CAFFE_CUDA_NUM_THREADS> BlockReduce;
   __shared__ typename BlockReduce::TempStorage temp_storage;
   for (int colIndex = blockIdx.x; colIndex < cols; colIndex += gridDim.x) {
     float mx = FLT_MIN;
-    for (int rowIndex = threadIdx.x; rowIndex < rows; rowIndex += blockDim.x) {
+    const int length = lengths == nullptr ? rows : lengths[colIndex];
+    for (int rowIndex = threadIdx.x; rowIndex < length;
+         rowIndex += blockDim.x) {
       mx = max(mx, data[rowIndex * cols + colIndex]);
     }
     mx = BlockReduce(temp_storage).Reduce(mx, cub::Max());
@@ -278,12 +309,15 @@ __global__ void rowwise_max_kernel(
     const int rows,
     const int cols,
     const float* data,
+    const int* lengths,
     float* out) {
   typedef cub::BlockReduce<float, CAFFE_CUDA_NUM_THREADS> BlockReduce;
   __shared__ typename BlockReduce::TempStorage temp_storage;
   for (int rowIndex = blockIdx.x; rowIndex < rows; rowIndex += gridDim.x) {
     float mx = FLT_MIN;
-    for (int colIndex = threadIdx.x; colIndex < cols; colIndex += blockDim.x) {
+    const int length = lengths == nullptr ? cols : lengths[rowIndex];
+    for (int colIndex = threadIdx.x; colIndex < length;
+         colIndex += blockDim.x) {
       mx = max(mx, data[rowIndex * cols + colIndex]);
     }
     mx = BlockReduce(temp_storage).Reduce(mx, cub::Max());
@@ -300,10 +334,16 @@ __global__ void columnwise_max_grad_kernel(
     const float* dYdata,
     const float* Xdata,
     const float* Ydata,
+    const int* lengths,
     float* dXdata) {
   CUDA_1D_KERNEL_LOOP(i, rows * cols) {
     int col = i % cols;
-    dXdata[i] = (Xdata[i] == Ydata[col]) * dYdata[col];
+    int row = i / cols;
+    if (lengths != nullptr && row >= lengths[col]) {
+      dXdata[i] = 0.0f;
+    } else {
+      dXdata[i] = (Xdata[i] == Ydata[col]) * dYdata[col];
+    }
   }
 }
 
@@ -313,10 +353,16 @@ __global__ void rowwise_max_grad_kernel(
     const float* dYdata,
     const float* Xdata,
     const float* Ydata,
+    const int* lengths,
     float* dXdata) {
   CUDA_1D_KERNEL_LOOP(i, rows * cols) {
+    int col = i % cols;
     int row = i / cols;
-    dXdata[i] = (Xdata[i] == Ydata[row]) * dYdata[row];
+    if (lengths != nullptr && col >= lengths[row]) {
+      dXdata[i] = 0.0f;
+    } else {
+      dXdata[i] = (Xdata[i] == Ydata[row]) * dYdata[row];
+    }
   }
 }
 } // anonymous namespace
@@ -327,12 +373,13 @@ void MaxReduceDimsOp<float, CUDAContext, true>::Compute(
     int rows,
     int cols,
     const float* data,
+    const int32_t* lengths_data,
     float* out_data) {
   columnwise_max_kernel<<<
       std::min(cols, CAFFE_MAXIMUM_NUM_BLOCKS),
       CAFFE_CUDA_NUM_THREADS,
       0,
-      context_.cuda_stream()>>>(rows, cols, data, out_data);
+      context_.cuda_stream()>>>(rows, cols, data, lengths_data, out_data);
 }
 
 // ReduceBackMax
@@ -341,12 +388,13 @@ void MaxReduceDimsOp<float, CUDAContext, false>::Compute(
     int rows,
     int cols,
     const float* data,
+    const int32_t* lengths_data,
     float* out_data) {
   rowwise_max_kernel<<<
       std::min(rows, CAFFE_MAXIMUM_NUM_BLOCKS),
       CAFFE_CUDA_NUM_THREADS,
       0,
-      context_.cuda_stream()>>>(rows, cols, data, out_data);
+      context_.cuda_stream()>>>(rows, cols, data, lengths_data, out_data);
 }
 
 // ReduceFrontMaxGradient
@@ -357,12 +405,14 @@ void MaxReduceDimsGradientOp<float, CUDAContext, true>::Compute(
     const float* dYdata,
     const float* Xdata,
     const float* Ydata,
+    const int32_t* lengths_data,
     float* dXdata) {
   columnwise_max_grad_kernel<<<
       CAFFE_GET_BLOCKS(rows * cols),
       CAFFE_CUDA_NUM_THREADS,
       0,
-      context_.cuda_stream()>>>(rows, cols, dYdata, Xdata, Ydata, dXdata);
+      context_.cuda_stream()>>>(
+      rows, cols, dYdata, Xdata, Ydata, lengths_data, dXdata);
 }
 
 // ReduceBackMaxGradient
@@ -373,12 +423,14 @@ void MaxReduceDimsGradientOp<float, CUDAContext, false>::Compute(
     const float* dYdata,
     const float* Xdata,
     const float* Ydata,
+    const int* lengths_data,
     float* dXdata) {
   rowwise_max_grad_kernel<<<
       CAFFE_GET_BLOCKS(rows * cols),
       CAFFE_CUDA_NUM_THREADS,
       0,
-      context_.cuda_stream()>>>(rows, cols, dYdata, Xdata, Ydata, dXdata);
+      context_.cuda_stream()>>>(
+      rows, cols, dYdata, Xdata, Ydata, lengths_data, dXdata);
 }
 
 REGISTER_CUDA_OPERATOR(

--- a/caffe2/python/operator_test/reduce_ops_test.py
+++ b/caffe2/python/operator_test/reduce_ops_test.py
@@ -60,10 +60,46 @@ class TestReduceFrontReductions(hu.HypothesisTestCase):
         dX1 = workspace.FetchBlob("dX1")
         np.testing.assert_array_equal(dX, dX1)
 
-    def reduce_op_test(self, op_name, op_ref, in_data, num_reduce_dims, device):
+    def max_op_test(self, op_name, num_reduce_dim, gc, dc, in_data, in_names, ref_max):
+
         op = core.CreateOperator(
             op_name,
-            ["inputs"],
+            in_names,
+            ["outputs"],
+            num_reduce_dim=num_reduce_dim
+        )
+
+        self.assertReferenceChecks(
+            device_option=gc,
+            op=op,
+            inputs=in_data,
+            reference=ref_max,
+        )
+
+        # Skip gradient check because it is too unreliable with max.
+        # Just check CPU and CUDA have same results
+        Y = np.array(ref_max(*in_data)[0]).astype(np.float32)
+        dY = np.array(np.random.rand(*Y.shape)).astype(np.float32)
+        if len(in_data) == 2:
+            grad_in_names = ["dY", in_names[0], "Y", in_names[1]]
+            grad_in_data = [dY, in_data[0], Y, in_data[1]]
+        else:
+            grad_in_names = ["dY", in_names[0], "Y"]
+            grad_in_data = [dY, in_data[0], Y]
+
+        grad_op = core.CreateOperator(
+            op_name + "Gradient",
+            grad_in_names,
+            ["dX"],
+            num_reduce_dim=num_reduce_dim
+        )
+        self.assertDeviceChecks(dc, grad_op, grad_in_data, [0])
+
+    def reduce_op_test(self, op_name, op_ref, in_data, in_names,
+                       num_reduce_dims, device):
+        op = core.CreateOperator(
+            op_name,
+            in_names,
             ["outputs"],
             num_reduce_dim=num_reduce_dims
         )
@@ -71,12 +107,12 @@ class TestReduceFrontReductions(hu.HypothesisTestCase):
         self.assertReferenceChecks(
             device_option=device,
             op=op,
-            inputs=[in_data],
+            inputs=in_data,
             reference=op_ref
         )
 
         self.assertGradientChecks(
-            device, op, [in_data], 0, [0], stepsize=1e-2, threshold=1e-2)
+            device, op, in_data, 0, [0], stepsize=1e-2, threshold=1e-2)
 
     @given(num_reduce_dim=st.integers(0, 4), **hu.gcs)
     def test_reduce_front_sum(self, num_reduce_dim, gc, dc):
@@ -85,9 +121,29 @@ class TestReduceFrontReductions(hu.HypothesisTestCase):
         def ref_sum(X):
             return [np.sum(X, axis=(tuple(range(num_reduce_dim))))]
 
-        self.reduce_op_test("ReduceFrontSum", ref_sum, X, num_reduce_dim, gc)
+        self.reduce_op_test(
+            "ReduceFrontSum", ref_sum, [X], ["input"], num_reduce_dim, gc)
         self.grad_variant_input_test(
             "ReduceFrontSumGradient", X, ref_sum, num_reduce_dim)
+
+    @given(**hu.gcs)
+    def test_reduce_front_sum_with_length(self, dc, gc):
+        num_reduce_dim = 1
+        X = np.random.rand(2, 3, 4, 5).astype(np.float32)
+        batch_size = int(np.prod([2, 3, 4, 5][num_reduce_dim:]))
+        d = 120 // batch_size
+        lengths = np.random.randint(1, d, size=batch_size).astype(np.int32)
+
+        def ref_sum(X, lengths):
+            Y = X.reshape(d, lengths.size)
+            rv = np.zeros((lengths.size, 1)).astype(np.float32)
+            for ii in range(lengths.size):
+                rv[ii] = np.sum(Y[:lengths[ii], ii])
+            return [rv.reshape((2, 3, 4, 5)[num_reduce_dim:])]
+
+        self.reduce_op_test(
+            "ReduceFrontSum", ref_sum, [X, lengths], ["input", "lengths"],
+            num_reduce_dim, gc)
 
     @given(num_reduce_dim=st.integers(0, 4), **hu.gcs)
     def test_reduce_front_mean(self, num_reduce_dim, gc, dc):
@@ -96,9 +152,29 @@ class TestReduceFrontReductions(hu.HypothesisTestCase):
         def ref_mean(X):
             return [np.mean(X, axis=(tuple(range(num_reduce_dim))))]
 
-        self.reduce_op_test("ReduceFrontMean", ref_mean, X, num_reduce_dim, gc)
+        self.reduce_op_test(
+            "ReduceFrontMean", ref_mean, [X], ["input"], num_reduce_dim, gc)
         self.grad_variant_input_test(
             "ReduceFrontMeanGradient", X, ref_mean, num_reduce_dim)
+
+    @given(**hu.gcs)
+    def test_reduce_front_mean_with_length(self, dc, gc):
+        num_reduce_dim = 1
+        X = np.random.rand(2, 3, 4, 5).astype(np.float32)
+        batch_size = int(np.prod([2, 3, 4, 5][num_reduce_dim:]))
+        d = 120 // batch_size
+        lengths = np.random.randint(1, d, size=batch_size).astype(np.int32)
+
+        def ref_mean(X, lengths):
+            Y = X.reshape(d, lengths.size)
+            rv = np.zeros((lengths.size, 1)).astype(np.float32)
+            for ii in range(lengths.size):
+                rv[ii] = np.mean(Y[:lengths[ii], ii])
+            return [rv.reshape((2, 3, 4, 5)[num_reduce_dim:])]
+
+        self.reduce_op_test(
+            "ReduceFrontMean", ref_mean, [X, lengths], ["input", "lengths"],
+            num_reduce_dim, gc)
 
     @given(num_reduce_dim=st.integers(0, 4), **hu.gcs)
     def test_reduce_front_max(self, num_reduce_dim, gc, dc):
@@ -107,31 +183,27 @@ class TestReduceFrontReductions(hu.HypothesisTestCase):
         def ref_frontmax(X):
             return [np.max(X, axis=(tuple(range(num_reduce_dim))))]
 
-        op = core.CreateOperator(
-            "ReduceFrontMax",
-            ["inputs"],
-            ["outputs"],
-            num_reduce_dim=num_reduce_dim
-        )
+        self.max_op_test(
+            "ReduceFrontMax", num_reduce_dim, gc, dc, [X], ["X"], ref_frontmax)
 
-        self.assertReferenceChecks(
-            device_option=gc,
-            op=op,
-            inputs=[X],
-            reference=ref_frontmax,
-        )
+    @given(**hu.gcs)
+    def test_reduce_front_max_with_length(self, dc, gc):
+        num_reduce_dim = 1
+        X = np.random.rand(2, 3, 4, 5).astype(np.float32)
+        batch_size = int(np.prod([2, 3, 4, 5][num_reduce_dim:]))
+        d = 120 // batch_size
+        lengths = np.random.randint(1, d, size=batch_size).astype(np.int32)
 
-        # Skip gradient check because it is too unreliable with max.
-        # Just check CPU and CUDA have same results
-        Y = np.array(ref_frontmax(X)[0]).astype(np.float32)
-        dY = np.array(np.random.rand(*Y.shape)).astype(np.float32)
-        grad_op = core.CreateOperator(
-            "ReduceFrontMaxGradient",
-            ["dY", "X", "Y"],
-            ["dX"],
-            num_reduce_dim=num_reduce_dim
-        )
-        self.assertDeviceChecks(dc, grad_op, [dY, X, Y], [0])
+        def ref_max(X, lengths):
+            Y = X.reshape(d, lengths.size)
+            rv = np.zeros((lengths.size, 1)).astype(np.float32)
+            for ii in range(lengths.size):
+                rv[ii] = np.max(Y[:lengths[ii], ii])
+            return [rv.reshape((2, 3, 4, 5)[num_reduce_dim:])]
+
+        self.max_op_test(
+            "ReduceFrontMax", num_reduce_dim, gc, dc, [X, lengths],
+            ["X", "lengths"], ref_max)
 
     @given(num_reduce_dim=st.integers(0, 4), **hu.gcs)
     def test_reduce_back_max(self, num_reduce_dim, gc, dc):
@@ -140,42 +212,59 @@ class TestReduceFrontReductions(hu.HypothesisTestCase):
         def ref_backmax(X):
             return [np.max(X, axis=(0, 1, 2, 3)[4 - num_reduce_dim:])]
 
-        op = core.CreateOperator(
-            "ReduceBackMax",
-            ["inputs"],
-            ["outputs"],
-            num_reduce_dim=num_reduce_dim
-        )
+        self.max_op_test(
+            "ReduceBackMax", num_reduce_dim, gc, dc, [X], ["X"], ref_backmax)
 
-        self.assertReferenceChecks(
-            device_option=gc,
-            op=op,
-            inputs=[X],
-            reference=ref_backmax
-        )
+    @given(**hu.gcs)
+    def test_reduce_back_max_with_length(self, gc, dc):
+        num_reduce_dim = 1
+        X = np.random.rand(2, 3, 4, 5).astype(np.float32)
+        batch_size = int(np.prod([2, 3, 4, 5][:4 - num_reduce_dim]))
+        d = 120 // batch_size
+        lengths = np.random.randint(1, d, size=batch_size).astype(np.int32)
 
-        # Skip gradient check because it is too unreliable with max
-        # Just check CPU and CUDA have same results
-        Y = np.array(ref_backmax(X)[0]).astype(np.float32)
-        dY = np.array(np.random.rand(*Y.shape)).astype(np.float32)
-        grad_op = core.CreateOperator(
-            "ReduceBackMaxGradient",
-            ["dY", "X", "Y"],
-            ["dX"],
-            num_reduce_dim=num_reduce_dim
-        )
-        self.assertDeviceChecks(dc, grad_op, [dY, X, Y], [0])
+        def ref_max(X, lengths):
+            Y = X.reshape(lengths.size, d)
+            rv = np.zeros((lengths.size, 1)).astype(np.float32)
+            for ii in range(lengths.size):
+                rv[ii] = np.max(Y[ii, :lengths[ii]])
+            return [rv.reshape((2, 3, 4, 5)[:4 - num_reduce_dim])]
 
-    @given(num_reduce_dim=st.integers(0, 4), **hu.gcs)
-    def test_reduce_back_sum(self, num_reduce_dim, dc, gc):
+        self.max_op_test(
+            "ReduceBackMax", num_reduce_dim, gc, dc, [X, lengths],
+            ["X", "lengths"], ref_max)
+
+    @given(**hu.gcs)
+    def test_reduce_back_sum(self, dc, gc):
+        num_reduce_dim = 1
         X = np.random.rand(6, 7, 8, 2).astype(np.float32)
 
         def ref_sum(X):
             return [np.sum(X, axis=(0, 1, 2, 3)[4 - num_reduce_dim:])]
 
-        self.reduce_op_test("ReduceBackSum", ref_sum, X, num_reduce_dim, gc)
+        self.reduce_op_test(
+            "ReduceBackSum", ref_sum, [X], ["input"], num_reduce_dim, gc)
         self.grad_variant_input_test(
             "ReduceBackSumGradient", X, ref_sum, num_reduce_dim)
+
+    @given(**hu.gcs)
+    def test_reduce_back_sum_with_length(self, dc, gc):
+        num_reduce_dim = 1
+        X = np.random.rand(2, 3, 4, 5).astype(np.float32)
+        batch_size = int(np.prod([2, 3, 4, 5][:4 - num_reduce_dim]))
+        d = 120 // batch_size
+        lengths = np.random.randint(1, d, size=batch_size).astype(np.int32)
+
+        def ref_sum(X, lengths):
+            Y = X.reshape(lengths.size, d)
+            rv = np.zeros((lengths.size, 1)).astype(np.float32)
+            for ii in range(lengths.size):
+                rv[ii] = np.sum(Y[ii, :lengths[ii]])
+            return [rv.reshape((2, 3, 4, 5)[:4 - num_reduce_dim])]
+
+        self.reduce_op_test(
+            "ReduceBackSum", ref_sum, [X, lengths], ["input", "lengths"],
+            num_reduce_dim, gc)
 
     @given(num_reduce_dim=st.integers(0, 4), **hu.gcs)
     def test_reduce_back_mean(self, num_reduce_dim, dc, gc):
@@ -184,6 +273,26 @@ class TestReduceFrontReductions(hu.HypothesisTestCase):
         def ref_mean(X):
             return [np.mean(X, axis=(0, 1, 2, 3)[4 - num_reduce_dim:])]
 
-        self.reduce_op_test("ReduceBackMean", ref_mean, X, num_reduce_dim, gc)
+        self.reduce_op_test(
+            "ReduceBackMean", ref_mean, [X], ["input"], num_reduce_dim, gc)
         self.grad_variant_input_test(
             "ReduceBackMeanGradient", X, ref_mean, num_reduce_dim)
+
+    @given(**hu.gcs)
+    def test_reduce_back_mean_with_length(self, dc, gc):
+        num_reduce_dim = 1
+        X = np.random.rand(2, 3, 4, 5).astype(np.float32)
+        batch_size = int(np.prod([2, 3, 4, 5][:4 - num_reduce_dim]))
+        d = 120 // batch_size
+        lengths = np.random.randint(1, d, size=batch_size).astype(np.int32)
+
+        def ref_mean(X, lengths):
+            Y = X.reshape(lengths.size, d)
+            rv = np.zeros((lengths.size, 1)).astype(np.float32)
+            for ii in range(lengths.size):
+                rv[ii] = np.mean(Y[ii, :lengths[ii]])
+            return [rv.reshape((2, 3, 4, 5)[:4 - num_reduce_dim])]
+
+        self.reduce_op_test(
+            "ReduceBackMean", ref_mean, [X, lengths], ["input", "lengths"],
+            num_reduce_dim, gc)


### PR DESCRIPTION
If ops are specified a second input, that would be tensor of ints specifying length of each sample. Ignore entries beyond the lengths when computing the reduction.

