### PR TITLE
Fix ONNX backend for MatMul

### DIFF
--- a/caffe2/onnx/backend.h
+++ b/caffe2/onnx/backend.h
@@ -206,6 +206,12 @@ class Caffe2Backend {
       OnnxNode* onnx_node,
       int opset_version);
 
+  Caffe2Ops CreateMatMul(
+      const ModelProto& init_model,
+      const ModelProto& pred_model,
+      OnnxNode* onnx_node,
+      int opset_version);
+
   // LUT related getters
   const std::unordered_map<std::string, std::string>& get_renamed_operators() const;
   const std::unordered_set<std::string>& get_rnn_operators() const;

--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -159,7 +159,6 @@ class Caffe2Backend(Backend):
         'Neg':                   'Negative',
         'BatchNormalization':    'SpatialBN',
         'InstanceNormalization': 'InstanceNorm',
-        'MatMul':                'BatchMatMul',
         'Upsample':              'ResizeNearest',
         'Identity':              'Copy',
         'InstanceNormalization': 'InstanceNorm',
@@ -201,6 +200,7 @@ class Caffe2Backend(Backend):
         'RNN': '_create_rnn',
         'Sqrt': '_create_sqrt',
         'Reciprocal': '_create_reciprocal',
+        'MatMul': '_create_matmul',
     }
 
     # NB: By default, you will use the LATEST definition of the operator,
@@ -959,6 +959,11 @@ class Caffe2Backend(Backend):
             [Y],
             exponent=-1.0,
         )
+
+    @classmethod
+    def _create_matmul(cls, init_model, pred_model, n, opset_version):
+        n.attrs['broadcast'] = 1
+        return cls._common_onnx_node_to_caffe2_op(init_model, pred_model, n, opset_version)
 
     @classmethod
     def _direct_initialize_parameters(cls, initializer, ws, device_option):

--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -159,6 +159,7 @@ class Caffe2Backend(Backend):
         'Neg':                   'Negative',
         'BatchNormalization':    'SpatialBN',
         'InstanceNormalization': 'InstanceNorm',
+        'MatMul':                'BatchMatMul',
         'Upsample':              'ResizeNearest',
         'Identity':              'Copy',
         'InstanceNormalization': 'InstanceNorm',
@@ -962,8 +963,11 @@ class Caffe2Backend(Backend):
 
     @classmethod
     def _create_matmul(cls, init_model, pred_model, n, opset_version):
-        n.attrs['broadcast'] = 1
-        return cls._common_onnx_node_to_caffe2_op(init_model, pred_model, n, opset_version)
+        op = cls._common_onnx_node_to_caffe2_op(init_model, pred_model, n, opset_version)
+        broadcast_arg = op.arg.add()
+        broadcast_arg.name = "broadcast"
+        broadcast_arg.i = 1
+        return op
 
     @classmethod
     def _direct_initialize_parameters(cls, initializer, ws, device_option):


### PR DESCRIPTION
The Caffe2 `BatchMatMul` op requires `broadcast=1` to match ONNX semantics