### PR TITLE
Fix windows build

### DIFF
--- a/caffe2/operators/reduction_front_back_ops.cc
+++ b/caffe2/operators/reduction_front_back_ops.cc
@@ -74,7 +74,7 @@ void SumReduceDimsGradientOp<CPUContext, true, false>::Compute(
   for (int i = 0; i < rows * cols; i++) {
     int row = i / cols;
     int col = i % cols;
-    if (lengths_data == nullptr or row < lengths_data[col]) {
+    if (lengths_data == nullptr || row < lengths_data[col]) {
       dXdata[i] = dYdata[col];
     } else {
       dXdata[i] = 0;
@@ -94,7 +94,7 @@ void SumReduceDimsGradientOp<CPUContext, false, false>::Compute(
   for (int i = 0; i < rows * cols; i++) {
     int row = i / cols;
     int col = i % cols;
-    if (lengths_data == nullptr or col < lengths_data[row]) {
+    if (lengths_data == nullptr || col < lengths_data[row]) {
       dXdata[i] = dYdata[row];
     } else {
       dXdata[i] = 0;


### PR DESCRIPTION
MSVC doesn't support `and`, `or`, `not`. Reverting back to old style. 

Ref: https://github.com/caffe2/caffe2/pull/2250