### PR TITLE
Fix ReduceMean/ReduceSum performance by specializing Eigen implementations for common shapes

### DIFF
--- a/caffe2/operators/reduce_ops.h
+++ b/caffe2/operators/reduce_ops.h
@@ -74,6 +74,7 @@ class ReduceOpBase : public Operator<Context> {
         Y->template mutable_data<T>(),
         Y_size,
         axes_,
+        y_dims,
         keepdims_);
   }
 
@@ -85,6 +86,7 @@ class ReduceOpBase : public Operator<Context> {
       T* Y_data,
       const TIndex Y_size,
       vector<int>& axes,
+      vector<TIndex>& Y_dims,
       int keepdims) = 0;
 
  private:
@@ -108,6 +110,7 @@ class ReduceSumOp : public ReduceOpBase<T, Context> {
       T* Y_data,
       const TIndex Y_size,
       vector<int>& axes,
+      vector<TIndex>& Y_dims,
       int keepdims) override;
 };
 
@@ -127,6 +130,7 @@ class ReduceMeanOp : public ReduceOpBase<T, Context> {
       T* Y_data,
       const TIndex Y_size,
       vector<int>& axes,
+      vector<TIndex>& Y_dims,
       int keepdims) override;
 };
 

--- a/caffe2/python/operator_test/reduce_ops_test.py
+++ b/caffe2/python/operator_test/reduce_ops_test.py
@@ -69,6 +69,33 @@ class TestReduceOps(hu.HypothesisTestCase):
             reduce_op_test("ReduceSum", reduce_sum_ref, data, axes, keepdims,
                            gc)
 
+        for axes in it.combinations(range(3), 2):
+            data = np.random.randn(d0, d1, d2).astype(np.float32)
+
+            reduce_op_test("ReduceMean", reduce_mean_ref, data, axes, keepdims,
+                           gc)
+
+            reduce_op_test("ReduceSum", reduce_sum_ref, data, axes, keepdims,
+                           gc)
+
+        for axes in it.combinations(range(2), 2):
+            data = np.random.randn(d0, d1).astype(np.float32)
+
+            reduce_op_test("ReduceMean", reduce_mean_ref, data, axes, keepdims,
+                           gc)
+
+            reduce_op_test("ReduceSum", reduce_sum_ref, data, axes, keepdims,
+                           gc)
+
+        for axes in it.combinations(range(1), 1):
+            data = np.random.randn(d0).astype(np.float32)
+
+            reduce_op_test("ReduceMean", reduce_mean_ref, data, axes, keepdims,
+                           gc)
+
+            reduce_op_test("ReduceSum", reduce_sum_ref, data, axes, keepdims,
+                           gc)
+
 
 class TestReduceFrontReductions(hu.HypothesisTestCase):
     def grad_variant_input_test(self, grad_op_name, X, ref, num_reduce_dim):


### PR DESCRIPTION
…ommon shapes


# Perf analysis

Setup: Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz

Reduce [2, 100100] tensor to [100100]. This is a shape seen in the LATTE output projection. Mean should amount to 200 kFLOPs (add + divide per column) and sum should be 100 kFLOPs (add per column)

**Before**

`benchReduceMean`

- 12.4465 ms/iter
- 16.7 MFLOP/s throughput

`benchReduceSum`

- 12.3889 ms/iter
- 8 MFLOP/s thoroughput

**After**

`benchReduceMean`

- 0.218622 ms/iter
- 914 MFLOP/s

`benchReduceSum`

- 0.209059 ms/iter
- 478 MFLOP/s