### PR TITLE
Initialize cpuinfo in the thread pool

### DIFF
--- a/caffe2/utils/threadpool/ThreadPool.cc
+++ b/caffe2/utils/threadpool/ThreadPool.cc
@@ -41,6 +41,7 @@ constexpr size_t kDefaultMinWorkSize = 80;
 #endif
 
 std::unique_ptr<ThreadPool> ThreadPool::defaultThreadPool() {
+  CAFFE_ENFORCE(cpuinfo_initialize(), "cpuinfo initialization failed");
   int numThreads = cpuinfo_get_processors_count();
 
   bool applyCap = false;

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -97,6 +97,13 @@ if (NOT TARGET cpuinfo)
   set(CPUINFO_BUILD_MOCK_TESTS OFF CACHE BOOL "")
   set(CPUINFO_BUILD_BENCHMARKS OFF CACHE BOOL "")
   set(CPUINFO_LIBRARY_TYPE "static" CACHE STRING "")
+  if(MSVC)
+    if (CAFFE2_USE_MSVC_STATIC_RUNTIME)
+      set(CPUINFO_RUNTIME_TYPE "static" CACHE STRING "")
+    else()
+      set(CPUINFO_RUNTIME_TYPE "shared" CACHE STRING "")
+    endif()
+  endif()
   add_subdirectory(
     "${CPUINFO_SOURCE_DIR}"
     "${CONFU_DEPENDENCIES_BINARY_DIR}/cpuinfo")


### PR DESCRIPTION
Thread pool called cpuinfo_get_processors_count() without initializing cpuinfo. Only by chance it didn't regress performance: threadpool is initialized after NNPACK, and NNPACK initializes cpuinfo itself.

This commit also updates cpuinfo to a version that aborts with a fatal error if its used uninitialized.