### PR TITLE
Apply CUDA_NVCC_EXECUTABLE envvar patch.

### DIFF
--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -253,6 +253,9 @@ if (MSVC)
   # simply enable it for the whole Windows build.
   set(CAFFE2_CMAKE_USE_LOCAL_FINDCUDA ON)
 endif()
+# We want to use local FindCUDA because of the following pending PR:
+# https://gitlab.kitware.com/cmake/cmake/merge_requests/1899
+set(CAFFE2_CMAKE_USE_LOCAL_FINDCUDA ON)
 
 if (${CAFFE2_CMAKE_USE_LOCAL_FINDCUDA})
   list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules_CUDA_fix)

--- a/cmake/Modules_CUDA_fix/FindCUDA.cmake
+++ b/cmake/Modules_CUDA_fix/FindCUDA.cmake
@@ -738,16 +738,20 @@ endif()
 
 
 # CUDA_NVCC_EXECUTABLE
-cuda_find_host_program(CUDA_NVCC_EXECUTABLE
-  NAMES nvcc
-  PATHS "${CUDA_TOOLKIT_ROOT_DIR}"
-  ENV CUDA_PATH
-  ENV CUDA_BIN_PATH
-  PATH_SUFFIXES bin bin64
-  NO_DEFAULT_PATH
-  )
-# Search default search paths, after we search our own set of paths.
-cuda_find_host_program(CUDA_NVCC_EXECUTABLE nvcc)
+if(DEFINED ENV{CUDA_NVCC_EXECUTABLE})
+  SET(CUDA_NVCC_EXECUTABLE "$ENV{CUDA_NVCC_EXECUTABLE}")
+else(DEFINED ENV{CUDA_NVCC_EXECUTABLE})
+  cuda_find_host_program(CUDA_NVCC_EXECUTABLE
+    NAMES nvcc
+    PATHS "${CUDA_TOOLKIT_ROOT_DIR}"
+    ENV CUDA_PATH
+    ENV CUDA_BIN_PATH
+    PATH_SUFFIXES bin bin64
+    NO_DEFAULT_PATH
+    )
+  # Search default search paths, after we search our own set of paths.
+  cuda_find_host_program(CUDA_NVCC_EXECUTABLE nvcc)
+endif(DEFINED ENV{CUDA_NVCC_EXECUTABLE})
 mark_as_advanced(CUDA_NVCC_EXECUTABLE)
 
 if(CUDA_NVCC_EXECUTABLE AND NOT CUDA_VERSION)


### PR DESCRIPTION
This patch is tracked upstream in
https://gitlab.kitware.com/cmake/cmake/merge_requests/1899

It is needed for ccache support in nvcc.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

