### PR TITLE
[easy] Minor improvement of the code quality in caffe2/onnx

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -1,8 +1,24 @@
-#include "backend.h"
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
-#include "device.h"
-#include "helper.h"
+#include "caffe2/onnx/backend.h"
+#include "caffe2/onnx/device.h"
+#include "caffe2/onnx/helper.h"
 #include "onnx/checker.h"
 #include "onnx/defs/schema.h"
 #include "onnx/optimizer/optimize.h"
@@ -10,7 +26,6 @@
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl_lite.h"
 
-#include <cassert>
 #include <cmath>
 #include <iostream>
 #include <sstream>
@@ -38,7 +53,7 @@ bool TryConvertingTensorRawValues(
   }
 
   size_t raw_size = onnx_tensor.raw_data().size();
-  assert(raw_size % sizeof(T) == 0);
+  CAFFE_ENFORCE(raw_size % sizeof(T) == 0);
 
   size_t num_elements = raw_size / sizeof(T);
   const void* src_ptr = static_cast<const void*>(onnx_tensor.raw_data().data());
@@ -89,7 +104,7 @@ ModelProto OptimizeOnnx(const ModelProto& input, bool init) {
   } else {
     passes.emplace_back("split_predict");
   }
-  return ONNX_NAMESPACE::optimization::Optimize(input, passes);
+  return ::ONNX_NAMESPACE::optimization::Optimize(input, passes);
 }
 
 template <class T, class U>
@@ -105,10 +120,10 @@ U LookUpWithDefault(
   }
 }
 
-const ONNX_NAMESPACE::OpSchema& GetOnnxSchema(const std::string& key) {
-  const auto* schema = ONNX_NAMESPACE::OpSchemaRegistry::Schema(key);
+const ::ONNX_NAMESPACE::OpSchema& GetOnnxSchema(const std::string& key) {
+  const auto* schema = ::ONNX_NAMESPACE::OpSchemaRegistry::Schema(key);
   if (!schema) {
-    throw std::runtime_error("No ONNX schema registered for '" + key + "'!");
+    CAFFE_THROW("No ONNX schema registered for '" + key + "'!");
   }
   return *schema;
 }
@@ -172,7 +187,7 @@ void CopyOnnxAttrValueToCaffe2Arg(
   } else if (attr.strings_size()) {
     arg->mutable_strings()->CopyFrom(attr.strings());
   } else {
-    throw std::runtime_error(
+    CAFFE_THROW(
         caffe2::MakeString("Unsupported ONNX attribute: ", attr.name()));
   }
 }
@@ -365,7 +380,7 @@ Caffe2Backend::get_special_operators() const {
 Caffe2Ops Caffe2Backend::CreateConstant(
     OnnxNode* onnx_node,
     int opset_version) {
-  assert(onnx_node->node.output_size() == 1);
+  CAFFE_ENFORCE(onnx_node->node.output_size() == 1);
 
   Caffe2Ops ret;
   auto* c2_op = ret.ops.Add();
@@ -438,7 +453,7 @@ Caffe2Ops Caffe2Backend::CreateConvPoolOpBase(
 
 Caffe2Ops Caffe2Backend::CreateReshape(OnnxNode* onnx_node, int opset_version) {
   auto c2_op = CommonOnnxNodeToCaffe2Ops(onnx_node, opset_version);
-  assert(c2_op.ops.size() == 1);
+  CAFFE_ENFORCE(c2_op.ops.size() == 1);
   auto* op = c2_op.ops.Mutable(0);
   op->add_output(DummyName::NewDummyName());
 
@@ -450,8 +465,7 @@ Caffe2Ops Caffe2Backend::CreateReciprocal(
     int opset_version) {
   const auto& node = onnx_node->node;
   if (node.input_size() != 1 || node.output_size() != 1) {
-    throw std::runtime_error(
-        "Caffe2 Reciprocal should have 1 input and 1 output");
+    CAFFE_THROW("Caffe2 Reciprocal should have 1 input and 1 output");
   }
 
   Caffe2Ops ret;
@@ -467,7 +481,7 @@ Caffe2Ops Caffe2Backend::CreateReciprocal(
 Caffe2Ops Caffe2Backend::CreateGather(OnnxNode* onnx_node, int opset_version) {
   const auto& node = onnx_node->node;
   if (node.input_size() < 2 || node.output_size() < 1) {
-    throw std::runtime_error("Caffe2 Gather should have 2 inputs and 1 output");
+    CAFFE_THROW("Caffe2 Gather should have 2 inputs and 1 output");
   }
 
   Caffe2Ops ret;
@@ -485,7 +499,7 @@ Caffe2Ops Caffe2Backend::CreateGather(OnnxNode* onnx_node, int opset_version) {
   } else if (axis == 1) {
     BuildOperator(c2_op, "BatchGather", inputs, outputs);
   } else {
-    throw std::runtime_error(caffe2::MakeString(
+    CAFFE_THROW(caffe2::MakeString(
         "Caffe2 only supports Gather with axis being 1 or 2, ",
         "whereas axis is ",
         axis));
@@ -497,7 +511,7 @@ Caffe2Ops Caffe2Backend::CreateGather(OnnxNode* onnx_node, int opset_version) {
 Caffe2Ops Caffe2Backend::CreateGemm(OnnxNode* onnx_node, int opset_version) {
   const auto& node = onnx_node->node;
   if (node.input_size() < 3 || node.output_size() < 1) {
-    throw std::runtime_error("Caffe2 Gemm should have 3 inputs and 1 output");
+    CAFFE_THROW("Caffe2 Gemm should have 3 inputs and 1 output");
   }
 
   Caffe2Ops ret;
@@ -577,7 +591,7 @@ Caffe2Ops Caffe2Backend::CreatePad(OnnxNode* onnx_node, int opset_version) {
   // Guard the invalid (negative) pads attribute.
   for (const auto i : pads) {
     if (i < 0) {
-      throw std::runtime_error(caffe2::MakeString(
+      CAFFE_THROW(caffe2::MakeString(
           "ONNX does not support negative pads in Pad, but get ", str));
     }
   }
@@ -586,7 +600,7 @@ Caffe2Ops Caffe2Backend::CreatePad(OnnxNode* onnx_node, int opset_version) {
   // non-negative
   if (!(pads.size() == 8 &&
         (pads.Get(0) + pads.Get(1) + pads.Get(4) + pads.Get(5) == 0))) {
-    throw std::runtime_error(caffe2::MakeString(
+    CAFFE_THROW(caffe2::MakeString(
         "Caffe2 only supports padding 2D Tensor, whereas padding is ", str));
   }
 
@@ -605,7 +619,7 @@ Caffe2Ops Caffe2Backend::CreatePad(OnnxNode* onnx_node, int opset_version) {
 // 1 output.
 Caffe2Ops Caffe2Backend::CreateConcat(OnnxNode* onnx_node, int opset_version) {
   auto c2_op = CommonOnnxNodeToCaffe2Ops(onnx_node, opset_version);
-  assert(c2_op.ops.size() == 1);
+  CAFFE_ENFORCE(c2_op.ops.size() == 1);
   auto* op = c2_op.ops.Mutable(0);
   op->add_output(DummyName::NewDummyName());
 
@@ -617,7 +631,7 @@ Caffe2Ops Caffe2Backend::CreateLogSoftmax(
     int opset_version) {
   const auto& node = onnx_node->node;
   if (node.input_size() < 1 || node.output_size() < 1) {
-    throw std::runtime_error("LogSoftmax should have 1 input and 1 output");
+    CAFFE_THROW("LogSoftmax should have 1 input and 1 output");
   }
   auto axis = onnx_node->attributes.get<int64_t>("axis", 1L);
   caffe2::Argument arg_axis;
@@ -636,7 +650,7 @@ Caffe2Ops Caffe2Backend::CreateLogSoftmax(
 
 Caffe2Ops Caffe2Backend::CreateSlice(OnnxNode* onnx_node, int opset_version) {
   auto op_tmp = CommonOnnxNodeToCaffe2Ops(onnx_node, opset_version);
-  assert(op_tmp.ops.size() == 1);
+  CAFFE_ENFORCE(op_tmp.ops.size() == 1);
   auto* op = op_tmp.ops.Mutable(0);
   std::unordered_map<std::string, caffe2::Argument*> args;
   for (auto& arg : *op->mutable_arg()) {
@@ -678,7 +692,7 @@ Caffe2Ops Caffe2Backend::CreateSlice(OnnxNode* onnx_node, int opset_version) {
     }
   }
 
-  assert(op->input_size() >= 1);
+  CAFFE_ENFORCE(op->input_size() >= 1);
   auto data = op->input(0);
   auto shape_tensor = DummyName::NewDummyName();
   Caffe2Ops ret;
@@ -783,7 +797,9 @@ Caffe2Ops Caffe2Backend::CreateSlice(OnnxNode* onnx_node, int opset_version) {
   return ret;
 }
 
-Caffe2Ops Caffe2Backend::CreateBatchNormalization(OnnxNode* onnx_node, int opset_version) {
+Caffe2Ops Caffe2Backend::CreateBatchNormalization(
+    OnnxNode* onnx_node,
+    int opset_version) {
   const auto& node = onnx_node->node;
   if (opset_version < 6) {
     auto& attributes = onnx_node->attributes;
@@ -796,11 +812,11 @@ Caffe2Ops Caffe2Backend::CreateBatchNormalization(OnnxNode* onnx_node, int opset
 Caffe2Ops Caffe2Backend::CreateMatMul(OnnxNode* onnx_node, int opset_version) {
   const auto& node = onnx_node->node;
   if (node.input_size() != 2) {
-    throw std::runtime_error("MatMul should have 2 inputs");
+    CAFFE_THROW("MatMul should have 2 inputs");
   }
 
   auto c2_op = CommonOnnxNodeToCaffe2Ops(onnx_node, opset_version);
-  assert(c2_op.ops.size() == 1);
+  CAFFE_ENFORCE(c2_op.ops.size() == 1);
   auto* op = c2_op.ops.Mutable(0);
   auto* broadcast_arg = op->add_arg();
   broadcast_arg->set_name("broadcast");
@@ -859,7 +875,7 @@ Caffe2Ops Caffe2Backend::CommonOnnxNodeToCaffe2Ops(
   auto broken_version = LookUpWithDefault(
       get_broken_operators(), onnx_op_type, std::numeric_limits<int>::max());
   if (broken_version <= opset_version) {
-    throw std::runtime_error(caffe2::MakeString(
+    CAFFE_THROW(caffe2::MakeString(
         "Don't know how to translate op ",
         onnx_op_type,
         " in ONNX operator set v",
@@ -870,7 +886,7 @@ Caffe2Ops Caffe2Backend::CommonOnnxNodeToCaffe2Ops(
   c2_op->set_type(
       LookUpWithDefault(get_renamed_operators(), onnx_op_type, onnx_op_type));
   if (!IsOperator(c2_op->type())) {
-    throw std::runtime_error(
+    CAFFE_THROW(
         caffe2::MakeString("Don't know how to translate op ", onnx_op_type));
   }
 
@@ -975,7 +991,7 @@ void Caffe2Backend::OnnxToCaffe2(
           }
           net->mutable_external_input()->MergeFrom(c2ops.interface_blobs);
         } else {
-          throw std::runtime_error(caffe2::MakeString(
+          CAFFE_THROW(caffe2::MakeString(
               "Don't know how to convert ",
               node.op_type(),
               " without enough extra preconverted string"));
@@ -1009,7 +1025,7 @@ Caffe2BackendRep* Caffe2Backend::Prepare(
   Caffe2BackendRep* rep = new Caffe2BackendRep();
   ModelProto onnx_model;
   ParseProtobufFromLargeString(onnx_model_str, &onnx_model);
-  ONNX_NAMESPACE::checker::check_model(onnx_model);
+  ::ONNX_NAMESPACE::checker::check_model(onnx_model);
 
   int opset_version = -1;
   for (const auto& imp : onnx_model.opset_import()) {
@@ -1031,7 +1047,7 @@ Caffe2BackendRep* Caffe2Backend::Prepare(
   }
   if (opset_version < 0) {
     if (onnx_model.ir_version() >= 0x00000003) {
-      throw std::runtime_error(
+      CAFFE_THROW(
           "Model with IR version >= 3 did not specify ONNX operator set "
           "version (onnx-caffe2 requires it)");
     } else {
@@ -1072,7 +1088,7 @@ void Caffe2Backend::BuildTensorFillingOp(
   CAFFE_ENFORCE(!fill_name.empty());
 
   if (onnx_tensor.has_segment()) {
-    throw std::runtime_error("Currently not supporting loading segments.");
+    CAFFE_THROW("Currently not supporting loading segments.");
   }
 
   auto* c2_values = c2_op->add_arg();
@@ -1141,7 +1157,7 @@ void Caffe2Backend::BuildTensorFillingOp(
     auto* strings = c2_values->mutable_strings();
     strings->CopyFrom(onnx_tensor.string_data());
   } else {
-    throw std::runtime_error(
+    CAFFE_THROW(
         "unrecognized tensor type: " +
         TensorProto::DataType_Name(onnx_tensor.data_type()));
   }

--- a/caffe2/onnx/backend.h
+++ b/caffe2/onnx/backend.h
@@ -1,8 +1,24 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
-#include "backend_rep.h"
+#include "caffe2/onnx/backend_rep.h"
+#include "caffe2/onnx/device.h"
 #include "caffe2/proto/caffe2.pb.h"
-#include "device.h"
 #include "onnx/onnx_pb.h"
 
 #include <functional>
@@ -13,11 +29,11 @@
 namespace caffe2 {
 namespace onnx {
 
-using ONNX_NAMESPACE::AttributeProto;
-using ONNX_NAMESPACE::GraphProto;
-using ONNX_NAMESPACE::ModelProto;
-using ONNX_NAMESPACE::NodeProto;
-using ONNX_NAMESPACE::TensorProto;
+using ::ONNX_NAMESPACE::AttributeProto;
+using ::ONNX_NAMESPACE::GraphProto;
+using ::ONNX_NAMESPACE::ModelProto;
+using ::ONNX_NAMESPACE::NodeProto;
+using ::ONNX_NAMESPACE::TensorProto;
 
 // \brief This struct holds the converted ops after the onnx->c2 conversion.
 // Notice that for RNN ops, it may create ops in init_net. Hence we have the
@@ -112,6 +128,7 @@ class Caffe2Backend {
   bool SupportOp(const std::string tyep) const;
 
   Caffe2Ops ConvertNode(const std::string& node_str, int opset_version);
+
  private:
   using SpecialOpConverter = Caffe2Ops (Caffe2Backend::*)(OnnxNode*, int);
 

--- a/caffe2/onnx/backend_rep.cc
+++ b/caffe2/onnx/backend_rep.cc
@@ -1,5 +1,21 @@
-#include "backend_rep.h"
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "caffe2/core/common.h"
+#include "caffe2/onnx/backend_rep.h"
 
 #include <iostream>
 

--- a/caffe2/onnx/backend_rep.h
+++ b/caffe2/onnx/backend_rep.h
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include "caffe2/core/predictor.h"

--- a/caffe2/onnx/device.cc
+++ b/caffe2/onnx/device.cc
@@ -1,4 +1,20 @@
-#include "device.h"
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "caffe2/onnx/device.h"
 
 #include <cstdlib>
 #include <unordered_map>

--- a/caffe2/onnx/device.h
+++ b/caffe2/onnx/device.h
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include <functional>

--- a/caffe2/onnx/helper.cc
+++ b/caffe2/onnx/helper.cc
@@ -1,4 +1,20 @@
-#include "helper.h"
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "caffe2/onnx/helper.h"
 
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"

--- a/caffe2/onnx/helper.h
+++ b/caffe2/onnx/helper.h
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include <set>


### PR DESCRIPTION
- Add license comment
- Use `CAFFE_THROW` and `CAFFE_ENFORCE`
- Use `::ONNX_NAMESPACE` instead of `ONNX_NAMESPACE` to avoid potential namespace clash