### PR TITLE
Export number of iterations of AtomicIterOp

### DIFF
--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -1697,10 +1697,18 @@ class TestOperators(hu.HypothesisTestCase):
             np.asarray([initial_iters]).astype(np.int64))
         concurrent_steps = core.ExecutionStep("concurrent_steps",
                                               num_iter=num_iters)
+        sre_ops = []
         for i in range(num_nets):
             net = core.Net("net_{}".format(i))
             net.AtomicIter([iter_mutex, "iter"], ["iter"])
             step = core.ExecutionStep("step", [net])
+            sre_op = net.StatRegistryExport(
+                [], [
+                    "stat_key_{}".format(i), "stat_value_{}".format(i),
+                    "stat_ts_{}".format(i)
+                ]
+            )
+            sre_ops.append(sre_op)
             concurrent_steps.AddSubstep(step)
 
         concurrent_steps.SetConcurrentSubsteps(True)
@@ -1712,6 +1720,13 @@ class TestOperators(hu.HypothesisTestCase):
         iters = self.ws.blobs[("iter")].fetch()
         self.assertEqual(iters.dtype, np.int64)
         self.assertEqual(iters[0], initial_iters + num_iters * num_nets)
+
+        for i in range(num_nets):
+            stat_key = self.ws.blobs[("stat_key_{}".format(i))].fetch()
+            self.assertEqual(b'atomic_iter/stats/iter/num_iter', stat_key[0])
+            stat_value = self.ws.blobs[("stat_value_{}".format(i))].fetch()
+            self.assertEqual(np.int64, stat_value.dtype)
+            self.assertEqual(1, stat_value[0])
 
     @given(a=hu.tensor(),
            src=st.sampled_from(list(viewkeys(_NUMPY_TYPE_TO_ENUM))),


### PR DESCRIPTION
Export number of iterations through a CAFFE_EXPORTED_STAT.  hypothesis_test.py has been updated to test counter with a fix to clear global stats before test starts.