### PR TITLE
[wip] put caffe2_protos to a standalone target

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -77,10 +77,16 @@ install(FILES ${PROJECT_BINARY_DIR}/caffe2/core/macros.h
 
 # ---[ List of libraries to link with
 
+add_library(caffe2_protos $<TARGET_OBJECTS:Caffe_PROTO> $<TARGET_OBJECTS:Caffe2_PROTO>)
+add_dependencies(caffe2_protos Caffe_PROTO Caffe2_PROTO)
+# TODO: enable using lite protobuf.
+target_link_libraries(caffe2_protos PUBLIC protobuf::libprotobuf)
+target_include_directories(caffe2_protos INTERFACE $<INSTALL_INTERFACE:include>)
+install(TARGETS caffe2_protos EXPORT Caffe2Targets DESTINATION lib)
+
 # Compile exposed libraries.
-add_library(caffe2 ${Caffe2_CPU_SRCS} $<TARGET_OBJECTS:Caffe_PROTO> $<TARGET_OBJECTS:Caffe2_PROTO>)
-add_dependencies(caffe2 Caffe_PROTO Caffe2_PROTO)
-target_link_libraries(caffe2 PUBLIC ${Caffe2_PUBLIC_DEPENDENCY_LIBS})
+add_library(caffe2 ${Caffe2_CPU_SRCS})
+target_link_libraries(caffe2 PUBLIC caffe2_protos ${Caffe2_PUBLIC_DEPENDENCY_LIBS})
 target_link_libraries(caffe2 PRIVATE ${Caffe2_DEPENDENCY_LIBS})
 target_link_libraries(caffe2 PRIVATE ${Caffe2_DEPENDENCY_WHOLE_LINK_LIBS})
 target_include_directories(caffe2 INTERFACE $<INSTALL_INTERFACE:include>)

--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -69,9 +69,6 @@ if ((NOT TARGET protobuf::libprotobuf) AND (NOT TARGET protobuf::libprotobuf-lit
   #     "Please set the proper paths so that I can find protobuf correctly.")
 endif()
 
-# TODO: enable using lite protobuf.
-list(APPEND Caffe2_PUBLIC_DEPENDENCY_LIBS protobuf::libprotobuf)
-
 # Protobuf generated files use <> as inclusion path, so following normal
 # convention we will use SYSTEM inclusion path.
 get_target_property(__tmp protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
This is in order to start isolating protobuf dependency. kicking off a PR for contbuild.