### PR TITLE
[easy] Hypen as a valid part of model names

### DIFF
--- a/caffe2/python/models/download.py
+++ b/caffe2/python/models/download.py
@@ -154,7 +154,7 @@ def validModelName(name):
     invalid_names = ['__init__']
     if name in invalid_names:
         return False
-    if not re.match("^[/0-9a-zA-Z_]+$", name):
+    if not re.match("^[/0-9a-zA-Z_-]+$", name):
         return False
     return True
 


### PR DESCRIPTION
Detectron model names contains`-`. Tutorial on https://github.com/caffe2/models/tree/master/detectron/e2e_faster_rcnn_R-50-C4_1x won't work if `-` is not recognized as a valid character. 