### PR TITLE
Support ONNX SAME_UPPER

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -194,7 +194,7 @@ float OnnxAttributes::get(const std::string& key) const {
 
 template <> const std::string*
 OnnxAttributes::get(const std::string &key) const {
-  const std::string* value;
+  const std::string* value = nullptr;
   const auto it = onnx_attrs_.find(key);
   if (it != onnx_attrs_.end()) {
     const AttributeProto &attr = *it->second;
@@ -312,7 +312,7 @@ Caffe2Backend::get_renamed_operators() const {
 const std::unordered_map<std::string, std::string>&
 Caffe2Backend::get_renamed_attrs() const {
   const static std::unordered_map<std::string, std::string> kRenamedAttrs{
-      {"kernel_shape", "kernels"}, {"auto_pad", ""}};
+      {"kernel_shape", "kernels"}};
   return kRenamedAttrs;
 }
 
@@ -417,6 +417,7 @@ Caffe2Ops Caffe2Backend::CreateConvPoolOpBase(
 
   if (attributes.HasAttribute("auto_pad")) {
     auto auto_pad = attributes.get<const std::string*>("auto_pad");
+    attributes.remove("auto_pad");
     if (*auto_pad == "VALID") {
       auto* attr = attributes.AddRewrittenAttibute("legacy_pad");
       attr->set_i(LegacyPadding::VALID);

--- a/caffe2/onnx/backend.h
+++ b/caffe2/onnx/backend.h
@@ -81,6 +81,8 @@ template <>
 int64_t OnnxAttributes::get(const std::string& key) const;
 template <>
 float OnnxAttributes::get(const std::string& key) const;
+template <>
+const std::string* OnnxAttributes::get(const std::string& key) const;
 
 template <>
 ::google::protobuf::RepeatedPtrField<std::string> OnnxAttributes::get(

--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -210,7 +210,7 @@ class Caffe2Backend(Backend):
             if 'ONNX_CAFFE2_DEBUG' in os.environ:
                 print("\nC++:\n{}\nPython:\n{}".format(ops, ops2))
 
-            if 'ONNX_CAFFE2_PY' not in os.environ:
+            if 'ONNX_CAFFE2_CPP' in os.environ:
                 workspace.RunOperatorsOnce(ops)
             else:
                 workspace.RunOperatorsOnce(ops2)

--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -17,7 +17,7 @@ from subprocess import Popen, PIPE
 import caffe2
 from caffe2.python import core, workspace, rnn_cell, gru_cell
 from caffe2.python.model_helper import ModelHelper
-from caffe2.proto import caffe2_pb2
+from caffe2.proto import caffe2_pb2, caffe2_legacy_pb2
 import caffe2.python.utils
 import numpy as np
 import onnx
@@ -205,8 +205,15 @@ class Caffe2Backend(Backend):
                 ops2 = init_ops + ops2
                 for op in ops2:
                     op.device_option.CopyFrom(device_option)
+
+            # For testing
+            if 'ONNX_CAFFE2_DEBUG' in os.environ:
                 print("\nC++:\n{}\nPython:\n{}".format(ops, ops2))
-            workspace.RunOperatorsOnce(ops)
+
+            if 'ONNX_CAFFE2_PY' not in os.environ:
+                workspace.RunOperatorsOnce(ops)
+            else:
+                workspace.RunOperatorsOnce(ops2)
             output_values = [workspace.FetchBlob(name) for name in node.output]
             return namedtupledict('Outputs', node.output)(*output_values)
 

--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -17,7 +17,7 @@ from subprocess import Popen, PIPE
 import caffe2
 from caffe2.python import core, workspace, rnn_cell, gru_cell
 from caffe2.python.model_helper import ModelHelper
-from caffe2.proto import caffe2_pb2, caffe2_legacy_pb2
+from caffe2.proto import caffe2_pb2
 import caffe2.python.utils
 import numpy as np
 import onnx
@@ -206,14 +206,8 @@ class Caffe2Backend(Backend):
                 for op in ops2:
                     op.device_option.CopyFrom(device_option)
 
-            # For testing
-            if 'ONNX_CAFFE2_DEBUG' in os.environ:
                 print("\nC++:\n{}\nPython:\n{}".format(ops, ops2))
-
-            if 'ONNX_CAFFE2_CPP' in os.environ:
-                workspace.RunOperatorsOnce(ops)
-            else:
-                workspace.RunOperatorsOnce(ops2)
+            workspace.RunOperatorsOnce(ops)
             output_values = [workspace.FetchBlob(name) for name in node.output]
             return namedtupledict('Outputs', node.output)(*output_values)
 


### PR DESCRIPTION
1) Add support for SAME_UPPER. Looks like Caffe2 does not support SAME_LOWER by default.

2) Fix the bug in C++ ONNX C2 backend. If an attribute is renamed to empty string, we should delete it.

3) ~~Looks like we have some CuDNN fall back issue, will fix it.~~