### PR TITLE
Limit the number of LOG(INFO) for unavailable engine to 64

### DIFF
--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -175,8 +175,12 @@ unique_ptr<OperatorBase> _CreateOperator(
     }
   }
   if (operator_def.engine().size() && !VLOG_IS_ON(1)) {
-    LOG(INFO) << "Engine " << operator_def.engine()
-              << " is not available for operator " << op_type << ".";
+    static int log_occurrences = 0;
+    if (log_occurrences <= 64) {
+      ++log_occurrences;
+      LOG(INFO) << "Engine " << operator_def.engine()
+                << " is not available for operator " << op_type << ".";
+    }
   }
   VLOG(1) << "Using default implementation.";
 


### PR DESCRIPTION
Inlining what glog's LOG_FIRST_N does because not every platform has glog.

