### PR TITLE
Some minor Python 3 compatibility changes

### DIFF
--- a/caffe2/python/layer_model_helper.py
+++ b/caffe2/python/layer_model_helper.py
@@ -500,7 +500,7 @@ class LayerModelHelper(model_helper.ModelHelper):
                 return self.add_layer(new_layer)
             return wrapper
         else:
-            raise ValueError(
+            raise AttributeError(
                 "Trying to create non-registered layer: {}".format(layer))
 
     @property
@@ -604,5 +604,5 @@ class LayerModelHelper(model_helper.ModelHelper):
         # and change the assertion accordingly
         assert isinstance(breakdown_map, dict)
         assert all(isinstance(k, six.string_types) for k in breakdown_map)
-        assert sorted(list(breakdown_map.values())) == range(len(breakdown_map))
+        assert sorted(breakdown_map.values()) == list(range(len(breakdown_map)))
         self._breakdown_map = breakdown_map


### PR DESCRIPTION
This fixes `__getattr__` to adhere to its contract as per Python API, and wraps `range` in a `list()` since in Python 3 it no longer returns a list itself.