### PR TITLE
Make error messages in net_dag more clear

### DIFF
--- a/caffe2/core/net_dag.cc
+++ b/caffe2/core/net_dag.cc
@@ -193,12 +193,12 @@ void DAGNetBase::HandleException(
       operator_nodes_[operator_idx].operator_->debug_def().name();
   const std::string& operator_type =
       operator_nodes_[operator_idx].operator_->debug_def().type();
-  const char* prefix = "Exception from operator '";
+  const char* prefix = "Exception from operator chain starting at '";
 #ifdef CAFFE2_USE_EXCEPTION_PTR
   if (!caught_exception_yet_.exchange(true)) {
     caught_exception_ = std::current_exception();
   } else {
-    prefix = "Secondary exception from operator '";
+    prefix = "Secondary exception from operator chain starting at '";
   }
 #endif // CAFFE2_USE_EXCEPTION_PTR
   LOG(ERROR) << prefix << operator_name << "' (type '" << operator_type
@@ -228,7 +228,7 @@ void DAGNetBase::WorkerFunction() {
           task_timers_[idx]->MicroSeconds());
     }
 
-    VLOG(1) << "Running operator #" << idx << " "
+    VLOG(1) << "Running chain starting at operator #" << idx << " "
             << operator_nodes_[idx].operator_->debug_def().name() << "("
             << operator_nodes_[idx].operator_->debug_def().type() << ").";
     CAFFE_ENFORCE(
@@ -244,7 +244,7 @@ void DAGNetBase::WorkerFunction() {
       if (!this_success) {
         // If an exception was thrown, the operator def will get printed
         // by Operator::Run[Async], but if no exception occurs we print it here.
-        LOG(ERROR) << "Operator chain failed: "
+        LOG(ERROR) << "Operator chain failed starting at: "
                    << ProtoDebugString(
                           operator_nodes_[idx].operator_->debug_def());
       }


### PR DESCRIPTION
The logging in net_dag.cc was a little misleading because it conflated the first operator in an execution chain with the operator actually being run. This change attempts to make the error a little more clear. The current interface between DAGNetBase and its child classes (which implement the virtual "RunAt()") doesn't make it clear which specific operator failed except by deep inspection of the exception thrown (if any is thrown). If an operator *does* thrown an exception, the exception message will indicate which exact operator caused it, but if it merely returns 'false' from Run, then the various implementations of DAGNetBase will swallow the failure and return after the entire chain is executed. Therefore, all we can deduce from DAGNetBase::WorkerFunction() is the operator at the head of the execution chain that failed, so we print that out. If an exception was thrown, we also print the exception message which narrows in on the specific operator that caused the error.