### PR TITLE
Add support for several auto-created observers

### DIFF
--- a/caffe2/core/net.h
+++ b/caffe2/core/net.h
@@ -161,7 +161,7 @@ unique_ptr<NetBase> CreateNet(
     const std::shared_ptr<const NetDef>& net_def,
     Workspace* ws);
 
-void SetGlobalNetObserverCreator(NetObserverCreator creator);
+void AddGlobalNetObserverCreator(NetObserverCreator creator);
 
 } // namespace caffe2
 

--- a/modules/observers/perf_observer.cc
+++ b/modules/observers/perf_observer.cc
@@ -10,7 +10,7 @@ namespace caffe2 {
 namespace {
 
 bool registerGlobalPerfNetObserverCreator(int* /*pargc*/, char*** /*pargv*/) {
-  SetGlobalNetObserverCreator([](NetBase* subject) {
+  AddGlobalNetObserverCreator([](NetBase* subject) {
     return caffe2::make_unique<PerfNetObserver>(subject);
   });
   return true;


### PR DESCRIPTION
This allows to support several auto-attached observers.

This is a sync of an internal diff. 