### PR TITLE
[C2] Support optional lengths input to ReduceFront/Back operators

### DIFF
--- a/caffe2/operators/reduction_front_back_ops.cu
+++ b/caffe2/operators/reduction_front_back_ops.cu
@@ -21,70 +21,90 @@
 namespace caffe2 {
 
 namespace {
-template <typename T>
+template <typename T, bool NORMALIZE>
 __global__ void columnwise_fill_kernel(
     const int rows,
     const int cols,
-    const float alpha,
     const T* dY,
+    const int* lengths,
     T* dX) {
   CUDA_1D_KERNEL_LOOP(i, rows * cols) {
-    dX[i] = dY[i % cols] * alpha;
+    int row = i / cols;
+    int col = i % cols;
+    if (lengths == nullptr) {
+      dX[i] = NORMALIZE ? dY[col] / rows : dY[col];
+    } else if (row < lengths[col]) {
+      dX[i] = NORMALIZE ? dY[col] / lengths[col] : dY[col];
+    } else {
+      dX[i] = 0;
+    }
   }
 }
 
-template <typename T>
+template <typename T, bool NORMALIZE>
 __global__ void rowwise_fill_kernel(
     const int rows,
     const int cols,
-    const float alpha,
     const T* dY,
+    const int* lengths,
     T* dX) {
   CUDA_1D_KERNEL_LOOP(i, rows * cols) {
-    dX[i] = dY[i / cols] * alpha;
+    int row = i / cols;
+    int col = i % cols;
+    if (lengths == nullptr) {
+      dX[i] = NORMALIZE ? dY[row] / cols : dY[row];
+    } else if (col < lengths[row]) {
+      dX[i] = NORMALIZE ? dY[row] / lengths[row] : dY[row];
+    } else {
+      dX[i] = 0;
+    }
   }
 }
 
-template <typename T>
+template <typename T, bool NORMALIZE>
 __global__ void rowwise_sum_kernel(
     const int rows,
     const int cols,
-    const float alpha,
     const T* data,
+    const int* lengths,
     T* out) {
   typedef cub::BlockReduce<float, CAFFE_CUDA_NUM_THREADS> BlockReduce;
   __shared__ typename BlockReduce::TempStorage temp_storage;
   for (int rowIndex = blockIdx.x; rowIndex < rows; rowIndex += gridDim.x) {
     T sum = 0;
     const int rowOffset = rowIndex * cols;
-    for (int colIndex = threadIdx.x; colIndex < cols; colIndex += blockDim.x) {
+    const int length = lengths == nullptr ? cols : lengths[rowIndex];
+    for (int colIndex = threadIdx.x; colIndex < length;
+         colIndex += blockDim.x) {
       sum += data[rowOffset + colIndex];
     }
     sum = BlockReduce(temp_storage).Reduce(sum, cub::Sum());
     if (threadIdx.x == 0) {
-      out[rowIndex] = alpha * sum;
+      out[rowIndex] = NORMALIZE ? sum / length : sum;
     }
     __syncthreads();
   }
 }
 
-template <typename T>
+template <typename T, bool NORMALIZE>
 __global__ void columnwise_sum_kernel(
     const int rows,
     const int cols,
-    const float alpha,
     const T* data,
+    const int* lengths,
     T* out) {
   typedef cub::BlockReduce<float, CAFFE_CUDA_NUM_THREADS> BlockReduce;
   __shared__ typename BlockReduce::TempStorage temp_storage;
   for (int colIndex = blockIdx.x; colIndex < cols; colIndex += gridDim.x) {
     T sum = 0;
-    for (int rowIndex = threadIdx.x; rowIndex < rows; rowIndex += blockDim.x) {
+    const int length = lengths == nullptr ? rows : lengths[colIndex];
+    for (int rowIndex = threadIdx.x; rowIndex < length;
+         rowIndex += blockDim.x) {
       sum += data[rowIndex * cols + colIndex];
     }
     sum = BlockReduce(temp_storage).Reduce(sum, cub::Sum());
     if (threadIdx.x == 0) {
-      out[colIndex] = alpha * sum;
+      out[colIndex] = NORMALIZE ? sum / length : sum;
     }
     __syncthreads();
   }
@@ -103,12 +123,13 @@ void SumReduceDimsOp<CUDAContext, true, false>::Compute(
     int rows,
     int cols,
     const T* in_data,
+    const int* lengths_data,
     T* out_data) {
-  columnwise_sum_kernel<T>
+  columnwise_sum_kernel<T, false>
       <<<std::min(cols, CAFFE_MAXIMUM_NUM_BLOCKS),
          CAFFE_CUDA_NUM_THREADS,
          0,
-         context_.cuda_stream()>>>(rows, cols, 1.0, in_data, out_data);
+         context_.cuda_stream()>>>(rows, cols, in_data, lengths_data, out_data);
 }
 
 // ReduceBackSum: rowwise sum
@@ -118,12 +139,13 @@ void SumReduceDimsOp<CUDAContext, false, false>::Compute(
     int rows,
     int cols,
     const T* in_data,
+    const int* lengths_data,
     T* out_data) {
-  rowwise_sum_kernel<T>
+  rowwise_sum_kernel<T, false>
       <<<std::min(rows, CAFFE_MAXIMUM_NUM_BLOCKS),
          CAFFE_CUDA_NUM_THREADS,
          0,
-         context_.cuda_stream()>>>(rows, cols, 1.0, in_data, out_data);
+         context_.cuda_stream()>>>(rows, cols, in_data, lengths_data, out_data);
 }
 
 // ReduceFrontSumGradient
@@ -133,12 +155,13 @@ void SumReduceDimsGradientOp<CUDAContext, true, false>::Compute(
     int rows,
     int cols,
     const T* dYdata,
+    const int* lengths_data,
     T* dXdata) {
-  columnwise_fill_kernel<T>
+  columnwise_fill_kernel<T, false>
       <<<CAFFE_GET_BLOCKS(rows * cols),
          CAFFE_CUDA_NUM_THREADS,
          0,
-         context_.cuda_stream()>>>(rows, cols, 1.0, dYdata, dXdata);
+         context_.cuda_stream()>>>(rows, cols, dYdata, lengths_data, dXdata);
 }
 
 // ReduceBackSumGradient
@@ -148,12 +171,13 @@ void SumReduceDimsGradientOp<CUDAContext, false, false>::Compute(
     int rows,
     int cols,
     const T* dYdata,
+    const int* lengths_data,
     T* dXdata) {
-  rowwise_fill_kernel<T>
+  rowwise_fill_kernel<T, false>
       <<<CAFFE_GET_BLOCKS(rows * cols),
          CAFFE_CUDA_NUM_THREADS,
          0,
-         context_.cuda_stream()>>>(rows, cols, 1.0, dYdata, dXdata);
+         context_.cuda_stream()>>>(rows, cols, dYdata, lengths_data, dXdata);
 }
 
 REGISTER_CUDA_OPERATOR(
@@ -181,12 +205,13 @@ void SumReduceDimsOp<CUDAContext, true, true>::Compute(
     int rows,
     int cols,
     const T* in_data,
+    const int* lengths_data,
     T* out_data) {
-  columnwise_sum_kernel<<<
-      std::min(cols, CAFFE_MAXIMUM_NUM_BLOCKS),
-      CAFFE_CUDA_NUM_THREADS,
-      0,
-      context_.cuda_stream()>>>(rows, cols, 1.0 / rows, in_data, out_data);
+  columnwise_sum_kernel<T, true>
+      <<<std::min(cols, CAFFE_MAXIMUM_NUM_BLOCKS),
+         CAFFE_CUDA_NUM_THREADS,
+         0,
+         context_.cuda_stream()>>>(rows, cols, in_data, lengths_data, out_data);
 }
 
 // ReduceBackMean: rowwise mean
@@ -196,12 +221,13 @@ void SumReduceDimsOp<CUDAContext, false, true>::Compute(
     int rows,
     int cols,
     const T* in_data,
+    const int* lengths_data,
     T* out_data) {
-  rowwise_sum_kernel<<<
-      std::min(rows, CAFFE_MAXIMUM_NUM_BLOCKS),
-      CAFFE_CUDA_NUM_THREADS,
-      0,
-      context_.cuda_stream()>>>(rows, cols, 1.0 / cols, in_data, out_data);
+  rowwise_sum_kernel<T, true>
+      <<<std::min(rows, CAFFE_MAXIMUM_NUM_BLOCKS),
+         CAFFE_CUDA_NUM_THREADS,
+         0,
+         context_.cuda_stream()>>>(rows, cols, in_data, lengths_data, out_data);
 }
 
 // ReduceFrontMeanGradient
@@ -211,12 +237,13 @@ void SumReduceDimsGradientOp<CUDAContext, true, true>::Compute(
     int rows,
     int cols,
     const T* dYdata,
+    const int* lengths_data,
     T* dXdata) {
-  columnwise_fill_kernel<T>
+  columnwise_fill_kernel<T, true>
       <<<CAFFE_GET_BLOCKS(rows * cols),
          CAFFE_CUDA_NUM_THREADS,
          0,
-         context_.cuda_stream()>>>(rows, cols, 1.0 / rows, dYdata, dXdata);
+         context_.cuda_stream()>>>(rows, cols, dYdata, lengths_data, dXdata);
 }
 
 // ReduceBackMeanGradient
@@ -226,12 +253,13 @@ void SumReduceDimsGradientOp<CUDAContext, false, true>::Compute(
     int rows,
     int cols,
     const T* dYdata,
+    const int* lengths_data,
     T* dXdata) {
-  rowwise_fill_kernel<T>
+  rowwise_fill_kernel<T, true>
       <<<CAFFE_GET_BLOCKS(rows * cols),
          CAFFE_CUDA_NUM_THREADS,
          0,
-         context_.cuda_stream()>>>(rows, cols, 1.0 / cols, dYdata, dXdata);
+         context_.cuda_stream()>>>(rows, cols, dYdata, lengths_data, dXdata);
 }
 
 REGISTER_CUDA_OPERATOR(
@@ -258,12 +286,15 @@ __global__ void columnwise_max_kernel(
     const int rows,
     const int cols,
     const float* data,
+    const int* lengths,
     float* out) {
   typedef cub::BlockReduce<float, CAFFE_CUDA_NUM_THREADS> BlockReduce;
   __shared__ typename BlockReduce::TempStorage temp_storage;
   for (int colIndex = blockIdx.x; colIndex < cols; colIndex += gridDim.x) {
     float mx = FLT_MIN;
-    for (int rowIndex = threadIdx.x; rowIndex < rows; rowIndex += blockDim.x) {
+    const int length = lengths == nullptr ? rows : lengths[colIndex];
+    for (int rowIndex = threadIdx.x; rowIndex < length;
+         rowIndex += blockDim.x) {
       mx = max(mx, data[rowIndex * cols + colIndex]);
     }
     mx = BlockReduce(temp_storage).Reduce(mx, cub::Max());
@@ -278,12 +309,15 @@ __global__ void rowwise_max_kernel(
     const int rows,
     const int cols,
     const float* data,
+    const int* lengths,
     float* out) {
   typedef cub::BlockReduce<float, CAFFE_CUDA_NUM_THREADS> BlockReduce;
   __shared__ typename BlockReduce::TempStorage temp_storage;
   for (int rowIndex = blockIdx.x; rowIndex < rows; rowIndex += gridDim.x) {
     float mx = FLT_MIN;
-    for (int colIndex = threadIdx.x; colIndex < cols; colIndex += blockDim.x) {
+    const int length = lengths == nullptr ? cols : lengths[rowIndex];
+    for (int colIndex = threadIdx.x; colIndex < length;
+         colIndex += blockDim.x) {
       mx = max(mx, data[rowIndex * cols + colIndex]);
     }
     mx = BlockReduce(temp_storage).Reduce(mx, cub::Max());
@@ -300,10 +334,16 @@ __global__ void columnwise_max_grad_kernel(
     const float* dYdata,
     const float* Xdata,
     const float* Ydata,
+    const int* lengths,
     float* dXdata) {
   CUDA_1D_KERNEL_LOOP(i, rows * cols) {
     int col = i % cols;
-    dXdata[i] = (Xdata[i] == Ydata[col]) * dYdata[col];
+    int row = i / cols;
+    if (lengths != nullptr && row >= lengths[col]) {
+      dXdata[i] = 0.0f;
+    } else {
+      dXdata[i] = (Xdata[i] == Ydata[col]) * dYdata[col];
+    }
   }
 }
 
@@ -313,10 +353,16 @@ __global__ void rowwise_max_grad_kernel(
     const float* dYdata,
     const float* Xdata,
     const float* Ydata,
+    const int* lengths,
     float* dXdata) {
   CUDA_1D_KERNEL_LOOP(i, rows * cols) {
+    int col = i % cols;
     int row = i / cols;
-    dXdata[i] = (Xdata[i] == Ydata[row]) * dYdata[row];
+    if (lengths != nullptr && col >= lengths[row]) {
+      dXdata[i] = 0.0f;
+    } else {
+      dXdata[i] = (Xdata[i] == Ydata[row]) * dYdata[row];
+    }
   }
 }
 } // anonymous namespace
@@ -327,12 +373,13 @@ void MaxReduceDimsOp<float, CUDAContext, true>::Compute(
     int rows,
     int cols,
     const float* data,
+    const int32_t* lengths_data,
     float* out_data) {
   columnwise_max_kernel<<<
       std::min(cols, CAFFE_MAXIMUM_NUM_BLOCKS),
       CAFFE_CUDA_NUM_THREADS,
       0,
-      context_.cuda_stream()>>>(rows, cols, data, out_data);
+      context_.cuda_stream()>>>(rows, cols, data, lengths_data, out_data);
 }
 
 // ReduceBackMax
@@ -341,12 +388,13 @@ void MaxReduceDimsOp<float, CUDAContext, false>::Compute(
     int rows,
     int cols,
     const float* data,
+    const int32_t* lengths_data,
     float* out_data) {
   rowwise_max_kernel<<<
       std::min(rows, CAFFE_MAXIMUM_NUM_BLOCKS),
       CAFFE_CUDA_NUM_THREADS,
       0,
-      context_.cuda_stream()>>>(rows, cols, data, out_data);
+      context_.cuda_stream()>>>(rows, cols, data, lengths_data, out_data);
 }
 
 // ReduceFrontMaxGradient
@@ -357,12 +405,14 @@ void MaxReduceDimsGradientOp<float, CUDAContext, true>::Compute(
     const float* dYdata,
     const float* Xdata,
     const float* Ydata,
+    const int32_t* lengths_data,
     float* dXdata) {
   columnwise_max_grad_kernel<<<
       CAFFE_GET_BLOCKS(rows * cols),
       CAFFE_CUDA_NUM_THREADS,
       0,
-      context_.cuda_stream()>>>(rows, cols, dYdata, Xdata, Ydata, dXdata);
+      context_.cuda_stream()>>>(
+      rows, cols, dYdata, Xdata, Ydata, lengths_data, dXdata);
 }
 
 // ReduceBackMaxGradient
@@ -373,12 +423,14 @@ void MaxReduceDimsGradientOp<float, CUDAContext, false>::Compute(
     const float* dYdata,
     const float* Xdata,
     const float* Ydata,
+    const int* lengths_data,
     float* dXdata) {
   rowwise_max_grad_kernel<<<
       CAFFE_GET_BLOCKS(rows * cols),
       CAFFE_CUDA_NUM_THREADS,
       0,
-      context_.cuda_stream()>>>(rows, cols, dYdata, Xdata, Ydata, dXdata);
+      context_.cuda_stream()>>>(
+      rows, cols, dYdata, Xdata, Ydata, lengths_data, dXdata);
 }
 
 REGISTER_CUDA_OPERATOR(

--- a/caffe2/python/operator_test/reduce_ops_test.py
+++ b/caffe2/python/operator_test/reduce_ops_test.py
@@ -60,10 +60,46 @@ class TestReduceFrontReductions(hu.HypothesisTestCase):
         dX1 = workspace.FetchBlob("dX1")
         np.testing.assert_array_equal(dX, dX1)
 
-    def reduce_op_test(self, op_name, op_ref, in_data, num_reduce_dims, device):
+    def max_op_test(self, op_name, num_reduce_dim, gc, dc, in_data, in_names, ref_max):
+
         op = core.CreateOperator(
             op_name,
-            ["inputs"],
+            in_names,
+            ["outputs"],
+            num_reduce_dim=num_reduce_dim
+        )
+
+        self.assertReferenceChecks(
+            device_option=gc,
+            op=op,
+            inputs=in_data,
+            reference=ref_max,
+        )
+
+        # Skip gradient check because it is too unreliable with max.
+        # Just check CPU and CUDA have same results
+        Y = np.array(ref_max(*in_data)[0]).astype(np.float32)
+        dY = np.array(np.random.rand(*Y.shape)).astype(np.float32)
+        if len(in_data) == 2:
+            grad_in_names = ["dY", in_names[0], "Y", in_names[1]]
+            grad_in_data = [dY, in_data[0], Y, in_data[1]]
+        else:
+            grad_in_names = ["dY", in_names[0], "Y"]
+            grad_in_data = [dY, in_data[0], Y]
+
+        grad_op = core.CreateOperator(
+            op_name + "Gradient",
+            grad_in_names,
+            ["dX"],
+            num_reduce_dim=num_reduce_dim
+        )
+        self.assertDeviceChecks(dc, grad_op, grad_in_data, [0])
+
+    def reduce_op_test(self, op_name, op_ref, in_data, in_names,
+                       num_reduce_dims, device):
+        op = core.CreateOperator(
+            op_name,
+            in_names,
             ["outputs"],
             num_reduce_dim=num_reduce_dims
         )
@@ -71,12 +107,12 @@ class TestReduceFrontReductions(hu.HypothesisTestCase):
         self.assertReferenceChecks(
             device_option=device,
             op=op,
-            inputs=[in_data],
+            inputs=in_data,
             reference=op_ref
         )
 
         self.assertGradientChecks(
-            device, op, [in_data], 0, [0], stepsize=1e-2, threshold=1e-2)
+            device, op, in_data, 0, [0], stepsize=1e-2, threshold=1e-2)
 
     @given(num_reduce_dim=st.integers(0, 4), **hu.gcs)
     def test_reduce_front_sum(self, num_reduce_dim, gc, dc):
@@ -85,9 +121,29 @@ class TestReduceFrontReductions(hu.HypothesisTestCase):
         def ref_sum(X):
             return [np.sum(X, axis=(tuple(range(num_reduce_dim))))]
 
-        self.reduce_op_test("ReduceFrontSum", ref_sum, X, num_reduce_dim, gc)
+        self.reduce_op_test(
+            "ReduceFrontSum", ref_sum, [X], ["input"], num_reduce_dim, gc)
         self.grad_variant_input_test(
             "ReduceFrontSumGradient", X, ref_sum, num_reduce_dim)
+
+    @given(**hu.gcs)
+    def test_reduce_front_sum_with_length(self, dc, gc):
+        num_reduce_dim = 1
+        X = np.random.rand(2, 3, 4, 5).astype(np.float32)
+        batch_size = int(np.prod([2, 3, 4, 5][num_reduce_dim:]))
+        d = 120 // batch_size
+        lengths = np.random.randint(1, d, size=batch_size).astype(np.int32)
+
+        def ref_sum(X, lengths):
+            Y = X.reshape(d, lengths.size)
+            rv = np.zeros((lengths.size, 1)).astype(np.float32)
+            for ii in range(lengths.size):
+                rv[ii] = np.sum(Y[:lengths[ii], ii])
+            return [rv.reshape((2, 3, 4, 5)[num_reduce_dim:])]
+
+        self.reduce_op_test(
+            "ReduceFrontSum", ref_sum, [X, lengths], ["input", "lengths"],
+            num_reduce_dim, gc)
 
     @given(num_reduce_dim=st.integers(0, 4), **hu.gcs)
     def test_reduce_front_mean(self, num_reduce_dim, gc, dc):
@@ -96,9 +152,29 @@ class TestReduceFrontReductions(hu.HypothesisTestCase):
         def ref_mean(X):
             return [np.mean(X, axis=(tuple(range(num_reduce_dim))))]
 
-        self.reduce_op_test("ReduceFrontMean", ref_mean, X, num_reduce_dim, gc)
+        self.reduce_op_test(
+            "ReduceFrontMean", ref_mean, [X], ["input"], num_reduce_dim, gc)
         self.grad_variant_input_test(
             "ReduceFrontMeanGradient", X, ref_mean, num_reduce_dim)
+
+    @given(**hu.gcs)
+    def test_reduce_front_mean_with_length(self, dc, gc):
+        num_reduce_dim = 1
+        X = np.random.rand(2, 3, 4, 5).astype(np.float32)
+        batch_size = int(np.prod([2, 3, 4, 5][num_reduce_dim:]))
+        d = 120 // batch_size
+        lengths = np.random.randint(1, d, size=batch_size).astype(np.int32)
+
+        def ref_mean(X, lengths):
+            Y = X.reshape(d, lengths.size)
+            rv = np.zeros((lengths.size, 1)).astype(np.float32)
+            for ii in range(lengths.size):
+                rv[ii] = np.mean(Y[:lengths[ii], ii])
+            return [rv.reshape((2, 3, 4, 5)[num_reduce_dim:])]
+
+        self.reduce_op_test(
+            "ReduceFrontMean", ref_mean, [X, lengths], ["input", "lengths"],
+            num_reduce_dim, gc)
 
     @given(num_reduce_dim=st.integers(0, 4), **hu.gcs)
     def test_reduce_front_max(self, num_reduce_dim, gc, dc):
@@ -107,31 +183,27 @@ class TestReduceFrontReductions(hu.HypothesisTestCase):
         def ref_frontmax(X):
             return [np.max(X, axis=(tuple(range(num_reduce_dim))))]
 
-        op = core.CreateOperator(
-            "ReduceFrontMax",
-            ["inputs"],
-            ["outputs"],
-            num_reduce_dim=num_reduce_dim
-        )
+        self.max_op_test(
+            "ReduceFrontMax", num_reduce_dim, gc, dc, [X], ["X"], ref_frontmax)
 
-        self.assertReferenceChecks(
-            device_option=gc,
-            op=op,
-            inputs=[X],
-            reference=ref_frontmax,
-        )
+    @given(**hu.gcs)
+    def test_reduce_front_max_with_length(self, dc, gc):
+        num_reduce_dim = 1
+        X = np.random.rand(2, 3, 4, 5).astype(np.float32)
+        batch_size = int(np.prod([2, 3, 4, 5][num_reduce_dim:]))
+        d = 120 // batch_size
+        lengths = np.random.randint(1, d, size=batch_size).astype(np.int32)
 
-        # Skip gradient check because it is too unreliable with max.
-        # Just check CPU and CUDA have same results
-        Y = np.array(ref_frontmax(X)[0]).astype(np.float32)
-        dY = np.array(np.random.rand(*Y.shape)).astype(np.float32)
-        grad_op = core.CreateOperator(
-            "ReduceFrontMaxGradient",
-            ["dY", "X", "Y"],
-            ["dX"],
-            num_reduce_dim=num_reduce_dim
-        )
-        self.assertDeviceChecks(dc, grad_op, [dY, X, Y], [0])
+        def ref_max(X, lengths):
+            Y = X.reshape(d, lengths.size)
+            rv = np.zeros((lengths.size, 1)).astype(np.float32)
+            for ii in range(lengths.size):
+                rv[ii] = np.max(Y[:lengths[ii], ii])
+            return [rv.reshape((2, 3, 4, 5)[num_reduce_dim:])]
+
+        self.max_op_test(
+            "ReduceFrontMax", num_reduce_dim, gc, dc, [X, lengths],
+            ["X", "lengths"], ref_max)
 
     @given(num_reduce_dim=st.integers(0, 4), **hu.gcs)
     def test_reduce_back_max(self, num_reduce_dim, gc, dc):
@@ -140,42 +212,59 @@ class TestReduceFrontReductions(hu.HypothesisTestCase):
         def ref_backmax(X):
             return [np.max(X, axis=(0, 1, 2, 3)[4 - num_reduce_dim:])]
 
-        op = core.CreateOperator(
-            "ReduceBackMax",
-            ["inputs"],
-            ["outputs"],
-            num_reduce_dim=num_reduce_dim
-        )
+        self.max_op_test(
+            "ReduceBackMax", num_reduce_dim, gc, dc, [X], ["X"], ref_backmax)
 
-        self.assertReferenceChecks(
-            device_option=gc,
-            op=op,
-            inputs=[X],
-            reference=ref_backmax
-        )
+    @given(**hu.gcs)
+    def test_reduce_back_max_with_length(self, gc, dc):
+        num_reduce_dim = 1
+        X = np.random.rand(2, 3, 4, 5).astype(np.float32)
+        batch_size = int(np.prod([2, 3, 4, 5][:4 - num_reduce_dim]))
+        d = 120 // batch_size
+        lengths = np.random.randint(1, d, size=batch_size).astype(np.int32)
 
-        # Skip gradient check because it is too unreliable with max
-        # Just check CPU and CUDA have same results
-        Y = np.array(ref_backmax(X)[0]).astype(np.float32)
-        dY = np.array(np.random.rand(*Y.shape)).astype(np.float32)
-        grad_op = core.CreateOperator(
-            "ReduceBackMaxGradient",
-            ["dY", "X", "Y"],
-            ["dX"],
-            num_reduce_dim=num_reduce_dim
-        )
-        self.assertDeviceChecks(dc, grad_op, [dY, X, Y], [0])
+        def ref_max(X, lengths):
+            Y = X.reshape(lengths.size, d)
+            rv = np.zeros((lengths.size, 1)).astype(np.float32)
+            for ii in range(lengths.size):
+                rv[ii] = np.max(Y[ii, :lengths[ii]])
+            return [rv.reshape((2, 3, 4, 5)[:4 - num_reduce_dim])]
 
-    @given(num_reduce_dim=st.integers(0, 4), **hu.gcs)
-    def test_reduce_back_sum(self, num_reduce_dim, dc, gc):
+        self.max_op_test(
+            "ReduceBackMax", num_reduce_dim, gc, dc, [X, lengths],
+            ["X", "lengths"], ref_max)
+
+    @given(**hu.gcs)
+    def test_reduce_back_sum(self, dc, gc):
+        num_reduce_dim = 1
         X = np.random.rand(6, 7, 8, 2).astype(np.float32)
 
         def ref_sum(X):
             return [np.sum(X, axis=(0, 1, 2, 3)[4 - num_reduce_dim:])]
 
-        self.reduce_op_test("ReduceBackSum", ref_sum, X, num_reduce_dim, gc)
+        self.reduce_op_test(
+            "ReduceBackSum", ref_sum, [X], ["input"], num_reduce_dim, gc)
         self.grad_variant_input_test(
             "ReduceBackSumGradient", X, ref_sum, num_reduce_dim)
+
+    @given(**hu.gcs)
+    def test_reduce_back_sum_with_length(self, dc, gc):
+        num_reduce_dim = 1
+        X = np.random.rand(2, 3, 4, 5).astype(np.float32)
+        batch_size = int(np.prod([2, 3, 4, 5][:4 - num_reduce_dim]))
+        d = 120 // batch_size
+        lengths = np.random.randint(1, d, size=batch_size).astype(np.int32)
+
+        def ref_sum(X, lengths):
+            Y = X.reshape(lengths.size, d)
+            rv = np.zeros((lengths.size, 1)).astype(np.float32)
+            for ii in range(lengths.size):
+                rv[ii] = np.sum(Y[ii, :lengths[ii]])
+            return [rv.reshape((2, 3, 4, 5)[:4 - num_reduce_dim])]
+
+        self.reduce_op_test(
+            "ReduceBackSum", ref_sum, [X, lengths], ["input", "lengths"],
+            num_reduce_dim, gc)
 
     @given(num_reduce_dim=st.integers(0, 4), **hu.gcs)
     def test_reduce_back_mean(self, num_reduce_dim, dc, gc):
@@ -184,6 +273,26 @@ class TestReduceFrontReductions(hu.HypothesisTestCase):
         def ref_mean(X):
             return [np.mean(X, axis=(0, 1, 2, 3)[4 - num_reduce_dim:])]
 
-        self.reduce_op_test("ReduceBackMean", ref_mean, X, num_reduce_dim, gc)
+        self.reduce_op_test(
+            "ReduceBackMean", ref_mean, [X], ["input"], num_reduce_dim, gc)
         self.grad_variant_input_test(
             "ReduceBackMeanGradient", X, ref_mean, num_reduce_dim)
+
+    @given(**hu.gcs)
+    def test_reduce_back_mean_with_length(self, dc, gc):
+        num_reduce_dim = 1
+        X = np.random.rand(2, 3, 4, 5).astype(np.float32)
+        batch_size = int(np.prod([2, 3, 4, 5][:4 - num_reduce_dim]))
+        d = 120 // batch_size
+        lengths = np.random.randint(1, d, size=batch_size).astype(np.int32)
+
+        def ref_mean(X, lengths):
+            Y = X.reshape(lengths.size, d)
+            rv = np.zeros((lengths.size, 1)).astype(np.float32)
+            for ii in range(lengths.size):
+                rv[ii] = np.mean(Y[ii, :lengths[ii]])
+            return [rv.reshape((2, 3, 4, 5)[:4 - num_reduce_dim])]
+
+        self.reduce_op_test(
+            "ReduceBackMean", ref_mean, [X, lengths], ["input", "lengths"],
+            num_reduce_dim, gc)


### PR DESCRIPTION
If ops are specified a second input, that would be tensor of ints specifying length of each sample. Ignore entries beyond the lengths when computing the reduction.