### PR TITLE
Fix observer logic in RNN executor. Remove dynamic casts

### DIFF
--- a/caffe2/core/observer.h
+++ b/caffe2/core/observer.h
@@ -28,8 +28,22 @@ class ObserverBase {
     return subject_;
   }
 
+  bool IsRNNCapable() {
+    return rnn_capable_;
+  }
+
+  // NOTE: This should only be called from RNNCapableOperatorObserver
+  // There is a static cast that depends on this assertion that will crash
+  // if broken.
+  void SetIsRNNCapable() {
+    rnn_capable_ = true;
+  }
+
  protected:
   T* subject_;
+
+ private:
+  bool rnn_capable_ = false;
 };
 
 /**

--- a/caffe2/operators/rnn/recurrent_network_executor.h
+++ b/caffe2/operators/rnn/recurrent_network_executor.h
@@ -136,10 +136,10 @@ class RecurrentNetworkExecutorBase {
 
           rnn_op.op = CreateOperator(op_copy, ws);
           for (const auto& observer : observers_list) {
-            auto rnn_observer =
-                dynamic_cast_if_rtti<const RNNCapableOperatorObserver*>(
-                    observer.get());
-            if (rnn_observer) {
+            if (observer->IsRNNCapable()) {
+              auto rnn_observer =
+                  static_cast<const RNNCapableOperatorObserver*>(
+                      observer.get());
               std::unique_ptr<ObserverBase<OperatorBase>> rnn_observer_copy =
                   rnn_observer->rnnCopy(rnn_op.op.get(), rnn_op.order);
               CAFFE_ENFORCE(
@@ -161,10 +161,10 @@ class RecurrentNetworkExecutorBase {
             // owned by this timestep.
             rnn_op.op = CreateOperator(step_net_def_.op(rnn_op.order), ws);
             for (const auto& observer : observers_list) {
-              auto rnn_observer =
-                  dynamic_cast_if_rtti<const RNNCapableOperatorObserver*>(
-                      observer.get());
-              if (rnn_observer) {
+              if (observer->IsRNNCapable()) {
+                auto rnn_observer =
+                    static_cast<const RNNCapableOperatorObserver*>(
+                        observer.get());
                 std::unique_ptr<ObserverBase<OperatorBase>> rnn_observer_copy =
                     rnn_observer->rnnCopy(rnn_op.op.get(), rnn_op.order);
                 CAFFE_ENFORCE(

--- a/caffe2/operators/rnn/rnn_capable_operator_observer.h
+++ b/caffe2/operators/rnn/rnn_capable_operator_observer.h
@@ -28,7 +28,9 @@ namespace caffe2 {
 class RNNCapableOperatorObserver : public ObserverBase<OperatorBase> {
  public:
   explicit RNNCapableOperatorObserver(OperatorBase* op)
-      : ObserverBase<OperatorBase>(op){};
+      : ObserverBase<OperatorBase>(op) {
+    SetIsRNNCapable();
+  };
 
   virtual std::unique_ptr<ObserverBase<OperatorBase>> rnnCopy(
       OperatorBase* subject,


### PR DESCRIPTION
Test case failed that triggered PR#2427 as a bandaid.  As part of this, we discussed redesigning how RNN-Capable observers were treated and landed on specifying a boolean for this purpose.  Updated code to support this.