### PR TITLE
Use std::cout instead of LOG(INFO) in TEST_Benchmark implementation

### DIFF
--- a/caffe2/core/net_dag.cc
+++ b/caffe2/core/net_dag.cc
@@ -16,6 +16,7 @@
 
 #include "caffe2/core/net_dag.h"
 
+#include <iostream>
 #include <set>
 #include <stack>
 #include <unordered_map>
@@ -315,8 +316,8 @@ vector<float> DAGNetBase::TEST_Benchmark(
     const int warmup_runs,
     const int main_runs,
     const bool run_individual) {
-  LOG(INFO) << "Starting benchmark.";
-  LOG(INFO) << "Running warmup runs.";
+  std::cout << "Starting benchmark." << std::endl;
+  std::cout << "Running warmup runs." << std::endl;
   CAFFE_ENFORCE(
       warmup_runs >= 0,
       "Number of warm up runs should be non negative, provided ",
@@ -326,7 +327,7 @@ vector<float> DAGNetBase::TEST_Benchmark(
     CAFFE_ENFORCE(Run(), "Warmup run ", i, " has failed.");
   }
 
-  LOG(INFO) << "Main runs.";
+  std::cout << "Main runs." << std::endl;
   CAFFE_ENFORCE(
       main_runs >= 0,
       "Number of main runs should be non negative, provided ",
@@ -337,13 +338,13 @@ vector<float> DAGNetBase::TEST_Benchmark(
     CAFFE_ENFORCE(Run(), "Main run ", i, " has failed.");
   }
   auto millis = timer.MilliSeconds();
-  LOG(INFO) << "Main run finished. Milliseconds per iter: "
+  std::cout << "Main run finished. Milliseconds per iter: "
             << millis / main_runs
-            << ". Iters per second: " << 1000.0 * main_runs / millis;
+            << ". Iters per second: " << 1000.0 * main_runs / millis << std::endl;
 
   if (run_individual) {
-    LOG(INFO) << "DAGNet does not do per-op benchmark. To do so, "
-                 "switch to a simple net type.";
+    std::cout << "DAGNet does not do per-op benchmark. To do so, "
+                 "switch to a simple net type." << std::endl;
   }
   return vector<float>{millis / main_runs};
 }

--- a/caffe2/core/net_simple.cc
+++ b/caffe2/core/net_simple.cc
@@ -17,6 +17,7 @@
 #include "caffe2/core/net_simple.h"
 #include "caffe2/core/net.h"
 
+#include <iostream>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -98,8 +99,9 @@ vector<float> SimpleNet::TEST_Benchmark(
     const int warmup_runs,
     const int main_runs,
     const bool run_individual) {
-  LOG(INFO) << "Starting benchmark.";
-  LOG(INFO) << "Running warmup runs.";
+  /* Use std::cout because logging may be disabled */
+  std::cout << "Starting benchmark." << std::endl;
+  std::cout << "Running warmup runs." << std::endl;
   CAFFE_ENFORCE(
       warmup_runs >= 0,
       "Number of warm up runs should be non negative, provided ",
@@ -109,7 +111,7 @@ vector<float> SimpleNet::TEST_Benchmark(
     CAFFE_ENFORCE(Run(), "Warmup run ", i, " has failed.");
   }
 
-  LOG(INFO) << "Main runs.";
+  std::cout << "Main runs." << std::endl;
   CAFFE_ENFORCE(
       main_runs >= 0,
       "Number of main runs should be non negative, provided ",
@@ -120,9 +122,9 @@ vector<float> SimpleNet::TEST_Benchmark(
     CAFFE_ENFORCE(Run(), "Main run ", i, " has failed.");
   }
   auto millis = timer.MilliSeconds();
-  LOG(INFO) << "Main run finished. Milliseconds per iter: "
+  std::cout << "Main run finished. Milliseconds per iter: "
             << millis / main_runs
-            << ". Iters per second: " << 1000.0 * main_runs / millis;
+            << ". Iters per second: " << 1000.0 * main_runs / millis << std::endl;
 
   vector<float> time_per_op(operators_.size(), 0);
   vector<uint64_t> flops_per_op;
@@ -194,10 +196,10 @@ vector<float> SimpleNet::TEST_Benchmark(
         memory_bytes_str << " (" << to_string(1.0e-6 * param_bytes_per_op[idx])
                          << " MB)";
       }
-      LOG(INFO) << "Operator #" << idx << " (" << print_name << ", " << op_type
+      std::cout << "Operator #" << idx << " (" << print_name << ", " << op_type
                 << ") " << time_per_op[idx] / main_runs << " ms/iter"
                 << flops_str.str() << memory_bytes_str.str()
-                << param_bytes_str.str();
+                << param_bytes_str.str() << std::endl;
       ++idx;
     }
     const std::vector<string> metric(
@@ -212,7 +214,7 @@ vector<float> SimpleNet::TEST_Benchmark(
     metric_per_op_type_vec_vec.emplace_back(&memory_bytes_per_op_type);
     metric_per_op_type_vec_vec.emplace_back(&param_bytes_per_op_type);
     for (int i = 0; i < metric_per_op_type_vec_vec.size(); ++i) {
-      LOG(INFO) << metric[i] << " per operator type:";
+      std::cout << metric[i] << " per operator type:" << std::endl;
       auto* item = metric_per_op_type_vec_vec[i];
       std::vector<std::pair<string, float>> metric_per_op_type_vec(
           (*item).begin(), (*item).end());
@@ -229,13 +231,13 @@ vector<float> SimpleNet::TEST_Benchmark(
         if (total_metric > 0.) {
           percent = (100.0 * op_item.second * normalizer[i] / total_metric);
         }
-        LOG(INFO) << std::setw(15) << std::setfill(' ')
+        std::cout << std::setw(15) << std::setfill(' ')
                   << op_item.second * normalizer[i] << " " << unit[i] << ". "
                   << std::setw(10) << std::setfill(' ') << percent << "%. "
-                  << op_item.first;
+                  << op_item.first << std::endl;
       }
-      LOG(INFO) << std::setw(15) << std::setfill(' ') << total_metric << " "
-                << unit[i] << " in Total";
+      std::cout << std::setw(15) << std::setfill(' ') << total_metric << " "
+                << unit[i] << " in Total" << std::endl;
     }
   }
   // We will reuse time_per_op to return the result of BenchmarkNet.

--- a/caffe2/core/net_simple_async.cc
+++ b/caffe2/core/net_simple_async.cc
@@ -17,6 +17,7 @@
 #include "caffe2/core/net_simple_async.h"
 #include "caffe2/core/net.h"
 
+#include <iostream>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -100,8 +101,8 @@ vector<float> AsyncSimpleNet::TEST_Benchmark(
     const int warmup_runs,
     const int main_runs,
     const bool run_individual) {
-  LOG(INFO) << "Starting benchmark.";
-  LOG(INFO) << "Running warmup runs.";
+  std::cout << "Starting benchmark." << std::endl;
+  std::cout << "Running warmup runs." << std::endl;
   CAFFE_ENFORCE(
       warmup_runs >= 0,
       "Number of warm up runs should be non negative, provided ",
@@ -111,7 +112,7 @@ vector<float> AsyncSimpleNet::TEST_Benchmark(
     CAFFE_ENFORCE(Run(), "Warmup run ", i, " has failed.");
   }
 
-  LOG(INFO) << "Main runs.";
+  std::cout << "Main runs." << std::endl;
   CAFFE_ENFORCE(
       main_runs >= 0,
       "Number of main runs should be non negative, provided ",
@@ -122,13 +123,13 @@ vector<float> AsyncSimpleNet::TEST_Benchmark(
     CAFFE_ENFORCE(Run(), "Main run ", i, " has failed.");
   }
   auto millis = timer.MilliSeconds();
-  LOG(INFO) << "Main run finished. Milliseconds per iter: "
+  std::cout << "Main run finished. Milliseconds per iter: "
             << millis / main_runs
-            << ". Iters per second: " << 1000.0 * main_runs / millis;
+            << ". Iters per second: " << 1000.0 * main_runs / millis << std::endl;
 
   if (run_individual) {
-    LOG(INFO) << "AsyncSimpleNet does not do per-op benchmark. To do so, "
-                 "switch to a simple net type.";
+    std::cout << "AsyncSimpleNet does not do per-op benchmark. To do so, "
+                 "switch to a simple net type." << std::endl;
   }
   return vector<float>{millis / main_runs};
 }

--- a/caffe2/mobile/contrib/arm-compute/core/net_gl.cc
+++ b/caffe2/mobile/contrib/arm-compute/core/net_gl.cc
@@ -18,6 +18,7 @@
 #include "caffe2/mobile/contrib/arm-compute/core/context.h"
 #include "caffe2/core/net.h"
 
+#include <iostream>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -103,8 +104,8 @@ vector<float> GLNet::TEST_Benchmark(
     const int warmup_runs,
     const int main_runs,
     const bool run_individual) {
-  LOG(INFO) << "Starting benchmark.";
-  LOG(INFO) << "Running warmup runs.";
+  std::cout << "Starting benchmark." << std::endl;
+  std::cout << "Running warmup runs." << std::endl;
   CAFFE_ENFORCE(
       warmup_runs >= 0,
       "Number of warm up runs should be non negative, provided ",
@@ -120,7 +121,7 @@ vector<float> GLNet::TEST_Benchmark(
   // Enforce gpu execution
   g_.sync();
 
-  LOG(INFO) << "Main runs.";
+  std::cout << "Main runs." << std::endl;
   CAFFE_ENFORCE(
       main_runs >= 0,
       "Number of main runs should be non negative, provided ",
@@ -133,9 +134,9 @@ vector<float> GLNet::TEST_Benchmark(
   g_.sync();
 
   auto millis = timer.MilliSeconds();
-  LOG(INFO) << "[C2DEBUG] Main run finished. Milliseconds per iter: "
+  std::cout << "[C2DEBUG] Main run finished. Milliseconds per iter: "
             << millis / main_runs
-            << ". Iters per second: " << 1000.0 * main_runs / millis;
+            << ". Iters per second: " << 1000.0 * main_runs / millis << std::endl;
 
   vector<float> time_per_op(operators_.size(), 0);
   vector<uint64_t> flops_per_op(operators_.size(), 0);
@@ -190,12 +191,12 @@ vector<float> GLNet::TEST_Benchmark(
                   << to_string(1.0e-6 * flops_per_op[idx] / time_per_op[idx])
                   << " GFLOPS)";
       }
-      LOG(INFO) << "[C2DEBUG] Operator #" << idx << " (" << print_name << ", " << op_type
+      std::cout << "[C2DEBUG] Operator #" << idx << " (" << print_name << ", " << op_type
                 << ") " << time_per_op[idx] / main_runs << " ms/iter"
-                << flops_str.str();
+                << flops_str.str() << std::endl;
       ++idx;
     }
-    LOG(INFO) << "[C2DEBUG] Time per operator type:";
+    std::cout << "[C2DEBUG] Time per operator type:" << std::endl;
     // sort by decreasing time spending.
     std::vector<std::pair<string, float>> time_per_op_type_vec(
         time_per_op_type.begin(), time_per_op_type.end());
@@ -204,8 +205,8 @@ vector<float> GLNet::TEST_Benchmark(
         time_per_op_type_vec.end(),
         PairLargerThan<string, float>);
     for (const auto& item : time_per_op_type_vec) {
-      LOG(INFO) << "[C2DEBUG] " << std::setw(15) << std::setfill(' ') << item.second / main_runs
-                << " " << item.first;
+      std::cout << "[C2DEBUG] " << std::setw(15) << std::setfill(' ') << item.second / main_runs
+                << " " << item.first << std::endl;
     }
   }
   // We will reuse time_per_op to return the result of BenchmarkNet.


### PR DESCRIPTION
LOG(INFO) can be stripped out at compile-time or disabled at run-time, but there're hardly use-cases where we want to call TEST_Benchmark, yet don't want to see the result. Additionally, on Android, LOG(INFO) writes to logcat, which is OK for errors/warnings, but inconvenient for benchmarking results, as on new phones logcat spawns logs like crazy.

