### PR TITLE
Quick and dirty raw value substitution from zip file import for ONNX

### DIFF
--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -13,6 +13,7 @@ from __future__ import unicode_literals
 import os
 import collections
 from subprocess import Popen, PIPE
+import zipfile
 
 import caffe2
 from caffe2.python import core, workspace, rnn_cell, gru_cell
@@ -649,6 +650,35 @@ class Caffe2Backend(Backend):
                          list(pred_mh.Proto().external_input))
 
     @classmethod
+    def _substitute_raw_value(cls, tp, raw_values_dict):
+        if tp.HasField('raw_data') and tp.raw_data == bytes(b'__EXTERNAL'):
+            if tp.name not in raw_values_dict:
+                raise RuntimeError('TensorProto for value {} referenced raw data but it was not found!'.format(tp.name))
+            else:
+                tp.raw_data = raw_values_dict[tp.name]
+
+    @classmethod
+    def _visit_and_substitute_raw_values(cls, nodes, raw_values_dict):
+        for node in nodes:
+            for attr in node.attribute:
+                if attr.HasField('t'):
+                    cls._substitute_raw_value(attr.t, raw_values_dict)
+                for t in attr.tensors:
+                    cls._substitute_raw_value(t, raw_values_dict)
+                if attr.HasField('g'):
+                    cls._visit_and_substitute_raw_values(attr.g.node, raw_values_dict)
+                for g in attr.graphs:
+                    cls._visit_and_substitute_raw_values(g.node, raw_values_dict)
+
+    @classmethod
+    def _external_value_resolution_pass(cls, model, raw_values_dict):
+        for init in model.graph.initializer:
+            cls._substitute_raw_value(init, raw_values_dict)
+
+        cls._visit_and_substitute_raw_values(model.graph.node, raw_values_dict)
+
+
+    @classmethod
     def _direct_initialize_parameters(cls, initializer, ws, device_option):
         for tp in initializer:
             ws.FeedBlob(tp.name, onnx.numpy_helper.to_array(tp), device_option)
@@ -672,6 +702,21 @@ class Caffe2Backend(Backend):
             passes.append('split_predict')
         out = onnx.optimizer.optimize(input, passes)
         return out
+
+    @classmethod
+    def prepare_zip_archive(cls, file, device='CPU', **kwargs):
+        with zipfile.ZipFile(file, mode='r') as z:
+            with z.open('__MODEL_PROTO', 'r') as f:
+                model = onnx.load(f);
+            blob_names = set(z.namelist()) - set('__MODEL_PROTO')
+            # TODO: make this more efficient
+            raw_values_dict = {}
+            for name in blob_names:
+                with z.open(name, 'r') as blob_file:
+                    raw_values_dict[name] = blob_file.read()
+
+        cls._external_value_resolution_pass(model, raw_values_dict)
+        return cls.prepare(model, device, **kwargs)
 
     @classmethod
     def prepare(cls, model, device='CPU', **kwargs):
@@ -912,6 +957,8 @@ class Caffe2Backend(Backend):
 
 
 prepare = Caffe2Backend.prepare
+
+prepare_zip_archive = Caffe2Backend.prepare_zip_archive
 
 run_node = Caffe2Backend.run_node
 


### PR DESCRIPTION
Since the backend implementation is split between C++ and python and is in flux, I implemented substitution of raw values from an ONNX zip archive as a separate pass that substitutes them in before passing to `prepare()`. This is slower but it works for now