### PR TITLE
Commit the part of protobuf that is already safe to patch

### DIFF
--- a/caffe2/utils/proto_utils.cc
+++ b/caffe2/utils/proto_utils.cc
@@ -33,7 +33,20 @@
 
 using ::google::protobuf::MessageLite;
 
+namespace caffe {
+// Wrapper functions for protobuf's GetEmptyStringALreadyInited() function
+// In order to avoid duplicated global variable in the case when protobuf
+// is built with hidden visibility.
+const ::std::string& GetEmptyStringAlreadyInited() {
+  return ::google::protobuf::internal::GetEmptyStringAlreadyInited();
+}
+}  // namespace caffe
+
 namespace caffe2 {
+
+const ::std::string& GetEmptyStringAlreadyInited() {
+  return ::google::protobuf::internal::GetEmptyStringAlreadyInited();
+}
 
 void ShutdownProtobufLibrary() {
   ::google::protobuf::ShutdownProtobufLibrary();

--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -160,6 +160,7 @@ function(caffe2_protobuf_generate_cpp_py srcs_var hdrs_var python_var)
       COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}"
       COMMAND ${CAFFE2_PROTOC_EXECUTABLE} -I${PROJECT_SOURCE_DIR} --cpp_out=${DLLEXPORT_STR}${PROJECT_BINARY_DIR} ${abs_fil}
       COMMAND ${CAFFE2_PROTOC_EXECUTABLE} -I${PROJECT_SOURCE_DIR} --python_out "${PROJECT_BINARY_DIR}" ${abs_fil}
+      COMMAND ${CMAKE_COMMAND} -DFILENAME=${CMAKE_CURRENT_BINARY_DIR}/${fil_we}.pb.h -P ${PROJECT_SOURCE_DIR}/cmake/ProtoBufPatch.cmake
       DEPENDS ${CAFFE2_PROTOC_EXECUTABLE} ${abs_fil}
       COMMENT "Running C++/Python protocol buffer compiler on ${fil}" VERBATIM )
   endforeach()

--- a/cmake/ProtoBufPatch.cmake
+++ b/cmake/ProtoBufPatch.cmake
@@ -1,0 +1,22 @@
+# CMake file to replace the string contents in Caffe2 proto.
+# Usage example:
+#   cmake -DFILENAME=caffe2.pb.h -P string_replacement.cmake
+
+file(READ ${FILENAME} content)
+string(
+    REPLACE
+    "::google::protobuf::internal::GetEmptyStringAlreadyInited"
+    "GetEmptyStringAlreadyInited"
+    content
+    "${content}")
+string(REPLACE
+	"namespace caffe2 {"
+	"namespace caffe2 { const ::std::string& GetEmptyStringAlreadyInited(); "
+	content
+	"${content}")
+string(REPLACE
+	"namespace caffe {"
+	"namespace caffe { const ::std::string& GetEmptyStringAlreadyInited(); "
+	content
+	"${content}")
+file(WRITE ${FILENAME} "${content}")


### PR DESCRIPTION
This helps the effort to hide protobuf visibility. Kicking a contbuild. Instead of sed, cmake would make it more platform independent.