### PR TITLE
Handle the ONNX opset for BatchNormalization

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -790,8 +790,7 @@ Caffe2Ops Caffe2Backend::CreateBatchNormalization(OnnxNode* onnx_node, int opset
     attributes.remove("consumed_inputs");
   }
 
-  auto c2_op = CommonOnnxNodeToCaffe2Ops(onnx_node, opset_version);
-  return c2_op;
+  return CommonOnnxNodeToCaffe2Ops(onnx_node, opset_version);
 }
 
 Caffe2Ops Caffe2Backend::CreateMatMul(OnnxNode* onnx_node, int opset_version) {

--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -353,6 +353,7 @@ Caffe2Backend::get_special_operators() const {
               {"LogSoftmax", &Caffe2Backend::CreateLogSoftmax},
               {"Slice", &Caffe2Backend::CreateSlice},
               {"Reciprocal", &Caffe2Backend::CreateReciprocal},
+              {"BatchNormalization", &Caffe2Backend::CreateBatchNormalization},
               {"MatMul", &Caffe2Backend::CreateMatMul}};
   return kSpecialOperators;
 }
@@ -780,6 +781,17 @@ Caffe2Ops Caffe2Backend::CreateSlice(OnnxNode* onnx_node, int opset_version) {
   }
 
   return ret;
+}
+
+Caffe2Ops Caffe2Backend::CreateBatchNormalization(OnnxNode* onnx_node, int opset_version) {
+  const auto& node = onnx_node->node;
+  if (opset_version < 6) {
+    auto& attributes = onnx_node->attributes;
+    attributes.remove("consumed_inputs");
+  }
+
+  auto c2_op = CommonOnnxNodeToCaffe2Ops(onnx_node, opset_version);
+  return c2_op;
 }
 
 Caffe2Ops Caffe2Backend::CreateMatMul(OnnxNode* onnx_node, int opset_version) {

--- a/caffe2/onnx/backend.h
+++ b/caffe2/onnx/backend.h
@@ -62,9 +62,14 @@ class OnnxAttributes {
     }
   }
 
-  bool remove(const std::string& key) {
-    if (onnx_attrs_.erase(key)) return true;
-    return false;
+  const AttributeProto* remove(const std::string& key) {
+    const AttributeProto* result = nullptr;
+    auto iter = onnx_attrs_.find(key);
+    if (iter != onnx_attrs_.end()) {
+      result = iter->second;
+      onnx_attrs_.erase(iter);
+    }
+    return result;
   }
 
  private:

--- a/caffe2/onnx/backend.h
+++ b/caffe2/onnx/backend.h
@@ -62,6 +62,11 @@ class OnnxAttributes {
     }
   }
 
+  bool remove(const std::string& key) {
+    if (onnx_attrs_.erase(key)) return true;
+    return false;
+  }
+
  private:
   std::unordered_map<std::string, const AttributeProto*> onnx_attrs_;
   std::unordered_map<std::string, AttributeProto> rewritten_onnx_attrs_;
@@ -153,6 +158,8 @@ class Caffe2Backend {
   Caffe2Ops CreateSlice(OnnxNode* onnx_node, int opset_version);
 
   Caffe2Ops CreateReciprocal(OnnxNode* onnx_node, int opset_version);
+
+  Caffe2Ops CreateBatchNormalization(OnnxNode* onnx_node, int opset_version);
 
   Caffe2Ops CreateMatMul(OnnxNode* onnx_node, int opset_version);
 


### PR DESCRIPTION
Remove consumed_inputs before converted to Caffe2 ops.