### PR TITLE
Log NNPACK profile to std::cout instead of LOG(INFO)

### DIFF
--- a/caffe2/share/contrib/nnpack/conv_op.cc
+++ b/caffe2/share/contrib/nnpack/conv_op.cc
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+
+#include <iostream>
+
 #include "caffe2/core/common.h"
 
 
@@ -405,7 +408,7 @@ bool NNPACKConvOp::RunOnDeviceWithOrderNCHW() {
               profile.output_transform * 1E3,
               gflops);
           CAFFE_ENFORCE(ret > 0);
-          LOG(INFO) << buffer;
+          std::cout << buffer << std::endl;
         }
       }
     }


### PR DESCRIPTION
Similar to #2333, but for NNPACK bindings

