### PR TITLE
Unit test for NNPACK implicit GEMM convolution with pre-compute trans…

### DIFF
--- a/caffe2/share/contrib/nnpack/conv_op_test.cc
+++ b/caffe2/share/contrib/nnpack/conv_op_test.cc
@@ -312,6 +312,30 @@ TEST(NNPACK, Conv_1x1s1_precompute) {
   }
 }
 
+TEST(NNPACK, Conv_3x3s2) {
+  for (int i = 0; i < kIters; ++i) {
+    runConv(3, 3, 2, 2,
+        1 /* groups */,
+        "AUTO",
+        randInt(3, 16),
+        randInt(3, 16),
+        1 /* batch size */);
+  }
+}
+
+TEST(NNPACK, Conv_3x3s2_precompute) {
+  for (int i = 0; i < kIters; ++i) {
+    int group = randInt(1, 2);
+    runConv(3, 3, 2, 2,
+        1 /* groups */,
+        "AUTO",
+        randInt(3, 16),
+        randInt(3, 16),
+        1 /* batch size */,
+        "PRECOMPUTE");
+  }
+}
+
 TEST(NNPACK, Conv_NxNs_grouped) {
   for (int i = 0; i < kIters; ++i) {
     int group = randInt(2, 3);


### PR DESCRIPTION
…forms (prepacking)

Prepacking was added to NNPACK very recently, and Caffe2 didn't have a unit test for this case.
While investigating a related bug, I added a unit test to check if it could be broken.

