### PR TITLE
Make data_parallel_model Synchronize match behavior of _AllReduceBlobs, _SyncAllParams for single host case

### DIFF
--- a/caffe2/python/data_parallel_model.py
+++ b/caffe2/python/data_parallel_model.py
@@ -697,11 +697,12 @@ barrier_instance = 0
 
 
 def Synchronize(model, timeout_sec=_DEFAULT_TIMEOUT_SEC):
+    if model._rendezvous is None or model._rendezvous['num_shards'] <= 1:
+        # Single host case
+        return
+
     log.info("Creating synchronization barrier net")
-    assert model._rendezvous is not None, "Missing rendezvous"
     assert model._rendezvous['engine'] == 'GLOO', "Engine does not support barrier"
-    assert model._rendezvous['num_shards'] > 1, \
-        "synchronization barrier requires multiple shards"
     global barrier_instance
     instance = barrier_instance
     barrier_instance += 1


### PR DESCRIPTION
Instead of asserting when calling this function on a single shard use case, early-out if there is only 1 shard. This makes the calling code cleaner because we do not need to branch on the number of shards or the nullity of model._rendezvous; the same API call works for both single host and multi-host cases. 