### PR TITLE
Skip DepthToSpace and MaxPool same mode onnx backend tests

### DIFF
--- a/caffe2/python/onnx/tests/onnx_backend_test.py
+++ b/caffe2/python/onnx/tests/onnx_backend_test.py
@@ -36,7 +36,8 @@ backend_test = onnx.backend.test.BackendTest(c2, __name__)
 backend_test.exclude(r'(test_hardsigmoid'  # Does not support Hardsigmoid.
                      '|test_mean|test_hardmax'  # Does not support Mean and Hardmax.
                      '|test_cast.*FLOAT16.*'  # Does not support Cast on Float16.
-                     '|test_averagepool_.*same.*)')  # Does not support Cast on Float16.
+                     '|test_depthtospace.*'  # Does not support DepthToSpace.
+                     '|test_.*pool_.*same.*)')  # Does not support pool same.
 
 # Skip vgg to speed up CI
 if 'JENKINS_URL' in os.environ:


### PR DESCRIPTION
To make sure CI passes when test cases are checked in.