### PR TITLE
Checks a default op mapping onnx -> caffe2 bears the same arguments

### DIFF
--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -770,6 +770,14 @@ class Caffe2Backend(Backend):
             retval = Caffe2Rep(init_net, predict_net, ws, uninitialized)
             return retval
 
+    @staticmethod
+    def _check_op_argument_schema(opschema, op):
+        schema_argnames = list(map(lambda x: x.name, opschema.args))
+        for k in op.arg:
+            if k.name not in schema_argnames:
+                raise ValueError(
+                    "Don't know how to map argument {}, expected one of {}".format(
+                        k.name, ", ".join(schema_argnames)))
 
     @classmethod
     # TODO: This method needs a refactor for clarity
@@ -794,6 +802,8 @@ class Caffe2Backend(Backend):
         else:
             translator = cls._common_onnx_node_to_caffe2_op
         ops = translator(init_model, pred_model, OnnxNode(node_def), opset_version)
+        opschema = workspace.C.OpSchema.get(ops.op_type)
+        cls._check_op_argument_schema(opschema, ops)
         if isinstance(ops, Caffe2Ops):
             return ops
         if not isinstance(ops, collections.Iterable):


### PR DESCRIPTION
When adding an extra arg to an input ONNX op, if it's not supported in Caffe2, the exporter would just silently pass it to NetDef and ignore it in the implementation. It's pretty error-prone. Caffe2 also has an OpSchema description and we can enforce that all arguments explicitly appear in schema or listed explicitly in Caffe2. 

- make arguments check work as universally as possible in the c2 conversion
- Add test for argument-checking

